### PR TITLE
expand <type_traits> and <concepts>

### DIFF
--- a/src/libcxx/header_test.cpp
+++ b/src/libcxx/header_test.cpp
@@ -1,4 +1,5 @@
 #include <__config>
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cctype>

--- a/src/libcxx/include/concepts
+++ b/src/libcxx/include/concepts
@@ -8,22 +8,48 @@
 
 namespace std {
 
-template <class _Tp, class _Up>
+template<class _Tp, class _Up>
 concept same_as = is_same<_Tp, _Up>::value && is_same<_Up, _Tp>::value;
 
-// arithmetic:
+template<class _From, class _To>
+concept convertible_to =
+    is_convertible_v<_From, _To> &&
+    requires { static_cast<_To>(std::declval<_From>()); };
 
-template <class _Tp>
+template <class _Dp, class _Bp>
+concept derived_from =
+    is_base_of_v<_Bp, _Dp> &&
+    is_convertible_v<const volatile _Dp*, const volatile _Bp*>;
+
+template<class _Tp>
+concept destructible = is_nothrow_destructible_v<_Tp>;
+
+template<class _Tp, class... _Args>
+concept constructible_from =
+    destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
+
+template<class _Tp>
 concept integral = is_integral_v<_Tp>;
 
-template <class _Tp>
+template<class _Tp>
 concept signed_integral = integral<_Tp> && is_signed_v<_Tp>;
 
-template <class _Tp>
+template<class _Tp>
 concept unsigned_integral = integral<_Tp> && !signed_integral<_Tp>;
 
-template <class _Tp>
+template<class _Tp>
 concept floating_point = is_floating_point_v<_Tp>;
+
+template<class _Tp>
+concept move_constructible =
+    constructible_from<_Tp, _Tp> && std::convertible_to<_Tp, _Tp>;
+
+template<class _Tp>
+concept copy_constructible =
+    move_constructible<_Tp> &&
+    constructible_from<_Tp, _Tp&> && convertible_to<_Tp&, _Tp> &&
+    constructible_from<_Tp, const _Tp&> && convertible_to<const _Tp&, _Tp> &&
+    constructible_from<_Tp, const _Tp> && convertible_to<const _Tp, _Tp>;
 
 } // namespace std
 

--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -38,9 +38,20 @@ template<class...> using void_t = void;
 
 template<class...> using __require = true_type;
 
+// type relationships:
 template<class, class> struct is_same           : false_type {};
 template<class _Tp>    struct is_same<_Tp, _Tp> : true_type  {};
 template<class _Lp, class _Rp> inline constexpr bool is_same_v = is_same<_Lp, _Rp>::value;
+
+#if __has_builtin(__is_base_of)
+template<class _Lp, class _Rp> inline constexpr bool is_base_of_v = __is_base_of(_Lp, _Rp);
+template<class _Lp, class _Rp> using is_base_of = bool_constant<is_base_of_v<_Lp, _Rp>>;
+#endif
+
+#if __has_builtin(__is_convertible)
+template<class _Lp, class _Rp> inline constexpr bool is_convertible_v = __is_convertible(_Lp, _Rp);
+template<class _Lp, class _Rp> using is_convertible = bool_constant<is_convertible_v<_Lp, _Rp>>;
+#endif
 
 // logical operator traits:
 template<class...>                struct conjunction              : true_type                                           {};
@@ -77,6 +88,23 @@ template<class>     struct is_volatile               : false_type {};
 template<class _Tp> struct is_volatile<_Tp volatile> : true_type  {};
 template<class _Tp> inline constexpr bool is_volatile_v = is_volatile<_Tp>::value;
 
+template<class>     struct is_lvalue_reference       : false_type {};
+template<class _Tp> struct is_lvalue_reference<_Tp&> : true_type  {};
+template<class _Tp> inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<_Tp>::value;
+
+template<class>     struct is_rvalue_reference        : false_type {};
+template<class _Tp> struct is_rvalue_reference<_Tp&&> : true_type  {};
+template<class _Tp> inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<_Tp>::value;
+
+template<class _Tp> using is_reference = disjunction<is_lvalue_reference<_Tp>, is_rvalue_reference<_Tp>>;
+template<class _Tp> inline constexpr bool is_reference_v = is_reference<_Tp>::value;
+
+template<class _Tp>            struct __member_pointer             : false_type {};
+template<class _Tp, class _Cp> struct __member_pointer<_Tp _Cp::*> : true_type  {};
+template<class _Tp> using is_member_pointer = __member_pointer<remove_cv_t<_Tp>>;
+template<class _Tp> inline constexpr bool is_member_pointer_v = is_member_pointer<_Tp>::value;
+
+// primary type categories:
 template<class _Tp> using is_void = is_same<remove_cv_t<_Tp>, void>;
 template<class _Tp> inline constexpr bool is_void_v = is_void<_Tp>::value;
 
@@ -114,107 +142,32 @@ template<>          struct __floating_point<long double> : true_type  {};
 template<class _Tp> using is_floating_point = __floating_point<remove_cv_t<_Tp>>;
 template<class _Tp> inline constexpr bool is_floating_point_v = is_floating_point<_Tp>::value;
 
-template<class _Tp> using is_arithmetic = disjunction<is_integral<_Tp>, is_floating_point<_Tp>>;
-template<class _Tp> inline constexpr bool is_arithmetic_v = is_arithmetic<_Tp>::value;
+#if __has_builtin(__is_array)
+template<class _Tp> inline constexpr bool is_array_v = __is_array(_Tp);
+template<class _Tp> using is_array = bool_constant<is_array_v<_Tp>>;
+#endif
 
-template<class _Tp> using is_fundamental = disjunction<is_void<_Tp>, is_null_pointer<_Tp>, is_arithmetic<_Tp>>;
-template<class _Tp> inline constexpr bool is_fundamental_v = is_fundamental<_Tp>::value;
-
-template<class _Tp> struct is_compound : std::integral_constant<bool, !std::is_fundamental<_Tp>::value> {};
-template<class _Tp> inline constexpr bool is_compound_v = is_compound<_Tp>::value;
-
-template<class _Tp, bool = is_arithmetic<_Tp>::value> struct __is_signed : integral_constant<bool, _Tp(-1) < _Tp(0)> {};
-template<class _Tp>                                   struct __is_signed<_Tp, false> : false_type {};
-template<class _Tp> struct is_signed : __is_signed<_Tp>::type {};
-template<class _Tp> constexpr bool is_signed_v = is_signed<_Tp>::value;
-
-template<class _Tp, bool = is_arithmetic<_Tp>::value> struct __is_unsigned : integral_constant<bool, _Tp(0) < _Tp(-1)> {};
-template<class _Tp>                                   struct __is_unsigned<_Tp, false> : false_type {};
-template<class _Tp> struct is_unsigned : __is_unsigned<_Tp>::type {};
-template<class _Tp> constexpr bool is_unsigned_v = is_unsigned<_Tp>::value;
-
-template<class>                 struct is_array           : false_type {};
-template<class _Tp>             struct is_array<_Tp[]>    : true_type  {};
-template<class _Tp, size_t _Np> struct is_array<_Tp[_Np]> : true_type  {};
-template<class _Tp> inline constexpr bool is_array_v = is_array<_Tp>::value;
-
-#if __has_feature(is_enum)
+#if __has_builtin(__is_enum)
 template<class _Tp> inline constexpr bool is_enum_v = __is_enum(_Tp);
 template<class _Tp> using is_enum = bool_constant<is_enum_v<_Tp>>;
 #endif
 
-#if __has_feature(is_union)
+#if __has_builtin(__is_union)
 template<class _Tp> inline constexpr bool is_union_v = __is_union(_Tp);
 template<class _Tp> using is_union = bool_constant<is_union_v<_Tp>>;
 #endif
 
-#if __has_feature(is_class)
+#if __has_builtin(__is_class)
 template<class _Tp> inline constexpr bool is_class_v = __is_class(_Tp);
 template<class _Tp> using is_class = bool_constant<is_class_v<_Tp>>;
 #endif
 
