### PR TITLE
Optimized _TransparentPlot_ASM for speed*

### DIFF
--- a/CEdev/lib/src/libraries/graphics_src/graphx/v2/graphics_lib.asm
+++ b/CEdev/lib/src/libraries/graphics_src/graphx/v2/graphics_lib.asm
@@ -1796,16 +1796,50 @@ ClipSprTransNextAmt =$+1
 	pop	ix
 	ret
 
-_:	ldi
+_TransparentPlot_ASM_Opaque:
+	ldi
 	ret	po
-_TransparentPlot_ASM:
-_:	cp	a,(hl)
-	jr	nz,--_
+	cp	a,(hl)
+	jr	z,_TransparentPlot_ASM_Transparent
+	ldi
+	ret	po
+	cp	a,(hl)
+	jr	z,_TransparentPlot_ASM_Transparent
+	ldi
+	ret	po
+	cp	a,(hl)
+	jr	z,_TransparentPlot_ASM_Transparent
+	ldi
+	ret	po
+	cp	a,(hl)
+	jr	nz,_TransparentPlot_ASM_Opaque
+_TransparentPlot_ASM_Transparent:
 	inc	de
 	inc	hl
 	dec	c
-	jr	nz,-_ 				; 41 cycles
-	ret
+	ret	z
+_TransparentPlot_ASM:
+	cp	a,(hl)
+	jr	nz,_TransparentPlot_ASM_Opaque
+	inc	de
+	inc	hl
+	dec	c
+	ret	z
+	cp	a,(hl)
+	jr	nz,_TransparentPlot_ASM_Opaque
+	inc	de
+	inc	hl
+	dec	c
+	ret	z
+	cp	a,(hl)
+	jr	nz,_TransparentPlot_ASM_Opaque
+	inc	de
+	inc	hl
+	dec	c
+	ret	z
+	cp	a,(hl)
+	jr	z,_TransparentPlot_ASM_Transparent
+	jr	_TransparentPlot_ASM_Opaque
 
 ;-------------------------------------------------------------------------------
 _Sprite:


### PR DESCRIPTION
Unrolled each of the opaque and transparent braches into four iterations, so stretches of the same pixel opaqueness/transparency mostly fall through the jumps and execute faster.

Before (12 bytes):
 * opaque->opaque: 41 cc
 * opaque->trans: 36 cc
 * trans->opaque: 46 cc
 * trans->trans: 41 cc

After (54 bytes; lists cycles after 1/2/3/4 mod 4 iterations in a row of previous pixel state):
 * opaque->opaque: 36/36/36/41 cc 
 * opaque->trans:  41/41/41/36 cc
 * trans->opaque: 38/38/38/46 cc
 * trans->trans: 33/33/33/38 cc

Starts on the fast transparent path based on the assumption that the majority of transparent sprite pixel rows start with a transparent pixel, as transparency is often used to draw "cutout" images.