### PR TITLE
includes: add names to some structs.

### DIFF
--- a/src/ce/include/ti/real.h
+++ b/src/ce/include/ti/real.h
@@ -22,11 +22,11 @@ extern "C" {
 /**
  * @brief Structure of real variable type
  */
-typedef struct { int8_t sign, exp; uint8_t mant[7]; } real_t;
+typedef struct real_t { int8_t sign, exp; uint8_t mant[7]; } real_t;
 /**
  * @brief Structure of complex variable type
  */
-typedef struct { real_t real, imag; } cplx_t;
+typedef struct cplx_t { real_t real, imag; } cplx_t;
 
 /** OP1 Variable */
 #define os_OP1                  ((uint8_t*)0xD005F8)

--- a/src/ce/include/ti/vars.h
+++ b/src/ce/include/ti/vars.h
@@ -197,27 +197,27 @@ extern "C" {
 /**
  * @brief Structure of list variable type
  */
-typedef struct { uint16_t dim; real_t items[1]; } list_t;
+typedef struct list_t { uint16_t dim; real_t items[1]; } list_t;
 /**
  * @brief Structure of complex list variable type
  */
-typedef struct { uint16_t dim; cplx_t items[1]; } cplx_list_t;
+typedef struct cplx_list_t { uint16_t dim; cplx_t items[1]; } cplx_list_t;
 /**
  * @brief Structure of matrix variable type
  */
-typedef struct { uint8_t cols, rows; real_t items[1]; } matrix_t;
+typedef struct matrix_t { uint8_t cols, rows; real_t items[1]; } matrix_t;
 /**
  * @brief Structure of string variable type
  */
-typedef struct { uint16_t len; char data[1]; } string_t;
+typedef struct string_t { uint16_t len; char data[1]; } string_t;
 /**
  * @brief Structure of equation variable type
  */
-typedef struct { uint16_t len; char data[1]; } equ_t;
+typedef struct equ_t { uint16_t len; char data[1]; } equ_t;
 /**
  * @brief Structure of miscellaneous variable type
  */
-typedef struct { uint16_t size; uint8_t data[1]; } var_t;
+typedef struct var_t { uint16_t size; uint8_t data[1]; } var_t;
 
 /**
  * Returns the size in bytes of free RAM that the user isn't using. A pointer is

--- a/src/fontlibc/fontlibc.h
+++ b/src/fontlibc/fontlibc.h
@@ -113,7 +113,7 @@ typedef enum {
  * enforced.  Check for malformed metadata!
  * @see fontlib_font_pack_t
  */
-typedef struct {
+typedef struct fontlib_metadata_t {
     /**
      * Size of this struct, basically functions as a version field.
      * This does NOT include the lengths of the strings!
@@ -169,7 +169,7 @@ typedef struct {
  * it is probably not useful for C code to parse the width or bitmap data
  * directly.
  */
-typedef struct {
+typedef struct fontlib_font_t {
     /**
      * Version ID
      * @note This must be zero or the font will be rejected as invalid.
@@ -269,7 +269,7 @@ typedef struct {
  *  ti_Close(font_pack_file);
  * @endcode
  */
-typedef struct {
+typedef struct fontlib_font_pack_t {
     /**
      * Must be "FONTPACK"
      * @note This is NOT null-terminated!

--- a/src/graphx/graphx.h
+++ b/src/graphx/graphx.h
@@ -71,7 +71,7 @@ extern "C" {
  * Create at runtime (with uninitialized data) with gfx_MallocSprite(),
  * gfx_UninitedSprite(), or gfx_TempSprite().
  */
-typedef struct {
+typedef struct gfx_sprite_t {
     uint8_t width;   /**< Width of the image.  */
     uint8_t height;  /**< Height of the image. */
     uint8_t data[]; /**< Image data array.    */
@@ -92,7 +92,7 @@ typedef struct {
  * Create at compile-time with a tool like
  * <a href="https://github.com/mateoconlechuga/convimg" target="_blank">convimg</a>.
  */
-typedef struct {
+typedef struct gfx_rletsprite_t {
     uint8_t width; /**< Width of the image. */
     uint8_t height; /**< Height of the image. */
     uint8_t data[]; /**< Image data array. */
@@ -101,7 +101,7 @@ typedef struct {
 /**
  * A structure for working with 2D points.
  */
-typedef struct {
+typedef struct gfx_point_t {
     int x; /**< x point. */
     int y; /**< y point. */
 } gfx_point_t;
@@ -111,7 +111,7 @@ typedef struct {
  *
  * @see gfx_GetClipRegion
  */
-typedef struct {
+typedef struct gfx_region_t {
     int xmin; /**< Minimum x coordinate. */
     int ymin; /**< Minimum y coordinate. */
     int xmax; /**< Maximum x coordinate. */
@@ -123,7 +123,7 @@ typedef struct {
  *
  * @see gfx_Tilemap
  */
-typedef struct {
+typedef struct gfx_tilemap_t {
     uint8_t *map;            /**< Pointer to tilemap array. */
     gfx_sprite_t **tiles;    /**< Pointer to tileset sprites for the tilemap. */
     uint8_t tile_height;     /**< Individual tile height. */


### PR DESCRIPTION
Became "necessary" for the lua binding thing that didn't like anonymous structs.

I'm not sure which naming convention we should use, though, and maybe `_` as prefix isn't great, but it's been used in some places before already so I used that too.
We could also just use `the_type_name` for the struct name, and the typedef would still be `the_type_name_t`?
