### PR TITLE
Optimize popcount implementations

### DIFF
--- a/src/crt/bpopcnt.src
+++ b/src/crt/bpopcnt.src
@@ -3,25 +3,30 @@
 	section	.text
 	public	__bpopcnt
 __bpopcnt:
-	push	bc
-	ld	c,a		; c=(A|B|C|D|E|F|G|H)
-	and	a,$aa		; a=(A|0|C|0|E|0|G|0)
-	cpl			; a=(~A|1|~C|1|~E|1|~G|1)
-	rrca			; a=(1|~A|1|~C|1|~E|1|~G), cf=1
-	adc	a,c		; a=(A+B|C+D|E+F|G+H)
-	ld	b,a		; b=(A+B|C+D|E+F|G+H)
-	and	a,$33		; a=(00|C+D|00|G+H)
-	ld	c,a		; c=(00|C+D|00|G+H)
-	xor	a,b		; a=(A+B|00|E+F|00)
-	rrca
-	rrca			; a=(00|A+B|00|E+F)
-	add	a,c		; a=(A+B+C+D|E+F+G+H)
-	ld	c,a		; c=(A+B+C+D|E+F+G+H)
-	rrca
-	rrca
-	rrca
-	rrca			; a=(E+F+G+H|A+B+C+D)
-	add	a,c		; a=(A+B+C+D+E+F+G+H|A+B+C+D+E+F+G+H)
-	and	a,$f		; a=A+B+C+D+E+F+G+H
-	pop	bc
+	push	hl
+	ld	l, a
+	ld	h, 0
+
+	; Multiplying HL by 2 increases H by H+(L>>7).
+	; Use A to track these values of H to cancel from each iteration.
+	; On the first iteration H is 0, so skip subtracting it.
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	add	hl, hl
+	sub	a, h
+	; Note that the value of H after the 8th shift would be equivalent to the
+	; initial value of A, so instead of shifting and adding H to A at the end,
+	; simply offset from the initial value of A from the beginning.
+
+	pop	hl
 	ret

--- a/src/crt/ipopcnt.src
+++ b/src/crt/ipopcnt.src
@@ -3,8 +3,17 @@
 	section	.text
 	public	__ipopcnt
 __ipopcnt:
-	push	bc
-	ld	b, 3
-	jp	__lpopcnt.hijack1
+	push	hl
+	; Calculate 8-popcount(L)-popcount(HLU), and set HLU=H, L=0
+	call	__popcnt_common_init_full
+	; Subtract output carry and H (which will be added back in)
+	sbc	a, h
+	; Accumulate popcount(L)-popcount(HLU)+H-L=H-popcount(HLU)
+	call	__popcnt_common_iter
+	; Subtract final value from 8, and accumulate output carry
+	cpl
+	adc	a, 9
+	pop	hl
+	ret
 
-	extern	__lpopcnt.hijack1
+	extern	__popcnt_common_init_full, __popcnt_common_iter

--- a/src/crt/ipopcnt_fast.src
+++ b/src/crt/ipopcnt_fast.src
@@ -4,7 +4,7 @@
 	public	__ipopcnt_fast
 __ipopcnt_fast:
 	; Inlined implementation of __ipopcnt
-	push	hl
+	; Destroys: HL
 	ld	a, l
 	cpl
 	ld	l, a
@@ -46,5 +46,4 @@ __ipopcnt_fast:
 	add	hl, hl
 	cpl
 	adc	a, 9
-	pop	hl
 	ret

--- a/src/crt/ipopcnt_fast.src
+++ b/src/crt/ipopcnt_fast.src
@@ -1,0 +1,50 @@
+	assume	adl=1
+
+	section	.text
+	public	__ipopcnt_fast
+__ipopcnt_fast:
+	; Inlined implementation of __ipopcnt
+	push	hl
+	ld	a, l
+	cpl
+	ld	l, a
+	sub	a, h
+	sub	a, h
+
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+	add	hl, hl
+	sbc	a, l
+
+	add	hl, hl
+	cpl
+	adc	a, 9
+	pop	hl
+	ret

