### PR TITLE
Fix _GetC

### DIFF
--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -606,8 +606,7 @@ _GetChar_ASM:
 	push	bc
 	call	_GetSlotOffset
 	pop	hl
-	dec	hl
-	or	a,a
+	scf
 	sbc	hl,bc				; size-offset
 	jp	c,_ReturnNegativeOne
 	push	bc


### PR DESCRIPTION
If filesize = 0 and offset = 0, _GetC should return EOF, and not the next byte in memory.