### PR TITLE
Allow override of $PREFIX

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 DESTDIR = $(CURDIR)/
-PREFIX = CEdev
+PREFIX ?= ~/CEdev
 
 include $(CURDIR)/src/common.mk
 

--- a/makefile
+++ b/makefile
@@ -14,8 +14,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-DESTDIR = $(CURDIR)/
-PREFIX ?= ~/CEdev
+DESTDIR ?= $(HOME)/
+PREFIX ?= CEdev
 
 include $(CURDIR)/src/common.mk
 


### PR DESCRIPTION
I tried to run `make install`, but it kept installing to ./CEdev. I know the docs say it is supposed to install to ~/CEdev, but it didn't install there. I tried setting PREFIX, but the same result occured. This should fix that.