### PR TITLE
Fixed the C++ overloads for intmax_t abs and div

### DIFF
--- a/src/libcxx/include/cinttypes
+++ b/src/libcxx/include/cinttypes
@@ -12,10 +12,12 @@ namespace std {
 using ::imaxdiv_t;
 
 using ::imaxabs;
-inline constexpr intmax_t abs(intmax_t __x) { return imaxabs(__x); }
-
 using ::imaxdiv;
+
+#if __INTMAX_WIDTH__ > __LLONG_WIDTH__
+inline constexpr intmax_t abs(intmax_t __x) { return imaxabs(__x); }
 inline constexpr imaxdiv_t div(intmax_t __x, intmax_t __y) { return imaxdiv(__x, __y); }
+#endif // __INTMAX_WIDTH__ > __LLONG_WIDTH__
 
 } // namespace std
 


### PR DESCRIPTION
Because `intmax_t` and `long long` have the same width, `intmax_t abs(intmax_t)` and `long long abs(long long)` will conflict. Same thing for `imaxdiv_t div(intmax_t, intmax_t)` and `lldiv_t div(long long, long long)`.

It turns out that the `intmax_t` overloads of `abs` and `div` are only defined if `intmax_t` is an extended integer type (larger than `long long`)