### PR TITLE
__integral<signed short> was missing from type_traits

### DIFF
--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -94,6 +94,7 @@ template<>          struct __integral<           char8_t> : true_type  {};
 #endif
 template<>          struct __integral<          char16_t> : true_type  {};
 template<>          struct __integral<          char32_t> : true_type  {};
+template<>          struct __integral<  signed     short> : true_type  {};
 template<>          struct __integral<unsigned     short> : true_type  {};
 template<>          struct __integral<  signed       int> : true_type  {};
 template<>          struct __integral<unsigned       int> : true_type  {};


### PR DESCRIPTION
I noticed that `signed short` was absent from `<type_traits>`, causing `std::is_integral_v<signed short>` to return false.
```c++
#include <type_traits>

// passes
static_assert(std::is_integral_v<unsigned short>, "unsigned short is not integral");
// fails
static_assert(std::is_integral_v<signed short>, "signed short is not integral");

int main(void) {
    return 0;
}
```