### PR TITLE
Increase subdirectory portability

### DIFF
--- a/CEdev/examples/template/Makefile
+++ b/CEdev/examples/template/Makefile
@@ -1,4 +1,6 @@
+REALWINPATH = $(subst /,\,$(realpath $(1)))
 CEDEV ?= ..
+CEDEV := $(call REALWINPATH,$(CEDEV))
 BIN = $(CEDEV)\bin
 INCLUDE = $(CEDEV)\include
 WORKDIR ?= src
@@ -43,7 +45,8 @@ $(TARGET).hex : $(OBJECTS) $(STARTUPMODULE) $(LIBRARIES)
 	$(CV) $(@:%.8xp=%)
 
 %.obj : %.c
-	$(CC) $(CFLAGS) $<
+	cd $(dir $@) && \
+	$(CC) $(CFLAGS) $(notdir $<)
 
 %.obj : %.asm
 	$(CC) $(CFLAGS) $<


### PR DESCRIPTION
This allows us to, for example, portably include files from subdirectories:

    SOURCES = $(wildcard *.c) $(subst /,\,$(wildcard */*.c))

(note: if your shell supports "globstar" you can use `**/*.c` to recursively include from subdirectories)