### PR TITLE
These environment variables are unused

### DIFF
--- a/CEdev/examples/template/Makefile
+++ b/CEdev/examples/template/Makefile
@@ -1,8 +1,6 @@
 CEDEV ?= ..
 BIN = $(CEDEV)\bin
 INCLUDE = $(CEDEV)\include
-WORKDIR ?= src
-OUTDIR ?= src
 
 TARGET ?= template
 


### PR DESCRIPTION
Today's experiments with subdirectory support (and logging ez80cc file system use via process monitor) seem to show these environment variables are useless.