-#if __has_feature(is_trivial)
-template<class _Tp> inline constexpr bool is_trivial_v = __is_trivial(_Tp);
-template<class _Tp> using is_trivial = bool_constant<is_trivial_v<_Tp>>;
-#endif
-
-#if __has_feature(is_trivially_copyable)
-template<class _Tp> inline constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Tp);
-template<class _Tp> using is_trivially_copyable = bool_constant<is_trivially_copyable_v<_Tp>>;
-#endif
-
-#if __has_feature(is_standard_layout)
-template<class _Tp> inline constexpr bool is_standard_layout_v = __is_standard_layout(_Tp);
-template<class _Tp> using is_standard_layout = bool_constant<is_standard_layout_v<_Tp>>;
-#endif
-
-#if __has_feature(is_pod)
-template<class _Tp> inline constexpr bool is_pod_v = __is_pod(_Tp);
-template<class _Tp> using is_pod = bool_constant<is_pod_v<_Tp>>;
-#endif
-
-#if __has_feature(is_empty)
-template<class _Tp> inline constexpr bool is_empty_v = __is_empty(_Tp);
-template<class _Tp> using is_empty = bool_constant<is_empty_v<_Tp>>;
-#endif
-
-#if __has_feature(is_polymorphic)
-template<class _Tp> inline constexpr bool is_polymorphic_v = __is_polymorphic(_Tp);
-template<class _Tp> using is_polymorphic = bool_constant<is_polymorphic_v<_Tp>>;
-#endif
-
-#if __has_feature(is_abstract)
-template<class _Tp> inline constexpr bool is_abstract_v = __is_abstract(_Tp);
-template<class _Tp> using is_abstract = bool_constant<is_abstract_v<_Tp>>;
-#endif
-
-#if __has_feature(is_final)
-template<class _Tp> inline constexpr bool is_final_v = __is_final(_Tp);
-template<class _Tp> using is_final = bool_constant<is_final_v<_Tp>>;
-#endif
+template<class _Tp> using is_function = negation<disjunction<is_const<_Tp const>, is_reference<_Tp>>>;
+template<class _Tp> inline constexpr bool is_function_v = is_function<_Tp>::value;
 
 template<class>     struct is_pointer       : false_type {};
 template<class _Tp> struct is_pointer<_Tp*> : true_type  {};
 template<class _Tp> inline constexpr bool is_pointer_v = is_pointer<_Tp>::value;
-
-template<class>     struct is_lvalue_reference       : false_type {};
-template<class _Tp> struct is_lvalue_reference<_Tp&> : true_type  {};
-template<class _Tp> inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<_Tp>::value;
-
-template<class>     struct is_rvalue_reference        : false_type {};
-template<class _Tp> struct is_rvalue_reference<_Tp&&> : true_type  {};
-template<class _Tp> inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<_Tp>::value;
-
-template<class _Tp> using is_reference = disjunction<is_lvalue_reference<_Tp>, is_rvalue_reference<_Tp>>;
-template<class _Tp> inline constexpr bool is_reference_v = is_reference<_Tp>::value;
-
-template<class _Tp> using is_function = negation<disjunction<is_const<_Tp const>, is_reference<_Tp>>>;
-template<class _Tp> inline constexpr bool is_function_v = is_function<_Tp>::value;
-
-template<class _Tp>            struct __member_pointer             : false_type {};
-template<class _Tp, class _Cp> struct __member_pointer<_Tp _Cp::*> : true_type  {};
-template<class _Tp> using is_member_pointer = __member_pointer<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_member_pointer_v = is_member_pointer<_Tp>::value;
 
 template<class _Tp>            struct __member_function_pointer             : false_type       {};
 template<class _Tp, class _Cp> struct __member_function_pointer<_Tp _Cp::*> : is_function<_Tp> {};
@@ -225,6 +178,14 @@ template<class _Tp>            struct __member_object_pointer             : fals
 template<class _Tp, class _Cp> struct __member_object_pointer<_Tp _Cp::*> : negation<is_function<_Tp>> {};
 template<class _Tp> using is_member_object_pointer = __member_object_pointer<remove_cv_t<_Tp>>;
 template<class _Tp> inline constexpr bool is_member_object_pointer_v = is_member_object_pointer<_Tp>::value;
+
+// composite type categories:
+
+template<class _Tp> using is_arithmetic = disjunction<is_integral<_Tp>, is_floating_point<_Tp>>;
+template<class _Tp> inline constexpr bool is_arithmetic_v = is_arithmetic<_Tp>::value;
+
+template<class _Tp> using is_fundamental = disjunction<is_void<_Tp>, is_null_pointer<_Tp>, is_arithmetic<_Tp>>;
+template<class _Tp> inline constexpr bool is_fundamental_v = is_fundamental<_Tp>::value;
 
 template <class _Tp> struct is_scalar : public integral_constant<bool,
     is_arithmetic<_Tp>::value ||
@@ -242,6 +203,74 @@ template <class _Tp> struct is_object : integral_constant<bool,
     is_class<_Tp>::value
 > {};
 template <class _Tp> inline constexpr bool is_object_v = is_object<_Tp>::value;
+
+template<class _Tp> struct is_compound : std::integral_constant<bool, !std::is_fundamental<_Tp>::value> {};
+template<class _Tp> inline constexpr bool is_compound_v = is_compound<_Tp>::value;
+
+#if __has_builtin(__is_trivial)
+template<class _Tp> inline constexpr bool is_trivial_v = __is_trivial(_Tp);
+template<class _Tp> using is_trivial = bool_constant<is_trivial_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_trivially_copyable)
+template<class _Tp> inline constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Tp);
+template<class _Tp> using is_trivially_copyable = bool_constant<is_trivially_copyable_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_standard_layout)
+template<class _Tp> inline constexpr bool is_standard_layout_v = __is_standard_layout(_Tp);
+template<class _Tp> using is_standard_layout = bool_constant<is_standard_layout_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_pod)
+template<class _Tp> inline constexpr bool is_pod_v = __is_pod(_Tp);
+template<class _Tp> using is_pod = bool_constant<is_pod_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_literal_type)
+template<class _Tp> inline constexpr bool is_literal_type_v = __is_literal_type(_Tp);
+template<class _Tp> using is_literal_type = bool_constant<is_literal_type_v<_Tp>>;
+#endif
+
+#if __has_builtin(__has_unique_object_representations)
+template<class _Tp> inline constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Tp);
+template<class _Tp> using has_unique_object_representations = bool_constant<has_unique_object_representations_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_empty)
+template<class _Tp> inline constexpr bool is_empty_v = __is_empty(_Tp);
+template<class _Tp> using is_empty = bool_constant<is_empty_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_polymorphic)
+template<class _Tp> inline constexpr bool is_polymorphic_v = __is_polymorphic(_Tp);
+template<class _Tp> using is_polymorphic = bool_constant<is_polymorphic_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_abstract)
+template<class _Tp> inline constexpr bool is_abstract_v = __is_abstract(_Tp);
+template<class _Tp> using is_abstract = bool_constant<is_abstract_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_final)
+template<class _Tp> inline constexpr bool is_final_v = __is_final(_Tp);
+template<class _Tp> using is_final = bool_constant<is_final_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_aggregate)
+template<class _Tp> inline constexpr bool is_aggregate_v = __is_aggregate(_Tp);
+template<class _Tp> using is_aggregate = bool_constant<is_aggregate_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_signed)
+template<class _Tp> inline constexpr bool is_signed_v = __is_signed(_Tp);
+template<class _Tp> using is_signed = bool_constant<is_signed_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_unsigned)
+template<class _Tp> inline constexpr bool is_unsigned_v = __is_unsigned(_Tp);
+template<class _Tp> using is_unsigned = bool_constant<is_unsigned_v<_Tp>>;
+#endif
 
 // const/volatile addition traits:
 template<class _Tp> using add_const = conditional<disjunction_v<is_reference<_Tp>, is_function<_Tp>, is_const<_Tp>>,
@@ -341,6 +370,17 @@ public:
 };
 template <class _Tp> using decay_t = typename decay<_Tp>::type;
 
+// underlying_type:
+
+#if __has_builtin(__underlying_type)
+template<class _Tp, bool = is_enum<_Tp>::value> struct __underlying_type_impl;
+template<class _Tp> struct __underlying_type_impl<_Tp, false> {};
+template<class _Tp> struct __underlying_type_impl<_Tp, true> { typedef __underlying_type(_Tp) type; };
+
+template<class _Tp> struct underlying_type  : __underlying_type_impl<_Tp, is_enum<_Tp>::value> {};
+template<class _Tp> using underlying_type_t = typename underlying_type<_Tp>::type;
+#endif
+
 // <utility> functions:
 template<class _Tp> add_rvalue_reference_t<_Tp> declval() noexcept;
 
