### PR TITLE
Fix gfx_Begin to set the right JR offset at larger text scale

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -240,7 +240,7 @@ gfx_Begin:
 ; Returns:
 ;  None
 	ld	hl,_LargeFontJump
-	ld	a,(hl)
+	ld	a,_PrintLargeFont-(_LargeFontJump+1)
 	ld	(UseLargeFont),a	; store the jump offset for later
 	ld	(hl),0			; jump nowhere if false
 	call	_boot_ClearVRAM		; clear the screen


### PR DESCRIPTION
Currently, if you call `gfx_Begin()` twice, with a `gfx_SetTextScale(1,1)` in between, everything after that second `gfx_Begin()` is not scaled, because the jr offset is overwritten to be 0.