### PR TITLE
Added is_signed to <type_traits>

### DIFF
--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -120,6 +120,16 @@ template<class _Tp> inline constexpr bool is_arithmetic_v = is_arithmetic<_Tp>::
 template<class _Tp> using is_fundamental = disjunction<is_void<_Tp>, is_null_pointer<_Tp>, is_arithmetic<_Tp>>;
 template<class _Tp> inline constexpr bool is_fundamental_v = is_fundamental<_Tp>::value;
 
+template<class _Tp, bool = is_arithmetic<_Tp>::value> struct __is_signed : integral_constant<bool, _Tp(-1) < _Tp(0)> {};
+template<class _Tp>                                   struct __is_signed<_Tp, false> : false_type {};
+template<class _Tp> struct is_signed : __is_signed<_Tp>::type {};
+template<class _Tp> constexpr bool is_signed_v = is_signed<_Tp>::value;
+
+template<class _Tp, bool = is_arithmetic<_Tp>::value> struct __is_unsigned : integral_constant<bool, _Tp(0) < _Tp(-1)> {};
+template<class _Tp>                                   struct __is_unsigned<_Tp, false> : false_type {};
+template<class _Tp> struct is_unsigned : __is_unsigned<_Tp>::type {};
+template<class _Tp> constexpr bool is_unsigned_v = is_unsigned<_Tp>::value;
+
 template<class>                 struct is_array           : false_type {};
 template<class _Tp>             struct is_array<_Tp[]>    : true_type  {};
 template<class _Tp, size_t _Np> struct is_array<_Tp[_Np]> : true_type  {};


### PR DESCRIPTION
Added `is_signed` and `is_unsigned` to `<type_traits>`

Test code:
```c++
static_assert(
	std::is_signed_v<void> == false &&
	std::is_signed_v<void*> == false &&
	std::is_signed_v<int> == true &&
	std::is_signed_v<int*> == false &&
	std::is_signed_v<unsigned int> == false &&
	std::is_signed_v<unsigned int*> == false &&
	std::is_signed_v<float> == true &&
	std::is_signed_v<double> == true &&
	std::is_signed_v<  signed __int48> == true &&
	std::is_signed_v<unsigned __int48> == false &&
	std::is_signed_v<bool> == false,
	"is_signed fail"
);

static_assert(
	std::is_unsigned_v<void> == false &&
	std::is_unsigned_v<void*> == false &&
	std::is_unsigned_v<int> == false &&
	std::is_unsigned_v<int*> == false &&
	std::is_unsigned_v<unsigned int> == true &&
	std::is_unsigned_v<unsigned int*> == false &&
	std::is_unsigned_v<float> == false &&
	std::is_unsigned_v<double> == false &&
	std::is_unsigned_v<  signed __int48> == false &&
	std::is_unsigned_v<unsigned __int48> == true &&
	std::is_unsigned_v<bool> == true,
	"is_unsigned fail"
);
```