### PR TITLE
fileioc: improve garbage collect handling

### DIFF
--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1228,7 +1228,7 @@ ti_Rename:
 	jr	c, .return_2
 	call	_ChkInRam
 	jr	nz, .in_archive
-	ld	hl, $f8			; $f8 = ret
+	ld	hl, util_no_op			; no-op routine instead of assuming $F8 points to a ret instruction lol
 	ld	(.smc_archive), hl
 	call	_PushOP1
 	call	util_Arc_Unarc
@@ -1419,7 +1419,7 @@ ti_SetPostGCHandler:
 	ld (util_post_gc_handler),hl
 	ex hl,de
 	jp (hl)
-util_post_gc_default_handler:=$F8
+util_post_gc_default_handler:=util_no_op
 
 ;-------------------------------------------------------------------------------
 ti_SetPreGCHandler:
@@ -1442,6 +1442,7 @@ ti_SetPreGCHandler:
 	jp (hl)
 util_pre_gc_default_handler:
 	xor a,a
+util_no_op:
 	ret
 
 

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1440,7 +1440,9 @@ ti_SetPreGCHandler:
 	ld (util_pre_gc_handler),hl
 	ex hl,de
 	jp (hl)
-util_pre_gc_default_handler:=$F8
+util_pre_gc_default_handler:
+	xor a,a
+	ret
 
 
 ;-------------------------------------------------------------------------------
@@ -1636,6 +1638,8 @@ util_Arc_Unarc: ;properly handle garbage collects :P
 	jr nz,.arc_unarc ;gc will not be triggered
 	call util_pre_gc_default_handler
 util_pre_gc_handler:=$-3
+	or a,a
+	ret nz ;exit if the handler returns a non-zero value
 	call _Arc_Unarc
 	jp util_post_gc_default_handler
 util_post_gc_handler:=$-3

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1417,15 +1417,15 @@ ti_SetGCBehavior:
 	or	a,a
 	sbc	hl,de
 	jr	nz,.notdefault1
-	ld	hl,util_pre_gc_default_handler
+	ld	hl,util_post_gc_default_handler
 .notdefault1:
-	ld	(util_pre_gc_handler),hl
+	ld	(util_post_gc_handler),hl
 	sbc	hl,hl
 	adc	hl,bc
 	jr	nz,.notdefault2
-	ld	hl,util_post_gc_default_handler
+	ld	hl,util_pre_gc_default_handler
 .notdefault2:
-	ld	(util_post_gc_handler),hl
+	ld	(util_pre_gc_handler),hl
 	ret
 util_post_gc_default_handler := util_no_op
 util_pre_gc_default_handler := util_no_op

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1408,11 +1408,11 @@ ti_SetGCBehavior:
 ;	sp + 6 : pointer to routine to be run after. Set to 0 to use default handler.
 ; return:
 ;   None
-	pop	bc
 	pop	de
+	pop	bc
 	ex	(sp),hl
-	push	de
 	push	bc
+	push	de
 	add	hl,de
 	or	a,a
 	sbc	hl,de
@@ -1420,18 +1420,15 @@ ti_SetGCBehavior:
 	ld	hl,util_pre_gc_default_handler
 .notdefault1:
 	ld	(util_pre_gc_handler),hl
-	ex hl,de
-	add hl,bc
-	or a,a
-	sbc hl,bc
+	sbc	hl,hl
+	adc	hl,bc
 	jr	nz,.notdefault2
 	ld	hl,util_post_gc_default_handler
 .notdefault2:
 	ld	(util_post_gc_handler),hl
 	ret
-util_post_gc_default_handler:=util_no_op
-util_pre_gc_default_handler:=util_no_op
-
+util_post_gc_default_handler := util_no_op
+util_pre_gc_default_handler := util_no_op
 
 ;-------------------------------------------------------------------------------
 ; internal library routines
@@ -1617,10 +1614,10 @@ util_set_offset:
 util_Arc_Unarc: ;properly handle garbage collects :P
 	call	_ChkInRAM
 	jp	nz,_Arc_Unarc ;if the file is already in archive, we won't trigger a gc
-	ex hl,de
+	ex	hl,de
 	call	_LoadDEInd_s
-	ex hl,de
-	call util_ArchiveHasRoom
+	ex	hl,de
+	call	util_ArchiveHasRoom
 	jp	nz,_Arc_Unarc ;gc will not be triggered
 	call	util_pre_gc_default_handler
 util_pre_gc_handler:=$-3

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1408,11 +1408,11 @@ ti_SetGCBehavior:
 ;	sp + 6 : pointer to routine to be run after. Set to 0 to use default handler.
 ; return:
 ;   None
