### PR TITLE
C++20 <version> and expanded <type_traits>

### DIFF
--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -188,6 +188,11 @@ template<class _Tp> inline constexpr bool is_abstract_v = __is_abstract(_Tp);
 template<class _Tp> using is_abstract = bool_constant<is_abstract_v<_Tp>>;
 #endif
 
+#if __has_feature(is_final)
+template<class _Tp> inline constexpr bool is_final_v = __is_final(_Tp);
+template<class _Tp> using is_final = bool_constant<is_final_v<_Tp>>;
+#endif
+
 template<class>     struct is_pointer       : false_type {};
 template<class _Tp> struct is_pointer<_Tp*> : true_type  {};
 template<class _Tp> inline constexpr bool is_pointer_v = is_pointer<_Tp>::value;
@@ -263,6 +268,10 @@ template<class _Tp> struct remove_reference<_Tp&>  : type_identity<_Tp> {};
 template<class _Tp> struct remove_reference<_Tp&&> : type_identity<_Tp> {};
 template<class _Tp> using remove_reference_t = typename remove_reference<_Tp>::type;
 
+template <class _Tp> using __remove_cvref_t = typename remove_cv<typename remove_reference<_Tp>::type>::type;
+template <class _Tp> struct remove_cvref { using type = __remove_cvref_t<_Tp>; };
+template <class _Tp> using remove_cvref_t = typename remove_cvref<_Tp>::type;
+
 template<class _Tp> auto __add_pointer(int) -> type_identity<_Tp*>;
 template<class _Tp> auto __add_pointer(...) -> type_identity<_Tp>;
 template<class _Tp> using add_pointer = decltype(__add_pointer<_Tp>(0));
@@ -277,6 +286,60 @@ template<class _Tp> auto __add_rvalue_reference(int) -> type_identity<_Tp&&>;
 template<class _Tp> auto __add_rvalue_reference(...) -> type_identity<_Tp>;
 template<class _Tp> using add_rvalue_reference = decltype(__add_rvalue_reference<_Tp>(0));
 template<class _Tp> using add_rvalue_reference_t = typename add_rvalue_reference<_Tp>::type;
+
+// alignment_of:
+template <class _Tp> struct alignment_of
+    : public integral_constant<size_t, alignof(_Tp)> {};
+template <class _Tp> inline constexpr size_t alignment_of_v = alignment_of<_Tp>::value;
+
+// rank/extent:
+template <class _Tp> struct rank
+    : public integral_constant<size_t, 0> {};
+template <class _Tp> struct rank<_Tp[]>
+    : public integral_constant<size_t, rank<_Tp>::value + 1> {};
+template <class _Tp, size_t _Np> struct rank<_Tp[_Np]>
+    : public integral_constant<size_t, rank<_Tp>::value + 1> {};
+template <class _Tp> inline constexpr size_t rank_v = rank<_Tp>::value;
+
+template <class _Tp, unsigned _Ip = 0> struct extent
+    : public integral_constant<size_t, 0> {};
+template <class _Tp> struct extent<_Tp[], 0>
+    : public integral_constant<size_t, 0> {};
+template <class _Tp, unsigned _Ip> struct extent<_Tp[], _Ip>
+    : public integral_constant<size_t, extent<_Tp, _Ip-1>::value> {};
+template <class _Tp, size_t _Np> struct extent<_Tp[_Np], 0>
+    : public integral_constant<size_t, _Np> {};
+template <class _Tp, size_t _Np, unsigned _Ip> struct extent<_Tp[_Np], _Ip>
+    : public integral_constant<size_t, extent<_Tp, _Ip-1>::value> {};
+template <class _Tp, unsigned _Ip = 0> inline constexpr size_t extent_v = extent<_Tp, _Ip>::value;
+
+template<class _Tp> struct remove_extent { typedef _Tp type; };
+template<class _Tp> struct remove_extent<_Tp[]> { typedef _Tp type; };
+template<class _Tp, size_t _Np> struct remove_extent<_Tp[_Np]> { typedef _Tp type; };
+template <class _Tp> using remove_extent_t = typename remove_extent<_Tp>::type;
+
+template <class _Tp> struct remove_all_extents { typedef _Tp type; };
+template <class _Tp> struct remove_all_extents<_Tp[]> { typedef typename remove_all_extents<_Tp>::type type; };
+template <class _Tp, size_t _Np> struct remove_all_extents<_Tp[_Np]> { typedef typename remove_all_extents<_Tp>::type type; };
+template <class _Tp> using remove_all_extents_t = typename remove_all_extents<_Tp>::type;
+
+// decay:
+template<class _Tp>
+struct decay {
+private:
+    typedef typename std::remove_reference<_Tp>::type _Up;
+public:
+    typedef typename std::conditional< 
+        std::is_array<_Up>::value,
+        typename std::add_pointer<typename std::remove_extent<_Up>::type>::type,
+        typename std::conditional< 
+            std::is_function<_Up>::value,
+            typename std::add_pointer<_Up>::type,
+            typename std::remove_cv<_Up>::type
+        >::type
+    >::type type;
+};
+template <class _Tp> using decay_t = typename decay<_Tp>::type;
 
 // <utility> functions:
 template<class _Tp> add_rvalue_reference_t<_Tp> declval() noexcept;
