### PR TITLE
Correct comment in keypadc.h

### DIFF
--- a/src/keypadc/keypadc.h
+++ b/src/keypadc/keypadc.h
@@ -361,7 +361,7 @@ typedef enum {
 #define kb_KeyPower    ((kb_lkey_t)(6 << 8 | 1<<5))
 #define kb_KeyClear    ((kb_lkey_t)(6 << 8 | 1<<6))
 
-/* Keyboard group 5 - 83 Premium CE key names */
+/* Keyboard group 6 - 83 Premium CE key names */
 #define kb_KeyAnnul    kb_KeyClear
 
 /* Keyboard group 7 */


### PR DESCRIPTION
Correct the keyboard group number in the comment above #define kb_KeyAnnul in keypadc.h