### PR TITLE
Properly overwrite the variable type

### DIFF
--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -927,7 +927,8 @@ _DetectJump:
 	or	a,a
 	ld	a,(hl)
 	jr	z,.fdetectnormal
-	ld	(ix+12),a
+	ld	de,(ix+12)
+	ld	(de),a
 	jr	.fgoodtype
 .fdetectnormal:
 _DetectType := $+1


### PR DESCRIPTION
ti_DetectAny( didn't overwrite the variable type, it only writes them to the stack entry, which is wrong obviously. This PR fetches the address of the type var and writes the type of the variable to this address.