@@ -350,7 +390,7 @@ template<class, class...>         auto __constructible(...) -> false_type;
 template<class _Tp, class... _As> using is_constructible = decltype(__constructible<_Tp, _As...>(0));
 template<class _Tp, class... _As> inline constexpr bool is_constructible_v = is_constructible<_Tp, _As...>::value;
 
-#if __has_feature(is_trivially_constructible)
+#if __has_builtin(__is_trivially_constructible)
 template<class _Tp, class... _As> inline constexpr bool is_trivially_constructible_v = __is_trivially_constructible(_Tp, _As...);
 template<class _Tp, class... _As> using is_trivially_constructible = bool_constant<is_trivially_constructible_v<_Tp, _As...>>;
 #endif
@@ -392,6 +432,11 @@ template<class, class>         auto __assignable(...) -> false_type;
 template<class _Lp, class _Rp> using is_assignable = decltype(__assignable<_Lp, _Rp>(0));
 template<class _Lp, class _Rp> inline constexpr bool is_assignable_v = is_assignable<_Lp, _Rp>::value;
 
+#if __has_builtin(__is_trivially_assignable)
+template<class _Lp, class _Rp> inline constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_Lp, _Rp);
+template<class _Lp, class _Rp> using is_trivially_assignable = bool_constant<is_trivially_assignable_v<_Lp, _Rp>>;
+#endif
+
 template<class _Lp, class _Rp> auto __nt_assignable(int) -> enable_if_t<noexcept(declval<_Lp>() = declval<_Rp>()), true_type>;
 template<class, class>         auto __nt_assignable(...) -> false_type;
 template<class _Lp, class _Rp> using is_nothrow_assignable = decltype(__nt_assignable<_Lp, _Rp>(0));
@@ -399,6 +444,7 @@ template<class _Lp, class _Rp> inline constexpr bool is_nothrow_assignable_v = i
 
 template<class _Tp> using is_copy_assignable = is_assignable<add_lvalue_reference_t<_Tp>,
                                                              add_lvalue_reference_t<add_const_t<_Tp>>>;
+
 template<class _Tp> inline constexpr bool is_copy_assignable_v = is_copy_assignable<_Tp>::value;
 
 template<class _Tp> using is_nothrow_copy_assignable = is_nothrow_assignable<add_lvalue_reference_t<_Tp>,
@@ -413,7 +459,17 @@ template<class _Tp> using is_nothrow_move_assignable = is_nothrow_assignable<add
                                                                              add_rvalue_reference_t<_Tp>>;
 template<class _Tp> inline constexpr bool is_nothrow_move_assignable_v = is_nothrow_move_assignable<_Tp>::value;
 
-#if __has_feature(has_virtual_destructor)
+#if __has_builtin(__is_destructible)
+template<class _Tp> inline constexpr bool is_destructible_v = __is_destructible(_Tp);
+template<class _Tp> using is_destructible = bool_constant<is_destructible_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_trivially_destructible)
+template<class _Tp> inline constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Tp);
+template<class _Tp> using is_trivially_destructible = bool_constant<is_trivially_destructible_v<_Tp>>;
+#endif
+
+#if __has_builtin(__has_virtual_destructor)
 template<class _Tp> inline constexpr bool has_virtual_destructor_v = __has_virtual_destructor(_Tp);
 template<class _Tp> using has_virtual_destructor = bool_constant<has_virtual_destructor_v<_Tp>>;
 #endif

--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -79,68 +79,24 @@ template<class _Tp> using remove_volatile_t = typename remove_volatile<_Tp>::typ
 template<class _Tp> using remove_cv = remove_const<remove_volatile_t<_Tp>>;
 template<class _Tp> using remove_cv_t = typename remove_cv<_Tp>::type;
 
-// classification traits:
-template<class>     struct is_const            : false_type {};
-template<class _Tp> struct is_const<_Tp const> : true_type  {};
-template<class _Tp> inline constexpr bool is_const_v = is_const<_Tp>::value;
-
-template<class>     struct is_volatile               : false_type {};
-template<class _Tp> struct is_volatile<_Tp volatile> : true_type  {};
-template<class _Tp> inline constexpr bool is_volatile_v = is_volatile<_Tp>::value;
-
-template<class>     struct is_lvalue_reference       : false_type {};
-template<class _Tp> struct is_lvalue_reference<_Tp&> : true_type  {};
-template<class _Tp> inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<_Tp>::value;
-
-template<class>     struct is_rvalue_reference        : false_type {};
-template<class _Tp> struct is_rvalue_reference<_Tp&&> : true_type  {};
-template<class _Tp> inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<_Tp>::value;
-
-template<class _Tp> using is_reference = disjunction<is_lvalue_reference<_Tp>, is_rvalue_reference<_Tp>>;
-template<class _Tp> inline constexpr bool is_reference_v = is_reference<_Tp>::value;
-
-template<class _Tp>            struct __member_pointer             : false_type {};
-template<class _Tp, class _Cp> struct __member_pointer<_Tp _Cp::*> : true_type  {};
-template<class _Tp> using is_member_pointer = __member_pointer<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_member_pointer_v = is_member_pointer<_Tp>::value;
-
 // primary type categories:
-template<class _Tp> using is_void = is_same<remove_cv_t<_Tp>, void>;
-template<class _Tp> inline constexpr bool is_void_v = is_void<_Tp>::value;
+#if __has_builtin(__is_void)
+template<class _Tp> inline constexpr bool is_void_v = __is_void(_Tp);
+template<class _Tp> using is_void = bool_constant<is_void_v<_Tp>>;
+#endif
 
 template<class _Tp> using is_null_pointer = is_same<remove_cv_t<_Tp>, nullptr_t>;
 template<class _Tp> inline constexpr bool is_null_pointer_v = is_null_pointer<_Tp>::value;
 
-template<class _Tp> struct __integral                     : false_type {};
-template<>          struct __integral<              bool> : true_type  {};
-template<>          struct __integral<              char> : true_type  {};
-template<>          struct __integral<  signed      char> : true_type  {};
-template<>          struct __integral<unsigned      char> : true_type  {};
-template<>          struct __integral<           wchar_t> : true_type  {};
-#if __cplusplus >= 202002L
-template<>          struct __integral<           char8_t> : true_type  {};
+#if __has_builtin(__is_integral)
+template<class _Tp> inline constexpr bool is_integral_v = __is_integral(_Tp);
+template<class _Tp> using is_integral = bool_constant<is_integral_v<_Tp>>;
 #endif
-template<>          struct __integral<          char16_t> : true_type  {};
-template<>          struct __integral<          char32_t> : true_type  {};
-template<>          struct __integral<  signed     short> : true_type  {};
-template<>          struct __integral<unsigned     short> : true_type  {};
-template<>          struct __integral<  signed       int> : true_type  {};
-template<>          struct __integral<unsigned       int> : true_type  {};
-template<>          struct __integral<  signed      long> : true_type  {};
-template<>          struct __integral<unsigned      long> : true_type  {};
-template<>          struct __integral<  signed   __int48> : true_type  {};
-template<>          struct __integral<unsigned   __int48> : true_type  {};
-template<>          struct __integral<  signed long long> : true_type  {};
-template<>          struct __integral<unsigned long long> : true_type  {};
-template<class _Tp> using is_integral = __integral<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_integral_v = is_integral<_Tp>::value;
 
-template<class _Tp> struct __floating_point              : false_type {};
-template<>          struct __floating_point<      float> : true_type  {};
-template<>          struct __floating_point<     double> : true_type  {};
-template<>          struct __floating_point<long double> : true_type  {};
-template<class _Tp> using is_floating_point = __floating_point<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_floating_point_v = is_floating_point<_Tp>::value;
+#if __has_builtin(__is_floating_point)
+template<class _Tp> inline constexpr bool is_floating_point_v = __is_floating_point(_Tp);
+template<class _Tp> using is_floating_point = bool_constant<is_floating_point_v<_Tp>>;
+#endif
 
 #if __has_builtin(__is_array)
 template<class _Tp> inline constexpr bool is_array_v = __is_array(_Tp);
@@ -162,50 +118,82 @@ template<class _Tp> inline constexpr bool is_class_v = __is_class(_Tp);
 template<class _Tp> using is_class = bool_constant<is_class_v<_Tp>>;
 #endif
 
-template<class _Tp> using is_function = negation<disjunction<is_const<_Tp const>, is_reference<_Tp>>>;
-template<class _Tp> inline constexpr bool is_function_v = is_function<_Tp>::value;
+#if __has_builtin(__is_function)
+template<class _Tp> inline constexpr bool is_function_v = __is_function(_Tp);
+template<class _Tp> using is_function = bool_constant<is_function_v<_Tp>>;
+#endif
 