@@ -356,16 +419,20 @@ template<class _Tp> using has_virtual_destructor = bool_constant<has_virtual_des
 #endif
 
 // more <utility> functions:
+#if __cplusplus > 201103L
 template<class _Tp> _EZCXX_INLINE constexpr auto move(_Tp&& __value) noexcept {
     return static_cast<remove_reference_t<_Tp>&&>(__value);
 }
+#endif // __cplusplus > 201103L
 
+#if __cplusplus > 201103L
 template<class _Tp> _EZCXX_INLINE constexpr enable_if_t<is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp>>
 swap(_Tp& __lhs, _Tp& __rhs) noexcept(is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>) {
     _Tp __temp(move(__lhs));
     __lhs = move(__rhs);
     __rhs = move(__temp);
 }
+#endif // __cplusplus > 201103L
 
 // swappable classification traits:
 template<class _Lp, class _Rp> auto __swappable(int) -> __require<decltype(swap(declval<_Lp>(), declval<_Rp>()))>;

--- a/src/libcxx/include/utility
+++ b/src/libcxx/include/utility
@@ -28,8 +28,10 @@ template<class _Tp> _EZCXX_INLINE constexpr conditional_t<!is_nothrow_move_const
                                                           is_copy_constructible_v<_Tp>, _Tp const&, _Tp&&>
 move_if_noexcept(_Tp& __value) noexcept { return move(__value); }
 
+#if __cplusplus > 201103L
 template<class _Tp> _EZCXX_INLINE constexpr std::add_const_t<_Tp>& as_const(_Tp& __value) noexcept { return __value; }
 template<class _Tp> _EZCXX_INLINE constexpr auto as_const(_Tp const&& __value) noexcept = delete;