-	pop	de
 	pop	bc
+	pop	de
 	ex	(sp),hl
-	push	bc
 	push	de
+	push	bc
 	add	hl,de
 	or	a,a
 	sbc	hl,de

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1391,6 +1391,7 @@ ti_ArchiveHasRoom:
 	pop	de
 	ex	(sp),hl
 	push	de
+util_ArchiveHasRoom:
 	ld	bc,12
 	add	hl,bc
 	call	_FindFreeArcSpot
@@ -1620,9 +1621,8 @@ util_Arc_Unarc: ;properly handle garbage collects :P
 	pop	hl
 	jp	nz,_Arc_Unarc ;if the file is already in archive, we won't trigger a gc
 	call	_LoadDEInd_s
-	ld	hl,12
-	add	hl,de
-	call	_FindFreeArcSpot ;check if we will trigger a gc
+	ex hl,de
+	call util_ArchiveHasRoom
 	jp	nz,_Arc_Unarc ;gc will not be triggered
 	call	util_pre_gc_default_handler
 util_pre_gc_handler:=$-3

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1615,11 +1615,9 @@ util_set_offset:
 	ret
 
 util_Arc_Unarc: ;properly handle garbage collects :P
-	call	_ChkFindSym
-	push	hl
 	call	_ChkInRAM
-	pop	hl
 	jp	nz,_Arc_Unarc ;if the file is already in archive, we won't trigger a gc
+	ex hl,de
 	call	_LoadDEInd_s
 	ex hl,de
 	call util_ArchiveHasRoom

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1408,11 +1408,11 @@ ti_SetGCBehavior:
 ;	sp + 6 : pointer to routine to be run after. Set to 0 to use default handler.
 ; return:
 ;   None
-	pop	bc
 	pop	de
+	pop	bc
 	ex	(sp),hl
-	push	de
 	push	bc
+	push	de
 	add	hl,de
 	or	a,a
 	sbc	hl,de

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1640,7 +1640,7 @@ util_Arc_Unarc: ;properly handle garbage collects :P
 	call	util_pre_gc_default_handler
 util_pre_gc_handler:=$-3
 	or	a,a
-	ret	nz ;exit if the handler returns a non-zero value
+	ret	z ;exit if the handler returns false
 	call	_Arc_Unarc
 	jp	util_post_gc_default_handler
 util_post_gc_handler:=$-3

--- a/src/fileioc/fileioc.asm
+++ b/src/fileioc/fileioc.asm
@@ -1407,18 +1407,18 @@ ti_SetPostGCHandler:
 ;   sp + 3 : pointer to handler. Set to 0 to use default handler (xlibc palette)
 ; return:
 ;   None
-	pop de
-	ex (sp),hl
-	push de
-	add hl,de
-	or a,a
-	sbc hl,de
-	jr nz,.notdefault
-	ld hl,util_post_gc_default_handler
+	pop	de
+	ex	(sp),hl
+	push	de
+	add	hl,de
+	or	a,a
+	sbc	hl,de
+	jr	nz,.notdefault
+	ld	hl,util_post_gc_default_handler
 .notdefault:
-	ld (util_post_gc_handler),hl
-	ex hl,de
-	jp (hl)
+	ld	(util_post_gc_handler),hl
+	ex	hl,de
+	jp	(hl)
 util_post_gc_default_handler:=util_no_op
 
 ;-------------------------------------------------------------------------------
@@ -1428,20 +1428,20 @@ ti_SetPreGCHandler:
 ;   sp + 3 : pointer to handler. Set to 0 to use default handler (xlibc palette)
 ; return:
 ;   None
-	pop de
-	ex (sp),hl
-	push de
-	add hl,de
-	or a,a
-	sbc hl,de
-	jr nz,.notdefault
-	ld hl,util_pre_gc_default_handler
+	pop	de
+	ex	(sp),hl
+	push	de
+	add	hl,de
+	or	a,a
+	sbc	hl,de
+	jr	nz,.notdefault
+	ld	hl,util_pre_gc_default_handler
 .notdefault:
-	ld (util_pre_gc_handler),hl
-	ex hl,de
-	jp (hl)
+	ld	(util_pre_gc_handler),hl
+	ex	hl,de
+	jp	(hl)
 util_pre_gc_default_handler:
-	xor a,a
+	xor	a,a
 util_no_op:
 	ret
 
