### PR TITLE
Save and restore clobbered DE register

### DIFF
--- a/src/ce/getstringinput.src
+++ b/src/ce/getstringinput.src
@@ -100,7 +100,9 @@ __draw:
 __full:
 	ld	a,' '
 	ld	(curUnder),a
+	push 	de
 	call	_GetKey
+	pop	de
 	cp	a,kClear
 	jr	z,__clear
 	cp	a,kEnter


### PR DESCRIPTION
Behavior was: 
1. pqr will put "pqr\0" in the buffer
2. pqrs will put "pqrs\0" in the buffer
3. pqrst will put "pqrst" in the buffer (no NUL)
4. pqrstu will put "pqrst" in the buffer (as above, can not type the u)