### PR TITLE
Enable generation of MANPAGES on doxygen config

### DIFF
--- a/tools/doxygen/config
+++ b/tools/doxygen/config
@@ -1862,7 +1862,7 @@ RTF_SOURCE_CODE        = NO
 # classes and files.
 # The default value is: NO.
 
-GENERATE_MAN           = NO
+GENERATE_MAN           = YES
 
 # The MAN_OUTPUT tag is used to specify where the man pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -1896,7 +1896,7 @@ MAN_SUBDIR             =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_LINKS              = NO
+MAN_LINKS              = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the XML output


### PR DESCRIPTION
Enable the generation of Unix Man pages. MAN PAGES are highly useful for quickly finding out information on functions and headers. The MAN PAGES generated by doxygen in the project's current configuration seem to be usable. Maybe some configuration could be done to add a better header. This could be also added to the wiki to enable the MAN PAGES to be seen by the `man` utility. 

> 3. (Optional) Append and export the `MANPATH` environment variable using the repository's `doxygen/man` folder 

> This can be done by adding this to the bash configuration file (.bash_rc or .bash_profile depending on the operating system) `export MANPATH=":/path/to/toolchain/doxygen/man/"`. Please use the appropriate path according to the location of the `toolchain` directory on your system.