### PR TITLE
Fix 1-wide `gfx_Rectangle_NoClip`

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -912,10 +912,11 @@ _HorizLine_NoClip_Draw:
 	ld	(hl),0
 smcByte _Color
 	cpi
-	ret	po
 	ex	de,hl
 	ld	hl,-1
 	add	hl,de
+; Delay 1-wide early return for consistent register output values.
+	ret	po
 	ldir
 	ret
 


### PR DESCRIPTION
Fixes #427. Probably. I haven't actually tested it.