--- a/src/crt/llpopcnt_fast.src
+++ b/src/crt/llpopcnt_fast.src
@@ -3,17 +3,14 @@
 	section	.text
 	public	__llpopcnt_fast
 __llpopcnt_fast:
+	; Destroys: HL, DE
 	call	__lpopcnt_fast
-	push	de
-	push	hl
 	ex	de, hl
 	ld	l, b
 	ld	e, c
 	ld	d, a
 	call	__lpopcnt_fast
 	add	a, d
-	pop	hl
-	pop	de
 	ret
 
 	extern	__lpopcnt_fast

--- a/src/crt/llpopcnt_fast.src
+++ b/src/crt/llpopcnt_fast.src
@@ -1,0 +1,19 @@
+	assume	adl=1
+
+	section	.text
+	public	__llpopcnt_fast
+__llpopcnt_fast:
+	call	__lpopcnt_fast
+	push	de
+	push	hl
+	ex	de, hl
+	ld	l, b
+	ld	e, c
+	ld	d, a
+	call	__lpopcnt_fast
+	add	a, d
+	pop	hl
+	pop	de
+	ret
+
+	extern	__lpopcnt_fast

--- a/src/crt/lpopcnt.src
+++ b/src/crt/lpopcnt.src
@@ -3,32 +3,22 @@
 	section	.text
 	public	__lpopcnt
 __lpopcnt:
-	push	bc
-	ld	b, 4
-	public	__lpopcnt.hijack1
-.hijack1:
 	push	hl
-	xor	a, a
-	ld	c, a
-.loop:
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	add	hl, hl
-	adc	a, c
-	ld	l, e
-	djnz	.loop
+	; Calculate 8-popcount(L)-popcount(HLU), and set HLU=H
+	call	__popcnt_common_init_full
+	; Save the current count in H
+	ld	h, a
+	; Prepare to accumulate 8-popcount(E)-popcount(HLU)
+	ld	a, e
+	cpl
+	ld	l, a
+	; Subtract output carry and an additional H, the adjusted call adds H*2-L
+	sbc	a, h
+	call	__popcnt_common_iter_adjusted
+	; Subtract final value from 16, and accumulate output carry
+	cpl
+	adc	a, 17
 	pop	hl
-	pop	bc
 	ret
+
+	extern	__popcnt_common_init_full, __popcnt_common_iter_adjusted

--- a/src/crt/lpopcnt_fast.src
+++ b/src/crt/lpopcnt_fast.src
@@ -4,7 +4,7 @@
 	public	__lpopcnt_fast
 __lpopcnt_fast:
 	; Inlined implementation of __lpopcnt
-	push	hl
+	; Destroys: HL
 	ld	a, l
 	cpl
 	ld	l, a
@@ -51,5 +51,4 @@ __lpopcnt_fast:
 	add	hl, hl
 	cpl
 	adc	a, 17
-	pop	hl
 	ret

--- a/src/crt/lpopcnt_fast.src
+++ b/src/crt/lpopcnt_fast.src
@@ -1,23 +1,37 @@
 	assume	adl=1
 
 	section	.text
-	public	__spopcnt_fast
-__spopcnt_fast:
-	; Inlined implementation of __spopcnt
+	public	__lpopcnt_fast
+__lpopcnt_fast:
+	; Inlined implementation of __lpopcnt
 	push	hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-	add	hl, hl
-
-	ld	a, h
-	ld	h, l
+	ld	a, l
 	cpl
 	ld	l, a
+	sub	a, h
+	sub	a, h
+
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+
+	add	hl, hl
+	ld	h, a
+	ld	a, e
+	cpl
+	ld	l, a
+	sbc	a, h
 
 	add	hl, hl
 	sbc	a, h
@@ -36,6 +50,6 @@ __spopcnt_fast:
 
 	add	hl, hl
 	cpl
-	adc	a, 9
+	adc	a, 17
 	pop	hl
 	ret

