### PR TITLE
Added <algorithm> for max/min/clamp and fixed LLVM/Clang attributions

### DIFF
--- a/src/libcxx/include/__config
+++ b/src/libcxx/include/__config
@@ -5,5 +5,7 @@
 #pragma clang system_header
 
 #define _EZCXX_INLINE [[__gnu__::__visibility__("hidden"), __gnu__::__always_inline__]] inline
+#define _EZCXX_NODISCARD [[nodiscard]]
+#define _EZCXX_NODISCARD_EXT [[nodiscard]]
 
 #endif // _EZCXX_CONFIG

--- a/src/libcxx/include/algorithm
+++ b/src/libcxx/include/algorithm
@@ -1,0 +1,64 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _EZCXX_ALGORITHM
+#define _EZCXX_ALGORITHM
+
+#include <__config>
+
+// currently unused, but included in the standard
+#include <initializer_list>
+
+#pragma clang system_header
+
+// very limited implementation of <algorithm>
+// only supports std:max, std::min, and std::clamp
+// these functions can be replaced when <algorithm> is properly implemented
+
+namespace std {
+
+template <class _Tp, class _Compare> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& max(const _Tp& __a, const _Tp& __b, _Compare __comp)
+{
+    return __comp(__a, __b) ? __b : __a;
+}
+
+template <class _Tp> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& max(const _Tp& __a, const _Tp& __b)
+{
+    return (__a < __b) ? __b : __a;
+}
+
+template <class _Tp, class _Compare> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& min(const _Tp& __a, const _Tp& __b, _Compare __comp)
+{
+    return __comp(__a, __b) ? __a : __b;
+}
+
+template <class _Tp> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& min(const _Tp& __a, const _Tp& __b)
+{
+    return (__a < __b) ? __a : __b;
+}
+
+template <class _Tp, class _Compare> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi, _Compare __comp)
+{
+    return __comp(__v, __lo) ? __lo : __comp(__hi, __v) ? __hi : __v;
+}
+
+template <class _Tp> _EZCXX_NODISCARD_EXT inline constexpr
+const _Tp& clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi)
+{
+    return (__v < __lo) ? __lo : (__hi < __v) ? __hi : __v;
+}
+
+} // namespace std
+
+#endif // _EZCXX_ALGORITHM

--- a/src/libcxx/include/numbers
+++ b/src/libcxx/include/numbers
@@ -1,4 +1,12 @@
 // -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef _EZCXX_NUMBERS
 #define _EZCXX_NUMBERS
 

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -1,4 +1,12 @@
 // -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef _EZCXX_VERSION
 #define _EZCXX_VERSION
 
@@ -39,7 +47,7 @@
 // # define __cpp_lib_boyer_moore_searcher                 201603L
 # define __cpp_lib_byte                                 201603L
 // # define __cpp_lib_chrono                               201611L
-// # define __cpp_lib_clamp                                201603L
+# define __cpp_lib_clamp                                201603L
 // # define __cpp_lib_enable_shared_from_this              201603L
 // # define __cpp_lib_execution                            201603L
 // # define __cpp_lib_filesystem                           201703L


### PR DESCRIPTION
I've added `std::max std::min std::clamp` since they are commonly used C++ functions. Otherwise, the rest of `<algorithm>` can't be implemented since it would require `<iterators>` and a STL