-template<class>     struct is_pointer       : false_type {};
-template<class _Tp> struct is_pointer<_Tp*> : true_type  {};
-template<class _Tp> inline constexpr bool is_pointer_v = is_pointer<_Tp>::value;
+#if __has_builtin(__is_pointer)
+template<class _Tp> inline constexpr bool is_pointer_v = __is_pointer(_Tp);
+template<class _Tp> using is_pointer = bool_constant<is_pointer_v<_Tp>>;
+#endif
 
-template<class _Tp>            struct __member_function_pointer             : false_type       {};
-template<class _Tp, class _Cp> struct __member_function_pointer<_Tp _Cp::*> : is_function<_Tp> {};
-template<class _Tp> using is_member_function_pointer = __member_function_pointer<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_member_function_pointer_v = is_member_function_pointer<_Tp>::value;
+#if __has_builtin(__is_lvalue_reference)
+template<class _Tp> inline constexpr bool is_lvalue_reference_v = __is_lvalue_reference(_Tp);
+template<class _Tp> using is_lvalue_reference = bool_constant<is_lvalue_reference_v<_Tp>>;
+#endif
 
-template<class _Tp>            struct __member_object_pointer             : false_type                 {};
-template<class _Tp, class _Cp> struct __member_object_pointer<_Tp _Cp::*> : negation<is_function<_Tp>> {};
-template<class _Tp> using is_member_object_pointer = __member_object_pointer<remove_cv_t<_Tp>>;
-template<class _Tp> inline constexpr bool is_member_object_pointer_v = is_member_object_pointer<_Tp>::value;
+#if __has_builtin(__is_rvalue_reference)
+template<class _Tp> inline constexpr bool is_rvalue_reference_v = __is_rvalue_reference(_Tp);
+template<class _Tp> using is_rvalue_reference = bool_constant<is_rvalue_reference_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_member_object_pointer)
+template<class _Tp> inline constexpr bool is_member_object_pointer_v = __is_member_object_pointer(_Tp);
+template<class _Tp> using is_member_object_pointer = bool_constant<is_member_object_pointer_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_member_function_pointer)
+template<class _Tp> inline constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Tp);
+template<class _Tp> using is_member_function_pointer = bool_constant<is_member_function_pointer_v<_Tp>>;
+#endif
 
 // composite type categories:
+#if __has_builtin(__is_fundamental)
+template<class _Tp> inline constexpr bool is_fundamental_v = __is_fundamental(_Tp);
+template<class _Tp> using is_fundamental = bool_constant<is_fundamental_v<_Tp>>;
+#endif
 
-template<class _Tp> using is_arithmetic = disjunction<is_integral<_Tp>, is_floating_point<_Tp>>;
-template<class _Tp> inline constexpr bool is_arithmetic_v = is_arithmetic<_Tp>::value;
+#if __has_builtin(__is_arithmetic)
+template<class _Tp> inline constexpr bool is_arithmetic_v = __is_arithmetic(_Tp);
+template<class _Tp> using is_arithmetic = bool_constant<is_arithmetic_v<_Tp>>;
+#endif
 
-template<class _Tp> using is_fundamental = disjunction<is_void<_Tp>, is_null_pointer<_Tp>, is_arithmetic<_Tp>>;
-template<class _Tp> inline constexpr bool is_fundamental_v = is_fundamental<_Tp>::value;
+#if __has_builtin(__is_scalar)
+template<class _Tp> inline constexpr bool is_scalar_v = __is_scalar(_Tp);
+template<class _Tp> using is_scalar = bool_constant<is_scalar_v<_Tp>>;
+#endif
 
-template <class _Tp> struct is_scalar : public integral_constant<bool,
-    is_arithmetic<_Tp>::value ||
-    is_member_pointer<_Tp>::value ||
-    is_pointer<_Tp>::value ||
-    is_null_pointer<_Tp>::value ||
-    is_enum<_Tp>::value
-> {};
-template <class _Tp> inline constexpr bool is_scalar_v = is_scalar<_Tp>::value;
+#if __has_builtin(__is_object)
+template<class _Tp> inline constexpr bool is_object_v = __is_object(_Tp);
+template<class _Tp> using is_object = bool_constant<is_object_v<_Tp>>;
+#endif
 
-template <class _Tp> struct is_object : integral_constant<bool,
-    is_scalar<_Tp>::value ||
-    is_array<_Tp>::value ||
-    is_union<_Tp>::value ||
-    is_class<_Tp>::value
-> {};
-template <class _Tp> inline constexpr bool is_object_v = is_object<_Tp>::value;
+#if __has_builtin(__is_compound)
+template<class _Tp> inline constexpr bool is_compound_v = __is_compound(_Tp);
+template<class _Tp> using is_compound = bool_constant<is_compound_v<_Tp>>;
+#endif
 
-template<class _Tp> struct is_compound : std::integral_constant<bool, !std::is_fundamental<_Tp>::value> {};
-template<class _Tp> inline constexpr bool is_compound_v = is_compound<_Tp>::value;
+#if __has_builtin(__is_reference)
+template<class _Tp> inline constexpr bool is_reference_v = __is_reference(_Tp);
+template<class _Tp> using is_reference = bool_constant<is_reference_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_member_pointer)
+template<class _Tp> inline constexpr bool is_member_pointer_v = __is_member_pointer(_Tp);
+template<class _Tp> using is_member_pointer = bool_constant<is_member_pointer_v<_Tp>>;
+#endif
+
+// type properties:
+#if __has_builtin(__is_const)
+template<class _Tp> inline constexpr bool is_const_v = __is_const(_Tp);
+template<class _Tp> using is_const = bool_constant<is_const_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_volatile)
+template<class _Tp> inline constexpr bool is_volatile_v = __is_volatile(_Tp);
+template<class _Tp> using is_volatile = bool_constant<is_volatile_v<_Tp>>;
+#endif
 
 #if __has_builtin(__is_trivial)
 template<class _Tp> inline constexpr bool is_trivial_v = __is_trivial(_Tp);
@@ -297,60 +285,60 @@ template<class _Tp> struct remove_reference<_Tp&>  : type_identity<_Tp> {};
 template<class _Tp> struct remove_reference<_Tp&&> : type_identity<_Tp> {};
 template<class _Tp> using remove_reference_t = typename remove_reference<_Tp>::type;
 
-template <class _Tp> using __remove_cvref_t = typename remove_cv<typename remove_reference<_Tp>::type>::type;
-template <class _Tp> struct remove_cvref { using type = __remove_cvref_t<_Tp>; };
-template <class _Tp> using remove_cvref_t = typename remove_cvref<_Tp>::type;
+template<class _Tp> using __remove_cvref_t = typename remove_cv<typename remove_reference<_Tp>::type>::type;
+template<class _Tp> struct remove_cvref { using type = __remove_cvref_t<_Tp>; };
+template<class _Tp> using remove_cvref_t = typename remove_cvref<_Tp>::type;
 
-template<class _Tp> auto __add_pointer(int) -> type_identity<_Tp*>;
-template<class _Tp> auto __add_pointer(...) -> type_identity<_Tp>;
-template<class _Tp> using add_pointer = decltype(__add_pointer<_Tp>(0));
+template<class _Tp> auto __ezcxx_add_pointer(int) -> type_identity<_Tp*>;
+template<class _Tp> auto __ezcxx_add_pointer(...) -> type_identity<_Tp>;
+template<class _Tp> using add_pointer = decltype(__ezcxx_add_pointer<_Tp>(0));
 template<class _Tp> using add_pointer_t = typename add_pointer<_Tp>::type;
 
-template<class _Tp> auto __add_lvalue_reference(int) -> type_identity<_Tp&>;
-template<class _Tp> auto __add_lvalue_reference(...) -> type_identity<_Tp>;
-template<class _Tp> using add_lvalue_reference = decltype(__add_lvalue_reference<_Tp>(0));
+template<class _Tp> auto __ezcxx_add_lvalue_reference(int) -> type_identity<_Tp&>;
+template<class _Tp> auto __ezcxx_add_lvalue_reference(...) -> type_identity<_Tp>;
+template<class _Tp> using add_lvalue_reference = decltype(__ezcxx_add_lvalue_reference<_Tp>(0));
 template<class _Tp> using add_lvalue_reference_t = typename add_lvalue_reference<_Tp>::type;
 