@@ -1627,25 +1627,25 @@ util_set_offset:
 	ret
 
 util_Arc_Unarc: ;properly handle garbage collects :P
-	call _ChkFindSym
-	push hl
-	call _ChkInRAM
-	pop hl
-	jr nz,.arc_unarc ;if the file is already in archive, we won't trigger a gc
-	call _LoadDEInd_s
-	ld hl,12
-	add hl,de
-	call _FindFreeArcSpot ;check if we will trigger a gc
-	jr nz,.arc_unarc ;gc will not be triggered
-	call util_pre_gc_default_handler
+	call	_ChkFindSym
+	push	hl
+	call	_ChkInRAM
+	pop	hl
+	jr	nz,.arc_unarc ;if the file is already in archive, we won't trigger a gc
+	call	_LoadDEInd_s
+	ld	hl,12
+	add	hl,de
+	call	_FindFreeArcSpot ;check if we will trigger a gc
+	jr	nz,.arc_unarc ;gc will not be triggered
+	call	util_pre_gc_default_handler
 util_pre_gc_handler:=$-3
-	or a,a
-	ret nz ;exit if the handler returns a non-zero value
-	call _Arc_Unarc
-	jp util_post_gc_default_handler
+	or	a,a
+	ret	nz ;exit if the handler returns a non-zero value
+	call	_Arc_Unarc
+	jp	util_post_gc_default_handler
 util_post_gc_handler:=$-3
 .arc_unarc:
-	jp _Arc_Unarc
+	jp	_Arc_Unarc
 
 
 

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -386,14 +386,14 @@ bool ti_ArchiveHasRoom(uint24_t num_bytes);
 /**
  * Set routine to run after a garbage collect.
  * @param routine Routine to run following a garbage collect. NULL sets it to do nothing.
- * @note Useful for setting up the graphics palette.
+ * @note If your program uses graphx, pass gfx_Begin to setup graphics after the garbage collect finishes.
  * */
 void ti_SetPostGCHandler(void (*routine)(void));
 
 /**
  * Set routine to run before a garbage collect.
  * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing.
- * @note Useful for cleanup. Make sure to set OS graphics mode during.
+ * @note Useful for cleanup. If your program uses graphx, pass gfx_End to set OS graphics mode to avoid corrupted graphics during the garbage collect.
  * */
 void ti_SetPreGCHandler(void (*routine)(void));
 

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -392,10 +392,10 @@ void ti_SetPostGCHandler(void (*routine)(void));
 
 /**
  * Set routine to run before a garbage collect.
- * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing.
+ * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns a non-zero value, the variable will not be archived.
  * @note Useful for cleanup. If your program uses graphx, pass gfx_End to set OS graphics mode to avoid corrupted graphics during the garbage collect.
  * */
-void ti_SetPreGCHandler(void (*routine)(void));
+void ti_SetPreGCHandler(uint8_t (*routine)(void));
 
 
 /**

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -392,12 +392,12 @@ void ti_SetPostGCHandler(void (*routine)(void));
 
 /**
  * Set routine to run before a garbage collect.
- * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns true, the GC will not occur, and the post-GC handler will not be executed.
+ * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns false, the GC will not occur, and the post-GC handler will not be executed.
  * @note Useful for cleanup. If your program uses graphx, run gfx_End inside the passed function to set OS graphics mode to avoid corrupted graphics during the garbage collect.
  * @code
  *    bool pre_gc_handler(void){
  *          gfx_End();
- *          return false;
+ *          return true;
  *    }
  *    int main(void){
  *          gfx_Begin();

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -392,12 +392,12 @@ void ti_SetPostGCHandler(void (*routine)(void));
 
 /**
  * Set routine to run before a garbage collect.
- * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns true, the variable will not be archived.
+ * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns true, the GC will not occur, and the post-GC handler will not be executed.
  * @note Useful for cleanup. If your program uses graphx, run gfx_End inside the passed function to set OS graphics mode to avoid corrupted graphics during the garbage collect.
  * @code
  *    bool pre_gc_handler(void){
  *          gfx_End();
- *          return 0;
+ *          return false;
  *    }
  *    int main(void){
  *          gfx_Begin();

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -385,10 +385,18 @@ bool ti_ArchiveHasRoom(uint24_t num_bytes);
 
 /**
  * Set routine to run after a garbage collect.
- * @param routine Routine to run following a garbage collect. If this is 0, the default handler will be used.
+ * @param routine Routine to run following a garbage collect. NULL sets it to do nothing.
  * @note Useful for setting up the graphics palette.
  * */