+#endif // __cplusplus > 201103L
 
 } // namespace std
 

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -1,0 +1,211 @@
+// -*- C++ -*-
+#ifndef _EZCXX_VERSION
+#define _EZCXX_VERSION
+
+#pragma clang system_header
+
+#if __cplusplus >= 201402L
+// # define __cpp_lib_chrono_udls                          201304L
+// # define __cpp_lib_complex_udls                         201309L
+// # define __cpp_lib_exchange_function                    201304L
+// # define __cpp_lib_generic_associative_lookup           201304L
+// # define __cpp_lib_integer_sequence                     201304L
+// # define __cpp_lib_integral_constant_callable           201304L
+// # define __cpp_lib_is_final                             201402L
+// # define __cpp_lib_is_null_pointer                      201309L
+// # define __cpp_lib_make_reverse_iterator                201402L
+// # define __cpp_lib_make_unique                          201304L
+// # define __cpp_lib_null_iterators                       201304L
+// # define __cpp_lib_quoted_string_io                     201304L
+// # define __cpp_lib_result_of_sfinae                     201210L
+// # define __cpp_lib_robust_nonmodifying_seq_ops          201304L
+// # define __cpp_lib_shared_timed_mutex                   201402L
+// # define __cpp_lib_string_udls                          201304L
+// # define __cpp_lib_transformation_trait_aliases         201304L
+// # define __cpp_lib_transparent_operators                201210L
+// # define __cpp_lib_tuple_element_t                      201402L
+// # define __cpp_lib_tuples_by_type                       201304L
+#endif // __cplusplus >= 201402L
+
+#if __cplusplus >= 201703L
+// # define __cpp_lib_addressof_constexpr                  201603L
+// # define __cpp_lib_allocator_traits_is_always_equal     201411L
+// # define __cpp_lib_any                                  201606L
+// # define __cpp_lib_apply                                201603L
+// # define __cpp_lib_array_constexpr                      201603L
+// # define __cpp_lib_as_const                             201510L
+// # define __cpp_lib_atomic_is_always_lock_free           201603L
+// # define __cpp_lib_bool_constant                        201505L
+// # define __cpp_lib_boyer_moore_searcher                 201603L
+// # define __cpp_lib_byte                                 201603L
+// # define __cpp_lib_chrono                               201611L
+// # define __cpp_lib_clamp                                201603L
+// # define __cpp_lib_enable_shared_from_this              201603L
+// # define __cpp_lib_execution                            201603L
+// # define __cpp_lib_filesystem                           201703L
+// # define __cpp_lib_gcd_lcm                              201606L
+// # define __cpp_lib_hardware_interference_size           201703L
+// # define __cpp_lib_has_unique_object_representations    201606L
+// # define __cpp_lib_hypot                                201603L
+// # define __cpp_lib_incomplete_container_elements        201505L
+// # define __cpp_lib_invoke                               201411L
+// # define __cpp_lib_is_aggregate                         201703L
+// # define __cpp_lib_is_invocable                         201703L
+// # define __cpp_lib_is_swappable                         201603L
+// # define __cpp_lib_launder                              201606L
+// # define __cpp_lib_logical_traits                       201510L
+// # define __cpp_lib_make_from_tuple                      201606L
+// # define __cpp_lib_map_try_emplace                      201411L
+// # define __cpp_lib_math_special_functions               201603L
+// # define __cpp_lib_memory_resource                      201603L
+// # define __cpp_lib_node_extract                         201606L
+// # define __cpp_lib_nonmember_container_access           201411L
+// # define __cpp_lib_not_fn                               201603L
+// # define __cpp_lib_optional                             201606L
+// # define __cpp_lib_parallel_algorithm                   201603L
+// # define __cpp_lib_raw_memory_algorithms                201606L
+// # define __cpp_lib_sample                               201603L
+// # define __cpp_lib_scoped_lock                          201703L
+// # define __cpp_lib_shared_mutex                         201505L
+// # define __cpp_lib_shared_ptr_arrays                    201611L
+// # define __cpp_lib_shared_ptr_weak_type                 201606L
+// # define __cpp_lib_string_view                          201606L
+// # define __cpp_lib_to_chars                             201611L
+// # undef  __cpp_lib_transparent_operators
+// # define __cpp_lib_transparent_operators                201510L
+// # define __cpp_lib_type_trait_variable_templates        201510L
+// # define __cpp_lib_uncaught_exceptions                  201411L
+// # define __cpp_lib_unordered_map_try_emplace            201411L
+// # define __cpp_lib_variant                              202102L
+// # define __cpp_lib_void_t                               201411L
+#endif // __cplusplus >= 201703L
+
+#if __cplusplus >= 202002L
+// # undef  __cpp_lib_array_constexpr
+// # define __cpp_lib_array_constexpr                      201811L
+// # define __cpp_lib_assume_aligned                       201811L
+// # define __cpp_lib_atomic_flag_test                     201907L
+// # define __cpp_lib_atomic_float                         201711L
+// # define __cpp_lib_atomic_lock_free_type_aliases        201907L
+// # define __cpp_lib_atomic_ref                           201806L
+// # define __cpp_lib_atomic_shared_ptr                    201711L
+// # define __cpp_lib_atomic_value_initialization          201911L
+// # define __cpp_lib_atomic_wait                          201907L
+// # define __cpp_lib_barrier                              201907L
+// # define __cpp_lib_bind_front                           201907L
+// # define __cpp_lib_bit_cast                             201806L
+// # define __cpp_lib_bitops                               201907L
+// # define __cpp_lib_bounded_array_traits                 201902L
+// # define __cpp_lib_char8_t                              201907L
+// # define __cpp_lib_concepts                             202002L
+// # define __cpp_lib_constexpr_algorithms                 201806L
+// # define __cpp_lib_constexpr_complex                    201711L
+// # define __cpp_lib_constexpr_dynamic_alloc              201907L
+// # define __cpp_lib_constexpr_functional                 201907L
+// # define __cpp_lib_constexpr_iterator                   201811L
+// # define __cpp_lib_constexpr_memory                     201811L
+// # define __cpp_lib_constexpr_numeric                    201911L
+// # define __cpp_lib_constexpr_string                     201907L
+// # define __cpp_lib_constexpr_string_view                201811L
+// # define __cpp_lib_constexpr_tuple                      201811L
+// # define __cpp_lib_constexpr_utility                    201811L
+// # define __cpp_lib_constexpr_vector                     201907L
+// # define __cpp_lib_coroutine                            201902L
+// # if defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L
+// #  define __cpp_lib_destroying_delete                   201806L
+// # endif
+// # define __cpp_lib_endian                               201907L
+// # define __cpp_lib_erase_if                             202002L
+// # undef  __cpp_lib_execution
+// # define __cpp_lib_execution                            201902L
+// # define __cpp_lib_format                               202110L
+// # define __cpp_lib_format_uchar                         202311L
+// # define __cpp_lib_generic_unordered_lookup             201811L
+// # define __cpp_lib_int_pow2                             202002L
+// # define __cpp_lib_integer_comparison_functions         202002L
+// # define __cpp_lib_interpolate                          201902L
+// # define __cpp_lib_is_constant_evaluated                201811L
+// # define __cpp_lib_is_layout_compatible                 201907L
+// # define __cpp_lib_is_nothrow_convertible               201806L
+// # define __cpp_lib_is_pointer_interconvertible          201907L
+// # define __cpp_lib_jthread                              201911L
+// # define __cpp_lib_latch                                201907L
+// # define __cpp_lib_list_remove_return_type              201806L
+// # define __cpp_lib_math_constants                       201907L
+// # define __cpp_lib_move_iterator_concept                202207L
+// # define __cpp_lib_polymorphic_allocator                201902L
+// # define __cpp_lib_ranges                               202110L
+// # define __cpp_lib_remove_cvref                         201711L
+// # define __cpp_lib_semaphore                            201907L
+// # undef  __cpp_lib_shared_ptr_arrays
+// # define __cpp_lib_shared_ptr_arrays                    201707L
+// # define __cpp_lib_shift                                201806L
+// # define __cpp_lib_smart_ptr_for_overwrite              202002L
+// # define __cpp_lib_source_location                      201907L
+// # define __cpp_lib_span                                 202002L
+// # define __cpp_lib_ssize                                201902L
+// # define __cpp_lib_starts_ends_with                     201711L
+// # undef  __cpp_lib_string_view
+// # define __cpp_lib_string_view                          201803L
+// # define __cpp_lib_syncbuf                              201803L
+// # define __cpp_lib_three_way_comparison                 201907L
+// # define __cpp_lib_to_address                           201711L
+// # define __cpp_lib_to_array                             201907L
+// # define __cpp_lib_type_identity                        201806L
+// # define __cpp_lib_unwrap_ref                           201811L
+#endif // __cplusplus >= 202002L
+
+#if __cplusplus >= 202302L
+// # define __cpp_lib_adaptor_iterator_pair_constructor    202106L
+// # define __cpp_lib_allocate_at_least                    202302L
+// # define __cpp_lib_associative_heterogeneous_erasure    202110L
+// # define __cpp_lib_bind_back                            202202L
+// # define __cpp_lib_byteswap                             202110L
+// # define __cpp_lib_constexpr_bitset                     202207L
+// # define __cpp_lib_constexpr_charconv                   202207L
+// # define __cpp_lib_constexpr_cmath                      202202L
+// # undef  __cpp_lib_constexpr_memory
+// # define __cpp_lib_constexpr_memory                     202202L
+// # define __cpp_lib_constexpr_typeinfo                   202106L
+// # define __cpp_lib_containers_ranges                    202202L
+// # define __cpp_lib_expected                             202211L
+// # define __cpp_lib_format_ranges                        202207L
+// # define __cpp_lib_formatters                           202302L
+// # define __cpp_lib_forward_like                         202207L
+// # define __cpp_lib_invoke_r                             202106L
+// # define __cpp_lib_ios_noreplace                        202207L
+// # define __cpp_lib_is_scoped_enum                       202011L
+// # define __cpp_lib_mdspan                               202207L
+// # define __cpp_lib_modules                              202207L
+// # define __cpp_lib_move_only_function                   202110L
+// # undef  __cpp_lib_optional
+// # define __cpp_lib_optional                             202110L
+// # define __cpp_lib_out_ptr                              202106L
+// # define __cpp_lib_print                                202207L
+// # undef  __cpp_lib_ranges
+// # define __cpp_lib_ranges                               202211L
+// # define __cpp_lib_ranges_as_const                      202207L
+// # define __cpp_lib_ranges_as_rvalue                     202207L
+// # define __cpp_lib_ranges_chunk                         202202L
+// # define __cpp_lib_ranges_chunk_by                      202202L
+// # define __cpp_lib_ranges_contains                      202207L
+// # define __cpp_lib_ranges_find_last                     202207L
+// # define __cpp_lib_ranges_iota                          202202L
+// # define __cpp_lib_ranges_join_with                     202202L
+// # define __cpp_lib_ranges_repeat                        202207L
+// # define __cpp_lib_ranges_slide                         202202L
+// # define __cpp_lib_ranges_starts_ends_with              202106L
+// # define __cpp_lib_ranges_to_container                  202202L
+// # define __cpp_lib_ranges_zip                           202110L
+// # define __cpp_lib_reference_from_temporary             202202L
+// # define __cpp_lib_spanstream                           202106L
+// # define __cpp_lib_stacktrace                           202011L
+// # define __cpp_lib_stdatomic_h                          202011L
+// # define __cpp_lib_string_contains                      202011L
+// # define __cpp_lib_string_resize_and_overwrite          202110L
+// # define __cpp_lib_to_underlying                        202102L
+// # define __cpp_lib_tuple_like                           202207L
+// # define __cpp_lib_unreachable                          202202L
+#endif // __cplusplus >= 202302L
+
+#endif // _EZCXX_VERSION

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -7,12 +7,12 @@
 #if __cplusplus >= 201402L
 // # define __cpp_lib_chrono_udls                          201304L
 // # define __cpp_lib_complex_udls                         201309L