-template<class _Tp> auto __add_rvalue_reference(int) -> type_identity<_Tp&&>;
-template<class _Tp> auto __add_rvalue_reference(...) -> type_identity<_Tp>;
-template<class _Tp> using add_rvalue_reference = decltype(__add_rvalue_reference<_Tp>(0));
+template<class _Tp> auto __ezcxx_add_rvalue_reference(int) -> type_identity<_Tp&&>;
+template<class _Tp> auto __ezcxx_add_rvalue_reference(...) -> type_identity<_Tp>;
+template<class _Tp> using add_rvalue_reference = decltype(__ezcxx_add_rvalue_reference<_Tp>(0));
 template<class _Tp> using add_rvalue_reference_t = typename add_rvalue_reference<_Tp>::type;
 
 // alignment_of:
-template <class _Tp> struct alignment_of
+template<class _Tp> struct alignment_of
     : public integral_constant<size_t, alignof(_Tp)> {};
-template <class _Tp> inline constexpr size_t alignment_of_v = alignment_of<_Tp>::value;
+template<class _Tp> inline constexpr size_t alignment_of_v = alignment_of<_Tp>::value;
 
 // rank/extent:
-template <class _Tp> struct rank
+template<class _Tp> struct rank
     : public integral_constant<size_t, 0> {};
-template <class _Tp> struct rank<_Tp[]>
+template<class _Tp> struct rank<_Tp[]>
     : public integral_constant<size_t, rank<_Tp>::value + 1> {};
-template <class _Tp, size_t _Np> struct rank<_Tp[_Np]>
+template<class _Tp, size_t _Np> struct rank<_Tp[_Np]>
     : public integral_constant<size_t, rank<_Tp>::value + 1> {};
-template <class _Tp> inline constexpr size_t rank_v = rank<_Tp>::value;
+template<class _Tp> inline constexpr size_t rank_v = rank<_Tp>::value;
 
-template <class _Tp, unsigned _Ip = 0> struct extent
+template<class _Tp, unsigned _Ip = 0> struct extent
     : public integral_constant<size_t, 0> {};
-template <class _Tp> struct extent<_Tp[], 0>
+template<class _Tp> struct extent<_Tp[], 0>
     : public integral_constant<size_t, 0> {};
-template <class _Tp, unsigned _Ip> struct extent<_Tp[], _Ip>
+template<class _Tp, unsigned _Ip> struct extent<_Tp[], _Ip>
     : public integral_constant<size_t, extent<_Tp, _Ip-1>::value> {};
-template <class _Tp, size_t _Np> struct extent<_Tp[_Np], 0>
+template<class _Tp, size_t _Np> struct extent<_Tp[_Np], 0>
     : public integral_constant<size_t, _Np> {};
-template <class _Tp, size_t _Np, unsigned _Ip> struct extent<_Tp[_Np], _Ip>
+template<class _Tp, size_t _Np, unsigned _Ip> struct extent<_Tp[_Np], _Ip>
     : public integral_constant<size_t, extent<_Tp, _Ip-1>::value> {};
-template <class _Tp, unsigned _Ip = 0> inline constexpr size_t extent_v = extent<_Tp, _Ip>::value;
+template<class _Tp, unsigned _Ip = 0> inline constexpr size_t extent_v = extent<_Tp, _Ip>::value;
 
 template<class _Tp> struct remove_extent { typedef _Tp type; };
 template<class _Tp> struct remove_extent<_Tp[]> { typedef _Tp type; };
 template<class _Tp, size_t _Np> struct remove_extent<_Tp[_Np]> { typedef _Tp type; };
-template <class _Tp> using remove_extent_t = typename remove_extent<_Tp>::type;
+template<class _Tp> using remove_extent_t = typename remove_extent<_Tp>::type;
 
-template <class _Tp> struct remove_all_extents { typedef _Tp type; };
-template <class _Tp> struct remove_all_extents<_Tp[]> { typedef typename remove_all_extents<_Tp>::type type; };
-template <class _Tp, size_t _Np> struct remove_all_extents<_Tp[_Np]> { typedef typename remove_all_extents<_Tp>::type type; };
-template <class _Tp> using remove_all_extents_t = typename remove_all_extents<_Tp>::type;
+template<class _Tp> struct remove_all_extents { typedef _Tp type; };
+template<class _Tp> struct remove_all_extents<_Tp[]> { typedef typename remove_all_extents<_Tp>::type type; };
+template<class _Tp, size_t _Np> struct remove_all_extents<_Tp[_Np]> { typedef typename remove_all_extents<_Tp>::type type; };
+template<class _Tp> using remove_all_extents_t = typename remove_all_extents<_Tp>::type;
 
 // decay:
 template<class _Tp>
@@ -368,7 +356,7 @@ public:
         >::type
     >::type type;
 };
-template <class _Tp> using decay_t = typename decay<_Tp>::type;
+template<class _Tp> using decay_t = typename decay<_Tp>::type;
 
 // underlying_type:
 
@@ -467,6 +455,11 @@ template<class _Tp> using is_destructible = bool_constant<is_destructible_v<_Tp>
 #if __has_builtin(__is_trivially_destructible)
 template<class _Tp> inline constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Tp);
 template<class _Tp> using is_trivially_destructible = bool_constant<is_trivially_destructible_v<_Tp>>;
+#endif
+
+#if __has_builtin(__is_nothrow_destructible)
+template<class _Tp> inline constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Tp);
+template<class _Tp> using is_nothrow_destructible = bool_constant<is_nothrow_destructible_v<_Tp>>;
 #endif
 
 #if __has_builtin(__has_virtual_destructor)

--- a/src/libcxx/include/type_traits
+++ b/src/libcxx/include/type_traits
@@ -447,9 +447,17 @@ template<class _Tp> using is_nothrow_move_assignable = is_nothrow_assignable<add
                                                                              add_rvalue_reference_t<_Tp>>;
 template<class _Tp> inline constexpr bool is_nothrow_move_assignable_v = is_nothrow_move_assignable<_Tp>::value;
 
+/* Clang 16.0.0 required */
+#if 0
 #if __has_builtin(__is_destructible)
 template<class _Tp> inline constexpr bool is_destructible_v = __is_destructible(_Tp);
 template<class _Tp> using is_destructible = bool_constant<is_destructible_v<_Tp>>;
+#endif
+#elif __cplusplus >= 201907L
+template<typename _Tp> struct is_destructible
+    : std::integral_constant<bool, requires(_Tp _Object) { _Object.~_Tp(); }>
+{};
+template<class _Tp> inline constexpr bool is_destructible_v = is_destructible<_Tp>::value;
 #endif
 
 #if __has_builtin(__is_trivially_destructible)
@@ -457,9 +465,17 @@ template<class _Tp> inline constexpr bool is_trivially_destructible_v = __is_tri
 template<class _Tp> using is_trivially_destructible = bool_constant<is_trivially_destructible_v<_Tp>>;
 #endif
 
+/* Clang 16.0.0 required */
+#if 0
 #if __has_builtin(__is_nothrow_destructible)
 template<class _Tp> inline constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Tp);
 template<class _Tp> using is_nothrow_destructible = bool_constant<is_nothrow_destructible_v<_Tp>>;
+#endif
+#elif __cplusplus >= 201907L
+template<typename _Tp> struct is_nothrow_destructible
+    : std::integral_constant<bool, requires(_Tp _Object) { {_Object.~_Tp()} noexcept; }>
+{};
+template<class _Tp> inline constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<_Tp>::value;
 #endif
 
 #if __has_builtin(__has_virtual_destructor)

--- a/src/libcxx/include/utility
+++ b/src/libcxx/include/utility
@@ -33,6 +33,8 @@ template<class _Tp> _EZCXX_INLINE constexpr std::add_const_t<_Tp>& as_const(_Tp&
 template<class _Tp> _EZCXX_INLINE constexpr auto as_const(_Tp const&& __value) noexcept = delete;
 #endif // __cplusplus > 201103L
 
+[[noreturn]] inline void unreachable() { __builtin_unreachable(); }
+
 } // namespace std
 
 #endif // _EZCXX_UTILITY

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -53,11 +53,11 @@
 // # define __cpp_lib_filesystem                           201703L
 // # define __cpp_lib_gcd_lcm                              201606L
 // # define __cpp_lib_hardware_interference_size           201703L
