### PR TITLE
Calculate green LSB in default palette colors

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -369,14 +369,15 @@ _:	ld	a,b
 	ld	(de),a
 	inc	de
 	ld	a,b
+	rla
+	rla
+	rla
+	ld	a,b
 	rra
 	ld	(de),a
 	inc	de
 	inc	b
 	jr	nz,-_                       ; loop for 256 times to fill palette
-	scf
-	sbc	hl,hl
-	ld	(mpLcdPalette+(255*2)),hl
 	ret
 
 ;-------------------------------------------------------------------------------


### PR DESCRIPTION
Can someone confirm that this is both correct and desired?

Also, this is a lazy way of running all the autotests to see if any need to be updated.