### PR TITLE
Reset iy for token hook

### DIFF
--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -967,6 +967,7 @@ _:	inc	de
 	ld	(hl),de
 	pop	hl
 	push	iy
+	ld	iy,flags
 	call	_Get_Tok_Strng
 	pop	iy
 	ld	hl,(iy+9)


### PR DESCRIPTION
_Get_Tok_Strng calls the token hook, which needs bit 0, (iy+$35) or so, and if iy is random, it might happen that the OS things the hook is set, while it isn't, and then it resets the bit.