-// # define __cpp_lib_has_unique_object_representations    201606L
+# define __cpp_lib_has_unique_object_representations    201606L
 # define __cpp_lib_hypot                                201603L
 // # define __cpp_lib_incomplete_container_elements        201505L
 // # define __cpp_lib_invoke                               201411L
-// # define __cpp_lib_is_aggregate                         201703L
+# define __cpp_lib_is_aggregate                         201703L
 // # define __cpp_lib_is_invocable                         201703L
 // # define __cpp_lib_is_swappable                         201603L
 // # define __cpp_lib_launder                              201606L

--- a/src/libcxx/include/version
+++ b/src/libcxx/include/version
@@ -213,7 +213,7 @@
 // # define __cpp_lib_string_resize_and_overwrite          202110L
 // # define __cpp_lib_to_underlying                        202102L
 // # define __cpp_lib_tuple_like                           202207L
-// # define __cpp_lib_unreachable                          202202L
+# define __cpp_lib_unreachable                          202202L
 #endif // __cplusplus >= 202302L
 
 #endif // _EZCXX_VERSION

--- a/src/libcxx/type_traits.cpp
+++ b/src/libcxx/type_traits.cpp
@@ -28,10 +28,24 @@ const auto test_lambda = [](){};
 template<class T> void test_type_identity(integral_constant<T, 0>, type_identity_t<T>);
 C((is_void_v<decltype(test_type_identity(bool_constant<false>{}, 0))>));
 
+//------------------------------------------------------------------------------
+// type relationships
+//------------------------------------------------------------------------------
+
 // test is_same
 C((is_same_v<void, void>));
 C((!is_same<void, void const>::value));
 C((!is_same_v<void const, void() const>));
+
+// test is_base_of
+/** @todo */
+
+// test is_convertible
+/** @todo */
+
+//------------------------------------------------------------------------------
+// logical operator traits
+//------------------------------------------------------------------------------
 
 // test conjunction
 C((conjunction_v<>));
@@ -67,6 +81,10 @@ C((disjunction<test_true, false_type, true_type>::test));
 C((disjunction<test_true, true_type, false_type>::test));
 C((disjunction<test_true, true_type, true_type>::test));
 
+//------------------------------------------------------------------------------
+// const/volatile removal traits
+//------------------------------------------------------------------------------
+
 // test negation
 C((negation_v<false_type>));
 C((!negation<true_type>::value));
@@ -88,19 +106,9 @@ C((is_same_v<void, remove_cv_t<void volatile>>));
 C((is_same_v<void, remove_cv<void const volatile>::type>));
 C((is_same_v<void() const volatile, remove_cv_t<void() const volatile>>));
 
-// test is_const
-C((is_const_v<void const>));
-C((is_const<void* const>::value));
-C((!is_const_v<void>));
-C((!is_const<void volatile>::value));
-C((!is_const_v<void() const>));
-
-// test is_volatile
-C((is_volatile_v<void volatile>));
-C((is_volatile<void* volatile>::value));
-C((!is_volatile_v<void>));
-C((!is_volatile<void const>::value));
-C((!is_volatile_v<void() volatile>));
+//------------------------------------------------------------------------------
+// primary type categories
+//------------------------------------------------------------------------------
 
 // test is_void
 C((is_void_v<void>));
@@ -142,26 +150,6 @@ C((!is_floating_point_v<int>));
 C((!is_floating_point<true_type>::value));
 C((!is_floating_point_v<float() const>));
 
-// test is_arithmetic
-C((is_arithmetic_v<bool>));
-C((is_arithmetic<int const>::value));
-C((is_arithmetic_v<float volatile>));
-C((is_arithmetic<double const volatile>::value));
-C((!is_arithmetic_v<void>));
-C((!is_arithmetic<nullptr_t>::value));
-C((!is_arithmetic_v<integral_constant<int, 0>>));
-C((!is_arithmetic<double() const>::value));
-
-// test is_fundamental
-C((is_fundamental_v<void>));
-C((is_fundamental<nullptr_t>::value));
-C((is_fundamental_v<bool>));
-C((is_fundamental<int const>::value));
-C((is_fundamental_v<float volatile>));
-C((is_fundamental<double const volatile>::value));
-C((!is_fundamental_v<integral_constant<int, 0>>));
-C((!is_fundamental<double() const>::value));
-
 // test is_enum
 C((is_enum_v<test_enum>));
 C((!is_enum<test_union>::value));
@@ -188,6 +176,23 @@ C((!is_class<void>::value));
 C((!is_class_v<nullptr_t>));
 C((!is_class<int>::value));
 C((!is_class_v<float>));
+
+// test is_function
+C((is_function_v<int(int)>));
+C((is_function<int(int, const char *, ...) const>::value));
+C((is_function_v<int(int) volatile &>));
+C((is_function<int(int) const volatile && noexcept>::value));
+C((!is_function_v<int>));
+C((!is_function<test_class>::value));
+C((!is_function_v<decltype(test_lambda)>));
+C((!is_function<int(*)(int)>::value));
+C((!is_function_v<int(&)(int) noexcept>));
+C((!is_function<void* test_class::*>::value));
+C((!is_function_v<void* test_class::*&>));
+C((!is_function<void* test_class::*&&>::value));
+C((!is_function_v<void(test_class::*)()>));
+C((!is_function<void(test_class::*&)()>::value));
+C((!is_function_v<void(test_class::*&&)()>));
 
 // test is_pointer
 C((is_pointer_v<void*>));
@@ -251,6 +256,59 @@ C((!is_rvalue_reference_v<void* test_class::*&>));
 C((!is_rvalue_reference<void(test_class::*)()>::value));
 C((!is_rvalue_reference_v<void(test_class::*&)()>));
 
+// test is_member_object_pointer
+C((is_member_object_pointer_v<int test_class::*>));
+C((!is_member_object_pointer<void*>::value));
+C((!is_member_object_pointer_v<nullptr_t>));
+C((!is_member_object_pointer<void(int)>::value));
+C((!is_member_object_pointer_v<void(*)(int)>));
+C((!is_member_object_pointer<int test_class::*()>::value));
+C((!is_member_object_pointer_v<int test_class::*&>));
+C((!is_member_object_pointer<int(test_class::*&)()>::value));
+
+// test is_member_function_pointer
+C((is_member_function_pointer_v<int(test_class::*)()>));
+C((!is_member_function_pointer<void*>::value));
+C((!is_member_function_pointer_v<nullptr_t>));
+C((!is_member_function_pointer<void(int)>::value));
+C((!is_member_function_pointer_v<void(*)(int)>));
+C((!is_member_function_pointer<int test_class::*>::value));
+C((!is_member_function_pointer_v<int test_class::*&>));
+C((!is_member_function_pointer<int(test_class::*&)()>::value));
+
+//------------------------------------------------------------------------------
+// composite type categories
+//------------------------------------------------------------------------------
+
+// test is_fundamental
+C((is_fundamental_v<void>));
+C((is_fundamental<nullptr_t>::value));
+C((is_fundamental_v<bool>));
+C((is_fundamental<int const>::value));
+C((is_fundamental_v<float volatile>));
+C((is_fundamental<double const volatile>::value));
+C((!is_fundamental_v<integral_constant<int, 0>>));
+C((!is_fundamental<double() const>::value));
+
+// test is_arithmetic
+C((is_arithmetic_v<bool>));
+C((is_arithmetic<int const>::value));
+C((is_arithmetic_v<float volatile>));
+C((is_arithmetic<double const volatile>::value));
+C((!is_arithmetic_v<void>));
+C((!is_arithmetic<nullptr_t>::value));
+C((!is_arithmetic_v<integral_constant<int, 0>>));
+C((!is_arithmetic<double() const>::value));
+
+// test is_scalar
+/** @todo */
+
+// test is_object
+/** @todo */
+
+// test is_compound
+/** @todo */
+
 // test is_reference
 C((is_reference_v<void*&>));
 C((is_reference<void*&&>::value));
@@ -275,23 +333,6 @@ C((!is_reference<void()>::value));
 C((!is_reference_v<void* test_class::*>));
 C((!is_reference<void(test_class::*)()>::value));
 
