### PR TITLE
Fix calloc ABI usage, optimize simple_malloc

### DIFF
--- a/src/libc/allocator.src
+++ b/src/libc/allocator.src
@@ -12,7 +12,9 @@ _calloc:
 	push	de
 	call	__imulu
 	push	hl
+	push	hl
 	call	_malloc
+	pop	de
 	add	hl,de
 	xor	a,a
 	sbc	hl,de
@@ -20,9 +22,9 @@ _calloc:
 	push	de
 	push	hl
 	call	nz,_memset
-	pop	hl
 	pop	de
-	pop	bc
+	pop	de
+	pop	de
 	ret
 
 if defined ALLOCATOR_SIMPLE

--- a/src/libc/allocator_simple.src
+++ b/src/libc/allocator_simple.src
@@ -5,24 +5,17 @@
 	public	__simple_malloc
 __simple_malloc:
 	pop	bc
-	ex	(sp),de
+	ex	(sp),hl
 	push	bc
-	ld	bc,(_heap_ptr)
-	push	bc
-	pop	iy
-	add	iy,de
-	lea	hl,iy
-	or	a,a
-	sbc	hl,bc
+	ld	de,(_heap_ptr)
+	add	hl,de
 	jr	c,.null
-	ld	de,___heaptop
-	lea	hl,iy
-	or	a,a
-	sbc	hl,de
+	ld	bc,___heaptop
+	sbc	hl,bc
 	jr	nc,.null
-	ld	(_heap_ptr),iy
-	push	bc
-	pop	hl
+	add	hl,bc
+	ld	(_heap_ptr),hl
+	ex	de,hl
 	ret
 .null:
 	or	a,a


### PR DESCRIPTION
The calloc implementation was ignoring ABI when calling malloc and memset, by assuming the parameters on the stack would not be modified. This is certainly not the case in the new simple_malloc implementation, so calloc could cause a buffer overflow via the memset.

Also, I optimized simple_malloc because I could :)