### PR TITLE
Revert "Optimized _TilePtrMapped"

### DIFF
--- a/CEdev/lib/src/graphics/graphx/graphics_lib.asm
+++ b/CEdev/lib/src/graphics/graphx/graphics_lib.asm
@@ -2511,16 +2511,20 @@ _TilePtrMapped:
 ;  arg2 : Y Map Offset
 ; Returns:
 ;  A pointer to the indexed tile in the tilemap (so it can be looked at or changed)
-	pop	hl			; return vector
-	pop	iy			; tilemap struct
-	pop	de			; x offset
-	ex	(sp),hl			; y offset
-	ld	h,(iy+13)		; tilemap width
+	push	ix
+	ld	ix,0                        ; setup frame
+	add	ix,sp
+	ld	iy,(ix+6)                   ; tilemap struct pointer
+	ld	h,(ix+12)                   ; y offset
+	ld	l,(iy+13)                   ; height
 	mlt	hl
-	ld	d,0
-	add.s	hl,de
-	ld	de,(iy+0)		; tilemap data
+	ex	de,hl
+	sbc	hl,hl
+	ld	l,(ix+9)                    ; x offset
+	ld	bc,(iy+0)                   ; pointer to map
 	add	hl,de
+	add	hl,bc
+	pop	ix                          ; end frame
 	ret
 
 ;-------------------------------------------------------------------------------


### PR DESCRIPTION
This doesn't actually work. I totally blanked on the fact that the function arguments need to be kept on the stack.