-// test is_function
-C((is_function_v<int(int)>));
-C((is_function<int(int, const char *, ...) const>::value));
-C((is_function_v<int(int) volatile &>));
-C((is_function<int(int) const volatile && noexcept>::value));
-C((!is_function_v<int>));
-C((!is_function<test_class>::value));
-C((!is_function_v<decltype(test_lambda)>));
-C((!is_function<int(*)(int)>::value));
-C((!is_function_v<int(&)(int) noexcept>));
-C((!is_function<void* test_class::*>::value));
-C((!is_function_v<void* test_class::*&>));
-C((!is_function<void* test_class::*&&>::value));
-C((!is_function_v<void(test_class::*)()>));
-C((!is_function<void(test_class::*&)()>::value));
-C((!is_function_v<void(test_class::*&&)()>));
-
 // test is_member_pointer
 C((is_member_pointer_v<int test_class::*>));
 C((is_member_pointer<int(test_class::*)()>::value));
@@ -302,25 +343,86 @@ C((!is_member_pointer<void(*)(int)>::value));
 C((!is_member_pointer_v<int test_class::*&>));
 C((!is_member_pointer<int(test_class::*&)()>::value));
 
-// test is_member_function_pointer
-C((is_member_function_pointer_v<int(test_class::*)()>));
-C((!is_member_function_pointer<void*>::value));
-C((!is_member_function_pointer_v<nullptr_t>));
-C((!is_member_function_pointer<void(int)>::value));
-C((!is_member_function_pointer_v<void(*)(int)>));
-C((!is_member_function_pointer<int test_class::*>::value));
-C((!is_member_function_pointer_v<int test_class::*&>));
-C((!is_member_function_pointer<int(test_class::*&)()>::value));
+//------------------------------------------------------------------------------
+// type properties
+//------------------------------------------------------------------------------
 
-// test is_member_object_pointer
-C((is_member_object_pointer_v<int test_class::*>));
-C((!is_member_object_pointer<void*>::value));
-C((!is_member_object_pointer_v<nullptr_t>));
-C((!is_member_object_pointer<void(int)>::value));
-C((!is_member_object_pointer_v<void(*)(int)>));
-C((!is_member_object_pointer<int test_class::*()>::value));
-C((!is_member_object_pointer_v<int test_class::*&>));
-C((!is_member_object_pointer<int(test_class::*&)()>::value));
+// test is_const
+C((is_const_v<void const>));
+C((is_const<void* const>::value));
+C((!is_const_v<void>));
+C((!is_const<void volatile>::value));
+C((!is_const_v<void() const>));
+
+// test is_volatile
+C((is_volatile_v<void volatile>));
+C((is_volatile<void* volatile>::value));
+C((!is_volatile_v<void>));
+C((!is_volatile<void const>::value));
+C((!is_volatile_v<void() volatile>));
+
+// test is_trivial
+/** @todo */
+
+// test is_trivially_copyable
+/** @todo */
+
+// test is_standard_layout
+/** @todo */
+
+// test is_pod
+/** @todo */
+
+// test is_literal_type
+/** @todo */
+
+// test has_unique_object_representations
+/** @todo */
+
+// test is_empty
+/** @todo */
+
+// test is_polymorphic
+/** @todo */
+
+// test is_abstract
+/** @todo */
+
+// test is_final
+/** @todo */
+
+// test is_aggregate
+/** @todo */
+
+// test is_signed
+C((std::is_signed_v<void> == false));
+C((std::is_signed_v<void*> == false));
+C((std::is_signed_v<int> == true));
+C((std::is_signed_v<int*> == false));
+C((std::is_signed_v<unsigned int> == false));
+C((std::is_signed_v<unsigned int*> == false));
+C((std::is_signed_v<float> == true));
+C((std::is_signed_v<double> == true));
+C((std::is_signed_v<  signed __int48> == true));
+C((std::is_signed_v<unsigned __int48> == false));
+C((std::is_signed_v<bool> == false));
+
+// test is_unsigned
+C((std::is_unsigned_v<void> == false));
+C((std::is_unsigned_v<void*> == false));
+C((std::is_unsigned_v<int> == false));
+C((std::is_unsigned_v<int*> == false));
+C((std::is_unsigned_v<unsigned int> == true));
+C((std::is_unsigned_v<unsigned int*> == false));
+C((std::is_unsigned_v<float> == false));
+C((std::is_unsigned_v<double> == false));
+C((std::is_unsigned_v<  signed __int48> == false));
+C((std::is_unsigned_v<unsigned __int48> == true));
+C((std::is_unsigned_v<bool> == true));
+
+//------------------------------------------------------------------------------
+// const/volatile addition traits
+//------------------------------------------------------------------------------
 
 // test add_const
 C((is_same_v<void const, add_const_t<void>>));
@@ -338,6 +440,10 @@ C((is_same_v<void const volatile, add_cv<void const>::type>));
 C((is_same_v<void const volatile, add_cv_t<void volatile>>));
 C((is_same_v<void const volatile, add_cv<void const volatile>::type>));
 C((is_same_v<void() const volatile, add_cv_t<void() const volatile>>));
+
+//------------------------------------------------------------------------------
+// reference/pointer transformation traits
+//------------------------------------------------------------------------------
 
 // test remove_pointer
 C((is_same_v<int const, remove_pointer_t<int const>>));
@@ -360,6 +466,15 @@ C((is_same_v<void*, remove_reference_t<void*>>));
 C((is_same_v<void**, remove_reference<void**>::type>));
 C((is_same_v<void(*)(), remove_reference_t<void(*)()>>));
 C((is_same_v<void(**)(), remove_reference<void(**)()>::type>));
+
+// test remove_cvref
+C((std::is_same_v<std::remove_cvref_t<int>, int>));
+C((std::is_same_v<std::remove_cvref_t<int&>, int>));
+C((std::is_same_v<std::remove_cvref_t<int&&>, int>));
+C((std::is_same_v<std::remove_cvref_t<const int&>, int>));
+C((std::is_same_v<std::remove_cvref_t<const int[2]>, int[2]>));
+C((std::is_same_v<std::remove_cvref_t<const int(&)[2]>, int[2]>));
+C((std::is_same_v<std::remove_cvref_t<int(int)>, int(int)>));
 
 // test add_pointer
 C((is_same_v<int const*, add_pointer_t<int const>>));
@@ -394,6 +509,64 @@ C((is_same_v<void*&, add_rvalue_reference_t<void*&>>));
 C((is_same_v<void(*&)(), add_rvalue_reference<void(*&)()>::type>));
 C((is_same_v<void*&&, add_rvalue_reference_t<void*&&>>));
 C((is_same_v<void(*&&)(), add_rvalue_reference<void(*&&)()>::type>));
+
+//------------------------------------------------------------------------------
+// alignment_of 
+//------------------------------------------------------------------------------
+
+// test alignment_of
+/** @todo */
+
+//------------------------------------------------------------------------------
+// rank/extent
+//------------------------------------------------------------------------------
+
+// test rank
+C((std::rank<int>{} == 0));
+C((std::rank<int[5]>{} == 1));
+C((std::rank<int[5][5]>{} == 2));
+C((std::rank<int[][5][5]>{} == 3));
+
+// test extent
+C((std::extent_v<int[3]> == 3));
+C((std::extent_v<int[3], 0> == 3));
+C((std::extent_v<int[3][4], 0> == 3));
+C((std::extent_v<int[3][4], 1> == 4));
+C((std::extent_v<int[3][4], 2> == 0));
+C((std::extent_v<int[]> == 0));
+
+// test remove_extent
+/** @todo */
+
+// test remove_all_extents
+/** @todo */
+
+//------------------------------------------------------------------------------
+// decay
+//------------------------------------------------------------------------------
+
+// test decay
+C(( std::is_same_v<std::decay_t<int       >, int        >));
+C((!std::is_same_v<std::decay_t<int       >, float      >));
+C(( std::is_same_v<std::decay_t<int&      >, int        >));
+C(( std::is_same_v<std::decay_t<int&&     >, int        >));
+C(( std::is_same_v<std::decay_t<const int&>, int        >));
+C(( std::is_same_v<std::decay_t<int[2]    >, int*       >));
+C((!std::is_same_v<std::decay_t<int[4][2] >, int*       >));
+C((!std::is_same_v<std::decay_t<int[4][2] >, int**      >));
+C(( std::is_same_v<std::decay_t<int[4][2] >, int(*)[2]  >));
+C(( std::is_same_v<std::decay_t<int(int)  >, int(*)(int)>));
+
+//------------------------------------------------------------------------------
+// underlying_type
+//------------------------------------------------------------------------------
+
+// test underlying_type
+/** @todo */
+
+//------------------------------------------------------------------------------
+// member classification traits
+//------------------------------------------------------------------------------
 
 // test is_constructible
 C((is_constructible_v<int>));