-// # define __cpp_lib_exchange_function                    201304L
+# define __cpp_lib_exchange_function                    201304L
 // # define __cpp_lib_generic_associative_lookup           201304L
 // # define __cpp_lib_integer_sequence                     201304L
-// # define __cpp_lib_integral_constant_callable           201304L
+# define __cpp_lib_integral_constant_callable           201304L
 // # define __cpp_lib_is_final                             201402L
-// # define __cpp_lib_is_null_pointer                      201309L
+# define __cpp_lib_is_null_pointer                      201309L
 // # define __cpp_lib_make_reverse_iterator                201402L
 // # define __cpp_lib_make_unique                          201304L
 // # define __cpp_lib_null_iterators                       201304L
@@ -33,11 +33,11 @@
 // # define __cpp_lib_any                                  201606L
 // # define __cpp_lib_apply                                201603L
 // # define __cpp_lib_array_constexpr                      201603L
-// # define __cpp_lib_as_const                             201510L
+# define __cpp_lib_as_const                             201510L
 // # define __cpp_lib_atomic_is_always_lock_free           201603L
-// # define __cpp_lib_bool_constant                        201505L
+# define __cpp_lib_bool_constant                        201505L
 // # define __cpp_lib_boyer_moore_searcher                 201603L
-// # define __cpp_lib_byte                                 201603L
+# define __cpp_lib_byte                                 201603L
 // # define __cpp_lib_chrono                               201611L
 // # define __cpp_lib_clamp                                201603L
 // # define __cpp_lib_enable_shared_from_this              201603L