--- a/src/crt/popcnt_common.src
+++ b/src/crt/popcnt_common.src
@@ -1,0 +1,53 @@
+	assume	adl=1
+
+	section	.text
+	public	__popcnt_common_init_full
+__popcnt_common_init_full:
+	; Calculates a combined popcount of L and HLU.
+	; Note the carry flag must be combined with A on return.
+	;     I: L,HLU=values to popcount
+	;     O: A-cf=8-popcount(L)-popcount(HLU), HLU=H, L=0
+	ld	a, l
+
+	public	__popcnt_common_init
+__popcnt_common_init:
+	; Same as above, but input is in A and HLU.
+
+	; Input value in A is inverted into L since HLU bits will be subtracted,
+	; calculating 8-popcount(A) to match the sign of accumulated bits.
+	cpl
+	ld	l, a
+	; Subtract an additional factor of H to cancel it out,
+	; since the code below is subtracting it by a factor of 0xFF.
+	sub	a, h
+
+	public	__popcnt_common_iter
+__popcnt_common_iter:
+	; Calculates a popcount accumulation.
+	; Note the carry flag must be combined with A on return.
+	;     I: HLU,L=values to popcount, A=current accumulation
+	;     O: A-cf=A+popcount(L)-popcount(HLU)+H-L, HLU=H, L=0
+	sub	a, h
+
+	public	__popcnt_common_iter_adjusted
+__popcnt_common_iter_adjusted:
+	; Same as above, but an additional H is accumulated into A.
+	; This is the same popcount technique as described in __bpopcnt,
+	; but bits shifted out from HLU are additionally subtracted.
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	add	hl, hl
+	sbc	a, h
+	; Sets the carry flag to the final bit from HLU, which the caller handles.
+	add	hl, hl
+	ret

--- a/src/crt/spopcnt.src
+++ b/src/crt/spopcnt.src
@@ -3,14 +3,18 @@
 	section	.text
 	public	__spopcnt
 __spopcnt:
+	; Set HLU=H and H=L, while saving HL on the stack
 	push	hl
-	ld	a,l
-	call	__bpopcnt
-	ld	l,a
-	ld	a,h
-	call	__bpopcnt
-	add	a,l
+	dec	sp
+	ex	(sp), hl
+	; Calculate 8-popcount(H)-popcount(HLU)
+	ld	a, h
+	call	__popcnt_common_init
+	; Subtract final value from 8, and accumulate output carry
+	cpl
+	adc	a, 9
 	pop	hl
+	inc	sp
 	ret
 
-	extern	__bpopcnt
+	extern	__popcnt_common_init

--- a/src/crt/spopcnt_fast.src
+++ b/src/crt/spopcnt_fast.src
@@ -4,7 +4,7 @@
 	public	__spopcnt_fast
 __spopcnt_fast:
 	; Inlined implementation of __spopcnt
-	push	hl
+	; Destroys: HL
 	add	hl, hl
 	add	hl, hl
 	add	hl, hl
@@ -37,5 +37,4 @@ __spopcnt_fast:
 	add	hl, hl
 	cpl
 	adc	a, 9
-	pop	hl
 	ret


### PR DESCRIPTION
I've come up with a novel algorithm for more efficiently doing popcount on eZ80 (which really shines when operating on 16 bits at a time).

16-bit, 24-bit, and 32-bit implementations call into a common set of code for popcounting 16 bits efficiently. Meanwhile, the 8-bit implementation is also smaller and faster than the previous implementation. (Note that the previous 8-bit implementation would be more optimal in a Z80 CRT, though).

I also implemented unrolled, self-contained versions for 16-bit, 24-bit, and 32-bit, which may be useful once the toolchain supports linking them.

I exhaustively tested the 8-bit and 16-bit implementations, and tested the 24-bit and 32-bit implementations within reasonable doubt.

These are my calculations for the cycle savings compared to the previous impls (assuming standard CE RAM waitstates):
- bpopcnt: -12.2%
- spopcnt: -43.6%
- ipopcnt: -14.8%
- lpopcnt: -25.2%

As for the sizes, the only standalone routine (bpopcnt) has been reduced by 5 bytes (-20%).
The others are more complicated due to the shared code:
- If only spopcnt is used, the new implementation is 5 bytes smaller (-12.5%).
- If only ipopcnt is used, the new implementation is 1 byte larger (+2.9%).
- If only lpopcnt is used, the new implementation is 12 bytes larger (+42.9%).
- If all routines are used, the new implementation is 14 bytes larger in total (+18.7%).