### PR TITLE
Fixed ldexpf behaviour for NaN and Inf (e.g. ldexpf(Inf, -1))

### DIFF
--- a/src/libc/ldexp.c
+++ b/src/libc/ldexp.c
@@ -47,7 +47,7 @@ float _ldexpf_c(float value, int power)
     int     exponent;
 	int powerplusexponent;
 
-	if ( value == 0.0 ) return 0;
+	if ( value == 0.0 || !isfinite(value) ) return value;
 
 	floating.value = value;
     exponent = (floating.bits >> exponent_shift) & exponent_mask;


### PR DESCRIPTION
ldexpf currently checks that `current_exponent + add_exponent <= exponent_max`. However, subtracting from the exponent value of Inf or NaN will result in a finite value. I have fixed this so that Inf and NaN are returned unmodified.