### PR TITLE
Implemented i48abs(int48_t) and added prototypes for i48div

### DIFF
--- a/examples/standalone_examples/math_test/src/main.c
+++ b/examples/standalone_examples/math_test/src/main.c
@@ -95,10 +95,12 @@ static int24_t iabs(int24_t x)
 {
     return x < 0 ? (int24_t)-x : x;
 }
+#ifndef _EZ80
 static int48_t i48abs(int48_t x)
 {
     return x < 0 ? (int48_t)-x : x;
 }
+#endif
 
 
 #if INTERACTIVE && defined(_EZ80)

--- a/src/crt/i48abs.src
+++ b/src/crt/i48abs.src
@@ -1,0 +1,23 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_i48abs
+
+; int48_t i48abs(int48_t)
+_i48abs:
+	pop	bc
+	pop	de
+	ex	(sp), hl
+
+	; read the signbit
+	push	hl
+	add	hl, hl
+	ex	(sp), hl
+
+	push	bc
+	ex	de, hl
+	ret nc	; positive
+	jp	__i48neg
+
+	extern	__i48neg

--- a/src/crt/i48div.src
+++ b/src/crt/i48div.src
@@ -1,0 +1,8 @@
+	assume	adl=1
+
+	section	.text
+
+;	public	_i48div
+
+; i48div_t i48div(int48_t numer, int48_t denom);
+; _i48div:

--- a/src/libc/include/stdlib.h
+++ b/src/libc/include/stdlib.h
@@ -13,6 +13,13 @@ typedef struct {
     long rem;
 } ldiv_t;
 
+#ifdef __SIZEOF_INT48__
+typedef struct {
+    signed __int48 quot;
+    signed __int48 rem;
+} i48div_t;
+#endif /* __SIZEOF_INT48__ */
+
 typedef struct {
     long long rem;
     long long quot;
@@ -96,11 +103,19 @@ long labs(long n);
 
 long long llabs(long long n);
 
+#ifdef __SIZEOF_INT48__
+signed __int48 i48abs(signed __int48 n);
+#endif /* __SIZEOF_INT48__ */
+
 div_t div(int numer, int denom);
 
 ldiv_t ldiv(long numer, long denom);
 
 lldiv_t lldiv(long long numer, long long denom);
+
+#ifdef __SIZEOF_INT48__
+i48div_t i48div(signed __int48 numer, signed __int48 denom);
+#endif /* __SIZEOF_INT48__ */
 
 __END_DECLS
 

--- a/src/libcxx/include/cstdlib
+++ b/src/libcxx/include/cstdlib
@@ -42,12 +42,20 @@ using ::labs;
 using ::llabs;
 inline constexpr long abs(long __x) { return labs(__x); }
 inline constexpr long long abs(long long __x) { return llabs(__x); }
+#ifdef __SIZEOF_INT48__
+using ::i48abs;
+inline signed __int48 abs(signed __int48 __x) { return i48abs(__x); }
+#endif // __SIZEOF_INT48__
 
 using ::div;
 using ::ldiv;
 using ::lldiv;
 inline constexpr ldiv_t div(long __x, long __y) { return ldiv(__x, __y); }
 inline constexpr lldiv_t div(long long __x, long long __y) { return lldiv(__x, __y); }
+#ifdef __SIZEOF_INT48__
+using ::i48div;
+inline i48div_t div(signed __int48 __x, signed __int48 __y) { return i48div(__x, __y); }
+#endif // __SIZEOF_INT48__
 
 } // namespace std
 


### PR DESCRIPTION
`signed __int48 i48abs(signed __int48 n)` is implemented in assembly. The function prototypes for `i48div_t i48div(signed __int48 numer, signed __int48 denom)` have been declared, but the function is not implemented.