@@ -53,7 +53,7 @@
 // # define __cpp_lib_is_invocable                         201703L
 // # define __cpp_lib_is_swappable                         201603L
 // # define __cpp_lib_launder                              201606L
-// # define __cpp_lib_logical_traits                       201510L
+# define __cpp_lib_logical_traits                       201510L
 // # define __cpp_lib_make_from_tuple                      201606L
 // # define __cpp_lib_map_try_emplace                      201411L
 // # define __cpp_lib_math_special_functions               201603L
@@ -77,7 +77,7 @@
 // # define __cpp_lib_uncaught_exceptions                  201411L
 // # define __cpp_lib_unordered_map_try_emplace            201411L
 // # define __cpp_lib_variant                              202102L
-// # define __cpp_lib_void_t                               201411L
+# define __cpp_lib_void_t                               201411L
 #endif // __cplusplus >= 201703L
 
 #if __cplusplus >= 202002L
@@ -93,7 +93,7 @@
 // # define __cpp_lib_atomic_wait                          201907L
 // # define __cpp_lib_barrier                              201907L
 // # define __cpp_lib_bind_front                           201907L
-// # define __cpp_lib_bit_cast                             201806L
+# define __cpp_lib_bit_cast                             201806L
 // # define __cpp_lib_bitops                               201907L
 // # define __cpp_lib_bounded_array_traits                 201902L
 // # define __cpp_lib_char8_t                              201907L