-void ti_SetPostGCHandler((void)(*routine)(void));
+void ti_SetPostGCHandler(void (*routine)(void));
+
+/**
+ * Set routine to run before a garbage collect.
+ * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing.
+ * @note Useful for cleanup. Make sure to set OS graphics mode during.
+ * */
+void ti_SetPreGCHandler(void (*routine)(void));
+
 
 /**
  * Allocates space for a real variable

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -382,6 +382,14 @@ uint8_t ti_RclVar(const uint8_t var_type, const char *var_name, void **data_stru
  */
 bool ti_ArchiveHasRoom(uint24_t num_bytes);
 
+
+/**
+ * Set routine to run after a garbage collect.
+ * @param routine Routine to run following a garbage collect. If this is 0, the default handler will be used.
+ * @note Useful for setting up the graphics palette.
+ * */
+void ti_SetPostGCHandler((void)(*routine)(void));
+
 /**
  * Allocates space for a real variable
  * @returns Pointer to variable

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -384,34 +384,11 @@ bool ti_ArchiveHasRoom(uint24_t num_bytes);
 
 
 /**
- * Set routine to run after a garbage collect.
+ * Set routines to run before and after a garbage collect would be triggered.
  * @param routine Routine to run following a garbage collect. NULL sets it to do nothing.
- * @note If your program uses graphx, pass gfx_Begin to setup graphics after the garbage collect finishes.
+ * @note If your program uses graphx, use gfx_End and gfx_Begin to reset graphics before, and setup graphics after the garbage collect.
  * */
-void ti_SetPostGCHandler(void (*routine)(void));
-
-/**
- * Set routine to run before a garbage collect.
- * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns false, the GC will not occur, and the post-GC handler will not be executed.
- * @note Useful for cleanup. If your program uses graphx, run gfx_End inside the passed function to set OS graphics mode to avoid corrupted graphics during the garbage collect.
- * @code
- *    bool pre_gc_handler(void){
- *          gfx_End();
- *          return true;
- *    }
- *    int main(void){
- *          gfx_Begin();
- *          ti_CloseAll();
- *          ti_SetPostGCHandler(gfx_Begin);
- *          ti_SetPreGCHandler(pre_gc_handler);
- *          //any garbage collect triggered in this program will now be preceeded by pre_gc_handler, and afterwards by gfx_Begin.
- *          //...
- *          ti_CloseAll();
- *          gfx_End();
- *    }
- * @endcode
- * */
-void ti_SetPreGCHandler(bool (*routine)(void));
+void ti_SetGCBehavior(void (*before)(void), void (*after)(void));
 
 
 /**

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -392,10 +392,26 @@ void ti_SetPostGCHandler(void (*routine)(void));
 
 /**
  * Set routine to run before a garbage collect.
- * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns a non-zero value, the variable will not be archived.
- * @note Useful for cleanup. If your program uses graphx, pass gfx_End to set OS graphics mode to avoid corrupted graphics during the garbage collect.
+ * @param routine Routine to run preceeding a garbage collect. NULL sets it to do nothing. If this routine returns true, the variable will not be archived.
+ * @note Useful for cleanup. If your program uses graphx, run gfx_End inside the passed function to set OS graphics mode to avoid corrupted graphics during the garbage collect.
+ * @code
+ *    bool pre_gc_handler(void){
+ *          gfx_End();
+ *          return 0;
+ *    }
+ *    int main(void){
+ *          gfx_Begin();
+ *          ti_CloseAll();
+ *          ti_SetPostGCHandler(gfx_Begin);
+ *          ti_SetPreGCHandler(pre_gc_handler);
+ *          //any garbage collect triggered in this program will now be preceeded by pre_gc_handler, and afterwards by gfx_Begin.
+ *          //...
+ *          ti_CloseAll();
+ *          gfx_End();
+ *    }
+ * @endcode
  * */
-void ti_SetPreGCHandler(uint8_t (*routine)(void));
+void ti_SetPreGCHandler(bool (*routine)(void));
 
 
 /**


### PR DESCRIPTION
When a gc will be triggered as a result of calling _Arc_Unarc, set OS graphics mode, restore afterwards.
Added ti_SetPostGCHandler((void)(*routine)(void)) so user programs can easily setup graphics again.
Had to replace some of the files in src/include/ to get fileioc to build. Ignore those if you can lol
GC handler functionality has been tested using the attached program.
[archive_overloader.zip](https://github.com/CE-Programming/toolchain/files/4914759/archive_overloader.zip)
