### PR TITLE
Use assembly version of feof

### DIFF
--- a/src/libc/feof.c
+++ b/src/libc/feof.c
@@ -1,7 +1,0 @@
-#include <stdio.h>
-#include <fileioc.h>
-
-int __attribute__((weak)) feof(FILE *stream)
-{
-    return stream->eof;
-}

--- a/src/libc/feof.src
+++ b/src/libc/feof.src
@@ -1,0 +1,11 @@
+	assume	adl = 1
+
+	section	.text
+	weak	_feof
+_feof:
+	ld	iy, 0
+	add	iy, sp
+	ld	iy, (iy + 3)
+	sbc	hl, hl
+	ld	l, (iy + 1)
+	ret


### PR DESCRIPTION
The code was generated by switching the optimization flag to -Ofast, which automatically uses IY. After a few attempts, I couldn't write a faster function, so I just included that.