@@ -114,7 +114,7 @@
 // # if defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L
 // #  define __cpp_lib_destroying_delete                   201806L
 // # endif
-// # define __cpp_lib_endian                               201907L
+# define __cpp_lib_endian                               201907L
 // # define __cpp_lib_erase_if                             202002L
 // # undef  __cpp_lib_execution
 // # define __cpp_lib_execution                            201902L
@@ -131,7 +131,7 @@
 // # define __cpp_lib_jthread                              201911L
 // # define __cpp_lib_latch                                201907L
 // # define __cpp_lib_list_remove_return_type              201806L
-// # define __cpp_lib_math_constants                       201907L
+# define __cpp_lib_math_constants                       201907L
 // # define __cpp_lib_move_iterator_concept                202207L
 // # define __cpp_lib_polymorphic_allocator                201902L
 // # define __cpp_lib_ranges                               202110L

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -11,7 +11,7 @@
 // # define __cpp_lib_generic_associative_lookup           201304L
 // # define __cpp_lib_integer_sequence                     201304L
 # define __cpp_lib_integral_constant_callable           201304L
-// # define __cpp_lib_is_final                             201402L
+# define __cpp_lib_is_final                             201402L
 # define __cpp_lib_is_null_pointer                      201309L
 // # define __cpp_lib_make_reverse_iterator                201402L
 // # define __cpp_lib_make_unique                          201304L
