### PR TITLE
Added additional macros/constants to sys/lcd.h and created sys/spi.h

### DIFF
--- a/src/ce/include/sys/lcd.h
+++ b/src/ce/include/sys/lcd.h
@@ -29,6 +29,34 @@ extern "C" {
 /* @endcond */
 /** LCD Control register */
 #define lcd_Control              (*(volatile uint24_t*)0xE30018)
+/** LCD RGB/BGR and Bits per pixel */
+#define lcd_VideoMode            (*(volatile uint16_t*)0xE30018)
+#define LCD_RGB1bit               (0x821) /**< RGB 1bit indexed color */
+#define LCD_RGB2bit               (0x823) /**< RGB 2bit indexed color */
+#define LCD_RGB4bit               (0x825) /**< RGB 4bit indexed color */
+#define LCD_RGB8bit               (0x827) /**< RGB 8bit indexed color */
+#define LCD_RGB1555               (0x829) /**< RGB 1555 16bit */
+#define LCD_RGB565                (0x82D) /**< RGB 565 16bit */
+#define LCD_RGB444                (0x82F) /**< RGB 444 16bit */
+#define LCD_RGB16bit              (LCD_RGB565) /**< TI-OS Default */
+#define LCD_BGR1bit               (0x921) /**< BGR 1bit indexed color */
+#define LCD_BGR2bit               (0x923) /**< BGR 2bit indexed color */
+#define LCD_BGR4bit               (0x925) /**< BGR 4bit indexed color */
+#define LCD_BGR8bit               (0x927) /**< BGR 8bit indexed color */
+#define LCD_BGR1555               (0x929) /**< BGR 1555 16bit */
+#define LCD_BGR565                (0x92D) /**< BGR 565 16bit */
+#define LCD_BGR444                (0x92F) /**< BGR 444 16bit */
+#define LCD_BGR16bit              (LCD_BGR565) /**< TI-OS Default */
+/** LCD Bits per pixel */
+#define lcd_VideoBPP             (*(volatile uint8_t*)0xE30018)
+#define LCD_INDEXED1              (0x21) /**< 1bit indexed color */
+#define LCD_INDEXED2              (0x23) /**< 2bit indexed color */
+#define LCD_INDEXED4              (0x25) /**< 4bit indexed color */
+#define LCD_INDEXED8              (0x27) /**< 8bit indexed color */
+#define LCD_COLOR1555             (0x29) /**< 1555 16bit */
+#define LCD_COLOR565              (0x2D) /**< 565 16bit */
+#define LCD_COLOR444              (0x2F) /**< 444 16bit */
+#define LCD_COLOR16               (LCD_COLOR565) /**< TI-OS Default */
 /* @cond */
 #define lcd_EnableInt            (*(volatile uint8_t*)0xE3001C)
 #define lcd_IntStatus            (*(volatile uint8_t*)0xE30020)
@@ -42,8 +70,8 @@ extern "C" {
 /** LCD palette registers, 512 bytes */
 #define lcd_Palette              ((uint16_t*)0xE30200)
 /* @cond */
-#define lcd_CrsrImageLen32       256
-#define lcd_CrsrImageLen64       1024
+#define lcd_CrsrImageLen32      (256)
+#define lcd_CrsrImageLen64      (1024)
 #define lcd_CrsrImage            ((uint8_t*)0xE30800)
 #define lcd_CrsrCtrl             (*(volatile uint8_t*)0xE30C00)
 #define lcd_CrsrConfig           (*(volatile uint8_t*)0xE30C04)

--- a/src/ce/include/sys/spi.h
+++ b/src/ce/include/sys/spi.h
@@ -1,0 +1,104 @@
+/**
+ * @file
+ * @authors
+ * @brief FTSSP010 SPI controller define file
+ */
+
+#ifndef SYS_SPI_H
+#define SYS_SPI_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* @cond */
+#define spi_ControlRegister0     ((volatile void*)0xF80000)
+#define spi_ControlRegister1     ((volatile void*)0xF80004)
+#define spi_ControlRegister2     ((volatile void*)0xF80008)
+#define spi_StatusBits           ((const volatile void*)0xF8000C)
+#define spi_InterruptControl     ((volatile void*)0xF80010)
+#define spi_InterruptStatus      ((const volatile void*)0xF80014)
+#define spi_FIFO                 ((volatile void*)0xF80018)
+#define spi_InsideReservedRange  ((volatile void*)0xF8001C)
+#define spi_Revision             ((const volatile void*)0xF80060)
+#define spi_Features             (*(const volatile uint32_t*)0xF80064)
+/* @endcond */
+
+/**
+ * In order to reliably use the LCD interface, the
+ * boot_InitializeHardware routine should be called at the start of a program
+ * to select the LCD interface and reset its configuration to the default.
+ */
+#define boot_InitializeHardware()  ((void(*)(void))0x384)();
+
+/**
+ * Sends a Command to the SPI controller using the 9bit FIFO protocol.
+ *
+ * @param[in] x 8bit parameter.
+ */
+#define SPI_COMMAND(x) \
+do { \
+    *(volatile uint8_t*)spi_FIFO = ((x) >> 6) & 0b111; \
+    *(volatile uint8_t*)spi_FIFO = ((x) >> 3) & 0b111; \
+    *(volatile uint8_t*)spi_FIFO = (x) & 0b111; \
+    *(volatile uint8_t*)spi_ControlRegister2 = 0x1; \
+    while ( ((const volatile uint8_t*)spi_StatusBits)[1] & 0xF0) {}; \
+    while ( ((const volatile uint8_t*)spi_StatusBits)[0] & (1 << 2)) {}; \
+    *(volatile uint8_t*)spi_ControlRegister2 = 0x0; \
+} while(0)
+
+/**
+ * Sends a Parameter to the SPI controller using the 9bit FIFO protocol.
+ *
+ * @param[in] x 8bit parameter.
+ */
+#define SPI_PARAMETER(x) \
+do { \
+    *(volatile uint8_t*)spi_FIFO = (((x) >> 6) & 0b111) | 0b100; \
+    *(volatile uint8_t*)spi_FIFO = ((x) >> 3) & 0b111; \
+    *(volatile uint8_t*)spi_FIFO = (x) & 0b111; \
+    *(volatile uint8_t*)spi_ControlRegister2 = 0x1; \
+    while ( ((const volatile uint8_t*)spi_StatusBits)[1] & 0xF0) {}; \
+    while ( ((const volatile uint8_t*)spi_StatusBits)[0] & (1 << 2)) {}; \
+    *(volatile uint8_t*)spi_ControlRegister2 = 0x0; \
+} while(0)
+
+/** @todo Implement vsync */
+#define SPI_UNINVERT_COLORS() SPI_COMMAND(0x20)
+
+/** @todo Implement vsync */
+#define SPI_INVERT_COLORS() SPI_COMMAND(0x21)
+
+/** Sets the LCD to BGR Row-Major mode (TI-OS default) */
+#define SPI_ROW_MAJOR() \
+do { \
+    SPI_COMMAND(0x36); \
+    SPI_PARAMETER(0b00001000); \
+    SPI_COMMAND(0x2A); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0x00); \
+    SPI_PARAMETER(0x01); SPI_PARAMETER(0x3F); \
+    SPI_COMMAND(0x2B); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0x00); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0xEF); \
+} while(0)
+
+/** Sets the LCD to BGR Column-Major mode */
+#define SPI_COLUMN_MAJOR() \
+do { \
+    SPI_COMMAND(0x36); \
+    SPI_PARAMETER(0b00101000); \
+    SPI_COMMAND(0x2A); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0x00); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0xEF); \
+    SPI_COMMAND(0x2B); \
+    SPI_PARAMETER(0x00); SPI_PARAMETER(0x00); \
+    SPI_PARAMETER(0x01); SPI_PARAMETER(0x3F); \
+} while(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
I wanted to add some additional macros/constants to `sys/lcd.h`; such as being able to set RGB/BGR and Bits per pixel with `lcd_VideoMode = LCD_BGR565` using the lower 16bits of `lcd_Control`, or just the Bits per pixel using `lcd_VideoBPP = LCD_INDEXED8` to set the lower 8bits of `lcd_Control`.

Additionally, I thought it would be nice to add `#define lcd_Ram8 ((uint8_t*)0xD40000)` and `#define lcd_Ram16 ((uint16_t*)0xD40000)` to `sys/lcd.h`.

I also added `sys/spi.h`, which contains #define's for the SPI registers, along with some macro routines to send SPI commands and parameters (based of the SPI sending example from [WikiTI](https://wikiti.brandonw.net/index.php?title=84PCE:Ports:D000#Sending)). There are also some macros for Inverting the colors, and for setting Row-Major/Column-Major through the SPI commands.

