### PR TITLE
Change OS_MATRIX_ELEMENT to row-major

### DIFF
--- a/src/ce/include/ti/vars.h
+++ b/src/ce/include/ti/vars.h
@@ -62,7 +62,7 @@ extern "C" {
  * @param col Column in matrix
  * @returns real_t containing element data
  */
-#define OS_MATRIX_ELEMENT(matrix, row, col) ((matrix)->items[(row)+(col)*(matrix)->rows])
+#define OS_MATRIX_ELEMENT(matrix, row, col) ((matrix)->items[(col)+(row)*(matrix)->cols])
 
 /** Maximum size of OS variable */
 #define OS_VAR_MAX_SIZE      (65512)


### PR DESCRIPTION
The TI-83+ link guide (http://merthsoft.com/linkguide/ti83+/vars.html#matrix) specifies that matrices are stored in row-major order. The OS_MATRIX_ELEMENT implementation performs memory lookups in column-major order. Basic testing confirms that the OS_MATRIX_ELEMENT indexes the matrix incorrectly.