### PR TITLE
Change memset_fast macro to function definition

### DIFF
--- a/src/ce/include/tice.h
+++ b/src/ce/include/tice.h
@@ -34,7 +34,7 @@
 /* @cond */
 #define prgm_CleanUp()
 #define pgrm_CleanUp()
-#define memset_fast memset
+void *memset_fast(void *s, int c, size_t n) __attribute__((nonnull(1)));
 #define _OS(function) function()
 #define asm_NewLine os_NewLine
 #define asm_MoveUp os_MoveUp

--- a/src/libc/memset.src
+++ b/src/libc/memset.src
@@ -2,7 +2,9 @@
 
 	section	.text
 	public	_memset
+	public _memset_fast
 _memset:
+_memset_fast:
 	pop	iy
 	pop	hl
 	pop	de


### PR DESCRIPTION
[description]
On TI-Planet Project Builder, this does not show up as a function definition, shown below. It bothered me, so I decided to change it into a function definition.
![](https://cdn.discordapp.com/attachments/432891584875593730/1155252415713521704/image.png)