### PR TITLE
More portable deletion of build products

### DIFF
--- a/CEdev/examples/template/Makefile
+++ b/CEdev/examples/template/Makefile
@@ -49,6 +49,6 @@ $(TARGET).hex : $(OBJECTS) $(STARTUPMODULE) $(LIBRARIES)
 	$(CC) $(CFLAGS) $<
     
 clean :
-	$(RM) $(wildcard *.src *.obj $(TARGET).*)
+	$(RM) $(OBJECTS:%.obj=%.src) $(OBJECTS) $(TARGET).*)
 
 .PHONY : all clean


### PR DESCRIPTION
This guarantees that all .obj and .src files created by the build process are removed, even if other directories are added down the line.