### PR TITLE
Build documentation in a few formats

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -308,7 +308,13 @@ jobs:
       - name: Disable Jekyll
         run: cmake -E touch ${{env.TOOLCHAIN_PATH}}/docs/build/html/.nojekyll
       - name: Remove .pickle files
-        run: find ${{env.TOOLCHAIN_PATH}}/docs/build/html -name '*.pickle' -delete
+        run: find ${{env.TOOLCHAIN_PATH}}/docs/build/ -name '*.pickle' -delete
+
+      - name: Upload downloadable artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: ${{env.TOOLCHAIN_PATH}}/docs/build/
 
       - name: Upload Website Documentation
         if: github.ref == 'refs/heads/master'

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -2,13 +2,16 @@
 
 build_documentation () {
   export current_version
+  export versions
+
   cp -f /tmp/conf.py conf.py
+  local format="${2:-html}"
 
   echo "Building documentation for ${current_version}..."
 
   if [ -f 'templates/versions.html' ]; then
     cp -f /tmp/versions.html templates/versions.html
-    sphinx-build . $1
+    sphinx-build -b "$format" . $1
     git checkout -- templates/versions.html
   else
     mkdir -p templates
@@ -22,30 +25,37 @@ build_documentation () {
 cp -f conf.py /tmp/conf.py
 cp -f templates/versions.html /tmp/versions.html
 
-export versions="master v9.2 v9.1 v9.0"
+# Maps target directory name to branch
+declare -A versions_map=(
+	[v9.2]=v9.2-docs
+	[v9.1]=v9.1
+	[v9.0]=v9.0
+	[master]=master
+)
 
-# build default
-current_version="v9.2"
-git checkout v9.2-docs
-build_documentation build/html
+# Pointers to other versions in the output documentation
+export versions="${!versions_map[@]}"
 
-# build v9.2
-current_version="v9.2"
-git checkout v9.2-docs
-build_documentation build/html/${current_version}
+# Also build the latest version at the root (which shouldn't be listed
+# in the list of versions since it duplicates the chosen one).
+default_version=v9.2
+versions_map[.]="${versions_map[$default_version]}"
 
-# build v9.1
-current_version="v9.1"
-git checkout v9.1
-build_documentation build/html/${current_version}
-
-# build v9.0
-current_version="v9.0"
-git checkout v9.0
-build_documentation build/html/${current_version}
-
-# build master
-current_version="master"
-git checkout master
-build_documentation build/html/${current_version}
+for target_dir in "${!versions_map[@]}"
+do
+	branch_name="${versions_map[$target_dir]}"
+	git checkout "${branch_name}"
+	for format in html singlehtml latex
+	do
+		if [ "${target_dir}" = "." ]; then
+			current_version="${default_version}"
+		else
+			current_version="${target_dir}"
+		fi
+		build_documentation "build/${format}/${target_dir}" "${format}" &
+	done
+	# Each format is run in parallel, but we need to wait for completion before
+	# checking out the next branch.
+	wait
+done
 


### PR DESCRIPTION
This makes the documentation build script emit single-file HTML and LaTeX output as well as multi-file HTML since some users may prefer to have a single-file version of the documentation. The PDF currently doesn't build because it tries to use SVG graphics, however.

The documentation building action now also saves the documentation as an artifact.