### PR TITLE
added perror and strerror along with autotests for them

### DIFF
--- a/src/libc/errno_str.c
+++ b/src/libc/errno_str.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int _ti_sprintf(
+    char *__restrict buffer, const char *__restrict format, ...
+) __attribute__ ((format (__printf__, 2, 3)));
+
+static char const * const errno_strings[] = {
+    "no error",
+    "permission error",
+    "invalid argument",
+    "io error",
+    "math domain error",
+    "math range error",
+};
+
+static char * const unknown_errno_string = "unknown error -8388608";
+
+#define unknown_errno_number_offset 14
+#if 0
+/* static_assert on a string is a Clang 16.0.0 extension */
+static_assert(
+    unknown_errno_string[unknown_errno_number_offset + 0] == '-' &&
+    unknown_errno_string[unknown_errno_number_offset + 8] == '\0',
+    "the string for unknown errno numbers has been changed"
+);
+#endif
+
+#define errno_strings_count (sizeof(errno_strings) / sizeof(errno_strings[0]))
+
+char* strerror(int errnum) {
+    if ((unsigned int)errnum >= errno_strings_count) {
+        _ti_sprintf(&(unknown_errno_string[unknown_errno_number_offset]), "%d", errnum);
+        return (char*)unknown_errno_string;
+    }
+    return (char*)errno_strings[errnum];
+}
+
+#if 0
+/** disabled until the prototypes for this function are defined */
+size_t strerrorlen_s(errno_t errnum) {
+    return strlen(strerror(errnum));
+}
+#endif
+
+void perror(const char *str) {
+    if (str != NULL && *str != '\0') {
+        fputs(str, stderr);
+        fputc(':', stderr);
+        fputc(' ', stderr);
+    }
+    fputs(strerror(errno), stderr);
+    fputc('\n', stderr);
+}

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -104,6 +104,8 @@ int sprintf(char *__restrict buffer,
     const char *__restrict format, ...)
     __attribute__ ((format (__printf__, 2, 3)));
 
+void perror(const char* str);
+
 __END_DECLS
 
 #endif /* _STDIO_H */

--- a/src/libc/include/string.h
+++ b/src/libc/include/string.h
@@ -72,6 +72,7 @@ int strcasecmp(const char *s1, const char *s2)
 int strncasecmp(const char *s1, const char *s2, size_t n)
                 __attribute__((nonnull(1, 2)));
 
+char* strerror(int errnum);
 
 __END_DECLS
 

--- a/src/libc/ti_routines.src
+++ b/src/libc/ti_routines.src
@@ -1,0 +1,9 @@
+	assume	adl=1
+
+	section	.text
+
+; to reduce binary size (or performance in the case of sprintf), ti's routines
+; can be linked instead of the toolchain's routines
+
+	public	__ti_sprintf
+__ti_sprintf := 0000BCh

--- a/src/libcxx/include/cstdio
+++ b/src/libcxx/include/cstdio
@@ -35,6 +35,7 @@ using ::vsprintf;
 using ::snprintf;
 using ::vsnprintf;
 using ::sprintf;
+using ::perror;
 } // namespace std
 
 #endif // _EZCXX_CSTDINT

--- a/src/libcxx/include/cstring
+++ b/src/libcxx/include/cstring
@@ -33,6 +33,7 @@ using ::strcmp;
 using ::strncmp;
 using ::strcasecmp;
 using ::strncasecmp;
+using ::strerror;
 } // namespace std
 
 #endif // _EZCXX_CSTRING

--- a/test/standalone/errno/autotest.json
+++ b/test/standalone/errno/autotest.json
@@ -1,0 +1,50 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|600",
+    "hashWait|1",
+    "key|enter",
+    "delay|600",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3"
+  ],
+  "hashes": {
+    "1": {
+      "description": "Valid errno screen",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "B0BE2F4E"
+      ]
+    },
+    "2": {
+      "description": "Invalid input screen",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "29401BEE"
+      ]
+    },
+    "3": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/standalone/errno/makefile
+++ b/test/standalone/errno/makefile
@@ -1,0 +1,18 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Oz
+CXXFLAGS = -Wall -Wextra -Oz
+
+PREFER_OS_LIBC = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/standalone/errno/src/main.c
+++ b/test/standalone/errno/src/main.c
@@ -1,0 +1,48 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+
+/** @note assumes that the following strings are used: */
+#if 0
+static char const * const errno_str[] = {
+    "no error",
+    "permission error",
+    "invalid argument",
+    "io error",
+    "math domain error",
+    "math range error",
+};
+
+static char * const unknown_errno_string = "unknown error -8388608";
+#endif
+
+int main(void)
+{
+    os_ClrHome();
+
+    errno = 0; perror(NULL);
+    errno = 1; perror("");
+    errno = 2; perror("\0");
+    errno = 3; perror(" ");
+    errno = 4; perror("%d");
+    errno = 5; perror("perror");
+
+    while (!os_GetCSC());
+
+    os_ClrHome();
+
+    errno = 6; perror(NULL);
+    errno = -1; perror("");
+    errno = -123456; perror("%d");
+    errno = 123456; perror("???");
+    errno = INT_MIN; perror(" ");
+    errno = INT_MAX; perror("#");
+    
+    while (!os_GetCSC());
+
+    return 0;
+}


### PR DESCRIPTION
also adds `ti_routines.src`, which allows for the explicit use of ti's `sprintf` to reduce binary size

identical to https://github.com/CE-Programming/toolchain/pull/546