### PR TITLE
core_makefile: quick fix for an issue where only one object would be …

### DIFF
--- a/src/core_makefile
+++ b/src/core_makefile
@@ -212,9 +212,11 @@ LDFLAGS := \
 
 ifneq ($(OS),Windows_NT)
 	LDFLAGS := '$(LDFLAGS)'
+	SAFEMKDIR = $(MKDIR) $(call NATIVEPATH,$1)
 else
 	WINCHKBINDIR := $(WINCHKDIR) $(BINDIR)
 	WINCHKOBJDIR := $(WINCHKDIR) $(OBJDIR)
+	SAFEMKDIR = $(WINCHKDIR) $(call NATIVEPATH,$1) $(MKDIR) $(call NATIVEPATH,$1)
 endif
 
 # this rule is trigged to build everything
@@ -234,42 +236,42 @@ $(BINDIR)/$(TARGETHEX): $(OBJECTS)
 
 # this rule handles conversion of the icon, if it is ever updated
 $(OBJDIR)/$(ICON_OBJ): $(ICONPNG)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(ICON_CONV) && \
 	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(ICON_ASM)
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.c $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.asm $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/%.asm $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/%.c $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.c $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.asm $(USERHEADERS)
-	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(call SAFEMKDIR,$(@D))
 	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 

--- a/src/core_makefile
+++ b/src/core_makefile
@@ -236,43 +236,43 @@ $(BINDIR)/$(TARGETHEX): $(OBJECTS)
 
 # this rule handles conversion of the icon, if it is ever updated
 $(OBJDIR)/$(ICON_OBJ): $(ICONPNG)
-	@$(call SAFEMKDIR,$(@D))
-	@$(ICON_CONV) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(ICON_CONV) && \
 	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(ICON_ASM)
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.c $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.asm $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/%.asm $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/%.c $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.c $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.asm $(USERHEADERS)
-	@$(call SAFEMKDIR,$(@D))
-	@$(CD) $(call NATIVEPATH,$(@D)) && \
+	@$(call SAFEMKDIR,$(@D)) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 clean:

--- a/src/core_makefile
+++ b/src/core_makefile
@@ -16,6 +16,10 @@ VERSION := 7.4
 #----------------------------
 
 # define some common makefile things
+
+# source: http://blog.jgc.org/2011/07/gnu-make-recursive-wildcard-function.html
+rwildcard = $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2)$(filter $(subst *,%,$2),$d))
+
 empty :=
 space := $(empty) $(empty)
 comma := $(empty),$(empty)
@@ -79,15 +83,15 @@ ICON_OBJ      := $(ICON_ASM:%.src=%.obj)
 ALLDIRS       := $(sort $(dir $(wildcard $(SRCDIR)/*/)))
 
 # find all of the available C, H and ASM files (Remember, you can create C <-> assembly routines easily this way)
-CSOURCES      := $(call NATIVEPATH,$(foreach dir,$(ALLDIRS),$(wildcard $(dir)*.c)))
-CPPSOURCES    := $(call NATIVEPATH,$(foreach dir,$(ALLDIRS),$(wildcard $(dir)*.cpp)))
-USERHEADERS   := $(call NATIVEPATH,$(foreach dir,$(ALLDIRS),$(wildcard $(dir)*.h)))
-USERHEADERS   += $(call NATIVEPATH,$(foreach dir,$(ALLDIRS),$(wildcard $(dir)*.hpp)))
-ASMSOURCES    := $(call NATIVEPATH,$(foreach dir,$(ALLDIRS),$(wildcard $(dir)*.asm)))
+CSOURCES      := $(call NATIVEPATH,$(call rwildcard,$(SRCDIR),*.c))
+CPPSOURCES    := $(call NATIVEPATH,$(call rwildcard,$(SRCDIR),*.cpp))
+USERHEADERS   := $(call NATIVEPATH,$(call rwildcard,$(SRCDIR),*.h))
+USERHEADERS   += $(call NATIVEPATH,$(call rwildcard,$(SRCDIR),*.hpp))
+ASMSOURCES    := $(call NATIVEPATH,$(call rwildcard,$(SRCDIR),*.asm))
 
 # figure out what the names of the sources will become once made into objects
-OBJECTS       += $(addprefix $(OBJDIR)/,$(notdir $(CSOURCES:%.c=%.obj)))
-OBJECTS       += $(addprefix $(OBJDIR)/,$(notdir $(ASMSOURCES:%.asm=%.obj)))
+OBJECTS       := $(filter %.obj,$(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.obj,$(subst \,/,$(CSOURCES))))
+OBJECTS       += $(filter %.obj,$(patsubst $(SRCDIR)/%.asm,$(OBJDIR)/%.obj,$(subst \,/,$(CSOURCES))))
 
 # check if there is an icon present that we can convert; if so, generate a recipe to build it properly
 ifneq ("$(wildcard $(ICONPNG))","")
@@ -220,7 +224,7 @@ dirs:
 	@echo C CE SDK Version $(VERSION) && \
 	$(WINCHKBINDIR) $(MKDIR) $(BINDIR) && \
 	$(WINCHKOBJDIR) $(MKDIR) $(OBJDIR)
-	
+
 $(BINDIR)/$(TARGET8XP): $(BINDIR)/$(TARGETHEX)
 	@$(CD) $(BINDIR) && \
 	$(CV) $(CVFLAGS) $(notdir $<)
@@ -230,36 +234,43 @@ $(BINDIR)/$(TARGETHEX): $(OBJECTS)
 
 # this rule handles conversion of the icon, if it is ever updated
 $(OBJDIR)/$(ICON_OBJ): $(ICONPNG)
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
 	@$(ICON_CONV) && \
-	$(CD) $(OBJDIR) && \
+	$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(ICON_ASM)
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.c $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 $(OBJDIR)/%.obj: $(GFXDIR)/%.asm $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/%.asm $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/%.c $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # these rules compile the source files into object files
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.c $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(CC) $(CFLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 # this rule builds the assembly files and places them in the object directory
 $(OBJDIR)/%.obj: $(SRCDIR)/*/%.asm $(USERHEADERS)
-	@$(CD) $(OBJDIR) && \
+	@$(WINCHKDIR) $(call NATIVEPATH,$(@D)) $(MKDIR) $(call NATIVEPATH,$(@D))
+	@$(CD) $(call NATIVEPATH,$(@D)) && \
 	$(AS) $(ASM_FLAGS) $(call WINPATH,$(addprefix $(CURDIR)/,$<))
 
 clean:


### PR DESCRIPTION
…left when multiple source files were named the same way in different folders


This has not been tested on POSIX systems.