@@ -481,66 +654,60 @@ C((is_nothrow_move_constructible<test_class>::value));
 C((is_nothrow_move_constructible_v<test_union>));
 C((!is_nothrow_move_constructible<int()>::value));
 
-// test is_signed
-C((std::is_signed_v<void> == false));
-C((std::is_signed_v<void*> == false));
-C((std::is_signed_v<int> == true));
-C((std::is_signed_v<int*> == false));
-C((std::is_signed_v<unsigned int> == false));
-C((std::is_signed_v<unsigned int*> == false));
-C((std::is_signed_v<float> == true));
-C((std::is_signed_v<double> == true));
-C((std::is_signed_v<  signed __int48> == true));
-C((std::is_signed_v<unsigned __int48> == false));
-C((std::is_signed_v<bool> == false));
+// test is_assignable
+/** @todo */
 
-// test is_unsigned
-C((std::is_unsigned_v<void> == false));
-C((std::is_unsigned_v<void*> == false));
-C((std::is_unsigned_v<int> == false));
-C((std::is_unsigned_v<int*> == false));
-C((std::is_unsigned_v<unsigned int> == true));
-C((std::is_unsigned_v<unsigned int*> == false));
-C((std::is_unsigned_v<float> == false));
-C((std::is_unsigned_v<double> == false));
-C((std::is_unsigned_v<  signed __int48> == false));
-C((std::is_unsigned_v<unsigned __int48> == true));
-C((std::is_unsigned_v<bool> == true));
+// test is_trivially_assignable
+/** @todo */
 
-// test rank
-C((std::rank<int>{} == 0));
-C((std::rank<int[5]>{} == 1));
-C((std::rank<int[5][5]>{} == 2));
-C((std::rank<int[][5][5]>{} == 3));
+// test is_nothrow_assignable
+/** @todo */
 
-// test extent
-C((std::extent_v<int[3]> == 3));
-C((std::extent_v<int[3], 0> == 3));
-C((std::extent_v<int[3][4], 0> == 3));
-C((std::extent_v<int[3][4], 1> == 4));
-C((std::extent_v<int[3][4], 2> == 0));
-C((std::extent_v<int[]> == 0));
+// test is_copy_assignable
+/** @todo */
 
-// test remove_cvref
-C((std::is_same_v<std::remove_cvref_t<int>, int>));
-C((std::is_same_v<std::remove_cvref_t<int&>, int>));
-C((std::is_same_v<std::remove_cvref_t<int&&>, int>));
-C((std::is_same_v<std::remove_cvref_t<const int&>, int>));
-C((std::is_same_v<std::remove_cvref_t<const int[2]>, int[2]>));
-C((std::is_same_v<std::remove_cvref_t<const int(&)[2]>, int[2]>));
-C((std::is_same_v<std::remove_cvref_t<int(int)>, int(int)>));
+// test is_nothrow_copy_assignable
+/** @todo */
 
-// test decay
-C(( std::is_same_v<std::decay_t<int       >, int        >));
-C((!std::is_same_v<std::decay_t<int       >, float      >));
-C(( std::is_same_v<std::decay_t<int&      >, int        >));
-C(( std::is_same_v<std::decay_t<int&&     >, int        >));
-C(( std::is_same_v<std::decay_t<const int&>, int        >));
-C(( std::is_same_v<std::decay_t<int[2]    >, int*       >));
-C((!std::is_same_v<std::decay_t<int[4][2] >, int*       >));
-C((!std::is_same_v<std::decay_t<int[4][2] >, int**      >));
-C(( std::is_same_v<std::decay_t<int[4][2] >, int(*)[2]  >));
-C(( std::is_same_v<std::decay_t<int(int)  >, int(*)(int)>));
+// test is_move_assignable
+/** @todo */
+
+// test is_nothrow_move_assignable
+/** @todo */
+
+/* Clang 16.0.0 required */
+#if 0
+// test is_destructible
+/** @todo */
+#endif
+
+// test is_trivially_destructible
+/** @todo */
+
+/* Clang 16.0.0 required */
+#if 0
+// test is_nothrow_destructible
+/** @todo */
+#endif
+
+// test has_virtual_destructor
+/** @todo */
+
+//------------------------------------------------------------------------------
+// swappable classification traits
+//------------------------------------------------------------------------------
+
+// test is_swappable_with
+/** @todo */
+
+// test is_swappable
+/** @todo */
+
+// test is_nothrow_swappable_with
+/** @todo */
+
+// test is_nothrow_swappable
+/** @todo */
 
 #undef C
 

--- a/test/standalone/concepts/autotest.json
+++ b/test/standalone/concepts/autotest.json
@@ -1,0 +1,40 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|200",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed",
+	  "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A"
+      ]
+    },
+    "2": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/standalone/concepts/makefile
+++ b/test/standalone/concepts/makefile
@@ -1,0 +1,18 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Wconversion -Wformat=2 -std=c17 -Oz
+CXXFLAGS = -Wall -Wextra -Wconversion -Wformat=2 -std=c++20 -Oz
+
+PREFER_OS_LIBC = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/standalone/concepts/src/main.cpp
+++ b/test/standalone/concepts/src/main.cpp
@@ -1,0 +1,66 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+#include <stdio.h>
+
+#include <concepts>
+
+// test derived_from
+namespace test_derived_from {
+    class A {};
+    class B : public A {};
+    class C : private A {};
+    
+    static_assert(std::derived_from<B, B> == true);
+    static_assert(std::derived_from<int, int> == false);
+    static_assert(std::derived_from<B, A> == true);
+    static_assert(std::derived_from<C, A> == false);
+
+    static_assert(std::is_base_of_v<B, B> == true);
+    static_assert(std::is_base_of_v<int, int> == false);
+    static_assert(std::is_base_of_v<A, B> == true);
+    static_assert(std::is_base_of_v<A, C> == true);
+}
+
+// test integral
+static_assert(std::integral<bool>);
+static_assert(std::integral<char>);
+static_assert(std::integral<int>);
+static_assert( ! std::integral<double> );
+static_assert( ! std::integral<decltype("")> );
+
+// test floating_point
+namespace test_floating_point {
+    constexpr std::floating_point auto x2(std::floating_point auto x) {
+        return x + x;
+    }
+    constexpr std::integral auto x2(std::integral auto x) {
+        return x << 1;
+    }
+
+    constexpr auto d = x2(1.1);
+    constexpr auto f = x2(2.2f);
+    constexpr auto i = x2(444);
+    
+    static_assert(std::is_same_v<double const, decltype(d)>);
+    static_assert(std::is_same_v<float const, decltype(f)>);
+    static_assert(std::is_same_v<int const, decltype(i)>);
+}
+
+int run_tests(void) {
+    return 0;
+}
+
+int main(void) {
+    os_ClrHome();
+    int failed_test = run_tests();
+    if (failed_test != 0) {
+        printf("Failed test L%d\n", failed_test);
+    } else {
+        printf("All tests passed");
+    }
+
+    while (!os_GetCSC());
+
+    return 0;
+}


### PR DESCRIPTION
Changes:
* expanded `<type_traits>`
* added to `<concepts>`
* added C++23 `std::unreachable` to `<utility>`

I have added to `<type_traits>` by replacing `__has_feature(is_foo)` to `__has_builtin(__is_foo)`. From this, almost all of C++17 `<type_traits>` has been implemented except for:
```c++
/* C++11 */
common_type
aligned_storage
aligned_union
result_of
is_trivially_copy_assignable
is_trivially_move_assignable
make_signed
make_unsigned
is_destructable // works in C++20, requires Clang 16 to work in C++11
is_nothrow_destructable // works in C++20, requires Clang 16 to work in C++11
/* C++17 */
is_swappable
is_nothrow_swappable
invoke_result
```
I also replaced existing functions in `<type_traits>` with builtins if possible. I still need to do testing to ensure that all transformations are correct.

`__has_builtin` is the same as `__has_feature`, except that the latter is "deprecated", so it won't return true for newer builtins https://releases.llvm.org/15.0.0/tools/clang/docs/LanguageExtensions.html#builtin-functions
```
There are multiple ways to detect support for a type trait __X in the compiler, depending on the oldest version of Clang you wish to support.
* From Clang 10 onwards, __has_builtin(__X) can be used.
* From Clang 6 onwards, !__is_identifier(__X) can be used.
* From Clang 3 onwards, __has_feature(X) can be used, but only supports the following traits:
```

