### PR TITLE
Fixed cbrtf for negative inputs

### DIFF
--- a/src/libc/cbrt.c
+++ b/src/libc/cbrt.c
@@ -2,7 +2,7 @@
 
 float cbrtf(float x)
 {
-    return powf(x, 1/3.f);
+    return copysignf(powf(fabsf(x), 1.f/3.f), x);
 }
 
 double cbrt(double) __attribute__((alias("cbrtf")));


### PR DESCRIPTION
Having `cbrtf` defined as `powf(x, 1.0f/3.0f)` doesn't work when `x` is negative. I have fixed this by doing `copysignf(powf(fabsf(x), 1.0f/3.0f), x)`, which ensures that the sign of `x` is preserved and that `powf` does not receive negative arguments.

To my knowledge, Calc84Maniac was working on a more accurate `cbrtf` routine in ez80sf. So I won't be adding any other modifications to `cbrtf`.