@@ -135,7 +135,7 @@
 // # define __cpp_lib_move_iterator_concept                202207L
 // # define __cpp_lib_polymorphic_allocator                201902L
 // # define __cpp_lib_ranges                               202110L
-// # define __cpp_lib_remove_cvref                         201711L
+# define __cpp_lib_remove_cvref                         201711L
 // # define __cpp_lib_semaphore                            201907L
 // # undef  __cpp_lib_shared_ptr_arrays
 // # define __cpp_lib_shared_ptr_arrays                    201707L
@@ -151,7 +151,7 @@
 // # define __cpp_lib_three_way_comparison                 201907L
 // # define __cpp_lib_to_address                           201711L
 // # define __cpp_lib_to_array                             201907L
-// # define __cpp_lib_type_identity                        201806L
+# define __cpp_lib_type_identity                        201806L
 // # define __cpp_lib_unwrap_ref                           201811L
 #endif // __cplusplus >= 202002L
 

--- a/src/libcxx/type_traits.cpp
+++ b/src/libcxx/type_traits.cpp
@@ -507,6 +507,41 @@ C((std::is_unsigned_v<  signed __int48> == false));
 C((std::is_unsigned_v<unsigned __int48> == true));
 C((std::is_unsigned_v<bool> == true));
 
+// test rank
+C((std::rank<int>{} == 0));
+C((std::rank<int[5]>{} == 1));
+C((std::rank<int[5][5]>{} == 2));
+C((std::rank<int[][5][5]>{} == 3));
+
+// test extent
+C((std::extent_v<int[3]> == 3));
+C((std::extent_v<int[3], 0> == 3));
+C((std::extent_v<int[3][4], 0> == 3));
+C((std::extent_v<int[3][4], 1> == 4));
+C((std::extent_v<int[3][4], 2> == 0));
+C((std::extent_v<int[]> == 0));
+
+// test remove_cvref
+C((std::is_same_v<std::remove_cvref_t<int>, int>));
+C((std::is_same_v<std::remove_cvref_t<int&>, int>));
+C((std::is_same_v<std::remove_cvref_t<int&&>, int>));
+C((std::is_same_v<std::remove_cvref_t<const int&>, int>));
+C((std::is_same_v<std::remove_cvref_t<const int[2]>, int[2]>));
+C((std::is_same_v<std::remove_cvref_t<const int(&)[2]>, int[2]>));
+C((std::is_same_v<std::remove_cvref_t<int(int)>, int(int)>));
+
+// test decay
+C(( std::is_same_v<std::decay_t<int       >, int        >));
+C((!std::is_same_v<std::decay_t<int       >, float      >));
+C(( std::is_same_v<std::decay_t<int&      >, int        >));
+C(( std::is_same_v<std::decay_t<int&&     >, int        >));
+C(( std::is_same_v<std::decay_t<const int&>, int        >));
+C(( std::is_same_v<std::decay_t<int[2]    >, int*       >));
+C((!std::is_same_v<std::decay_t<int[4][2] >, int*       >));
+C((!std::is_same_v<std::decay_t<int[4][2] >, int**      >));
+C(( std::is_same_v<std::decay_t<int[4][2] >, int(*)[2]  >));
+C(( std::is_same_v<std::decay_t<int(int)  >, int(*)(int)>));
+
 #undef C
 
 } // namespace


### PR DESCRIPTION
C++20 `<version>` provides macros to indicate which parts of libcxx are supported. For now, I have only defined the ones that should be fully supported
```
// c++14
__cpp_lib_exchange_function
__cpp_lib_integral_constant_callable
__cpp_lib_is_null_pointer
// c++17
__cpp_lib_as_const
__cpp_lib_bool_constant
__cpp_lib_logical_traits
__cpp_lib_void_t
// c++20
__cpp_lib_bit_cast
__cpp_lib_endian
__cpp_lib_math_constants
```
A few others are mostly complete such as `__cpp_lib_transformation_trait_aliases` and `__cpp_lib_is_swappable`