### PR TITLE
Added __frem to CRT (wraps fmodf)

### DIFF
--- a/src/crt/frem.src
+++ b/src/crt/frem.src
@@ -1,0 +1,21 @@
+	assume	adl=1
+
+	section	.text
+
+	public	__frem
+
+; wraps _fmodf
+__frem:
+	push	de, hl
+
+	push	de, hl	; y
+	ld	e, a	
+	push	de	; x_hi8
+	push	bc	; x_lo24
+	call	_fmodf
+	pop	hl, hl, hl, hl
+
+	pop	hl, de
+	ret
+
+	extern	_fmodf


### PR DESCRIPTION
```c
float fwrap(float x, float min, float max) {
    if (min > max)
        return fwrap(x, max, min);
    return (x >= 0 ? min : max) + fmodf(x, max - min);
}
```
This code when compiled with `-Ofast` (in C) would emit a lib-call to `__frem` instead of a call `_fmodf`. However, `__frem` wasn't defined in the toolchain. This has been fixed by adding the CRT routine for `__frem`, which wraps `_fmodf` for now.

Credit to @merthsoft for finding this bug