### PR TITLE
Fixed the behaviour of including math.h/cmath in C++

### DIFF
--- a/src/libc/include/__math_def.h
+++ b/src/libc/include/__math_def.h
@@ -1,0 +1,345 @@
+#ifndef _MATH_DEF_H
+#define _MATH_DEF_H
+
+#include <stdbool.h>
+
+#define NAN          __builtin_nanf("")
+#define INFINITY     __builtin_inff()
+
+#define HUGE_VALF    __builtin_inff()
+#define HUGE_VAL     __builtin_inf()
+#define HUGE_VALL    __builtin_infl()
+
+#define M_E           2.71828182845904523536     /* e              */
+#define M_LOG2E       1.44269504088896340736     /* log2(e)        */
+#define M_LOG10E      0.434294481903251827651    /* log10(e)       */
+#define M_LN2         0.693147180559945309417    /* ln(2)          */
+#define M_LN10        2.30258509299404568402     /* ln(10)         */
+#define M_PI          3.14159265358979323846     /* pi             */
+#define M_PI_2        1.57079632679489661923     /* pi/2           */
+#define M_PI_4        0.785398163397448309616    /* pi/4           */
+#define M_1_PI        0.318309886183790671538    /* 1/pi           */
+#define M_2_PI        0.636619772367581343076    /* 2/pi           */
+#define M_2_SQRTPI    1.12837916709551257390     /* 2/sqrt(pi)     */
+#define M_SQRT2       1.41421356237309504880     /* sqrt(2)        */
+#define M_SQRT1_2     0.707106781186547524401    /* 1/sqrt(2)      */
+
+#define FP_ILOGB0     (~__INT_MAX__)
+#define FP_ILOGBNAN     __INT_MAX__
+
+#define FP_ZERO      0x0
+#define FP_INFINITE  0x1
+#define FP_SUBNORMAL 0x2
+#define FP_NAN       0x3
+#define FP_NORMAL    0x4
+
+typedef float float_t;
+typedef double double_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int _fpclassifyf(float n);
+int _fpclassifyl(long double n);
+
+int _isinff(float n);
+int _isnanf(float n);
+int _isnormalf(float n);
+int _isfinitef(float n);
+int _iszerof(float n);
+int _issubnormalf(float n);
+
+int _isinfl(long double n);
+int _isnanl(long double n);
+int _isnormall(long double n);
+int _isfinitel(long double n);
+int _iszerol(long double n);
+int _issubnormall(long double n);
+
+#if 0
+/* disabled until builtin is optimized */
+#define _signbitf(x) __builtin_signbit(x)
+#define _signbitl(x) __builtin_signbit(x)
+#else
+bool _signbitf(float x);
+bool _signbitl(long double x);
+#endif
+
+double      acos(double);
+float       acosf(float);
+long double acosl(long double);
+
+double      acosh(double);
+float       acoshf(float);
+long double acoshl(long double);
+
+double      asin(double);
+float       asinf(float);
+long double asinl(long double);
+
+double      asinh(double);
+float       asinhf(float);
+long double asinhl(long double);
+
+double      atan(double);
+float       atanf(float);
+long double atanl(long double);
+
+double      atan2(double, double);
+float       atan2f(float, float);
+long double atan2l(long double, long double);
+
+double      atanh(double);
+float       atanhf(float);
+long double atanhl(long double);
+
+double      cbrt(double);
+float       cbrtf(float);
+long double cbrtl(long double);
+
+double      ceil(double);
+float       ceilf(float);
+long double ceill(long double);
+
+double      copysign(double, double);
+float       copysignf(float, float);
+long double copysignl(long double, long double);
+
+double      cos(double);
+float       cosf(float);
+long double cosl(long double);
+
+double      cosh(double);
+float       coshf(float);
+long double coshl(long double);
+
+double      erf(double);
+float       erff(float);
+long double erfl(long double);
+
+double      erfc(double);
+float       erfcf(float);
+long double erfcl(long double);
+
+double      exp(double);
+float       expf(float);
+long double expl(long double);
+
+double      exp2(double);
+float       exp2f(float);
+long double exp2l(long double);
+
+double      expm1(double);
+float       expm1f(float);
+long double expm1l(long double);
+
+#ifndef _ABS_FLOAT_DEFINED
+#define _ABS_FLOAT_DEFINED
+double      fabs(double);
+float       fabsf(float);
+long double fabsl(long double);
+#endif /* _ABS_FLOAT_DEFINED */
+
+double      fdim(double, double);
+float       fdimf(float, float);
+long double fdiml(long double, long double);
+
+double      floor(double);
+float       floorf(float);
+long double floorl(long double);
+
+double      fma(double, double, double);
+float       fmaf(float, float, float);
+long double fmal(long double, long double, long double);
+
+double      fmax(double, double);
+float       fmaxf(float, float);
+long double fmaxl(long double, long double);
+
+double      fmin(double, double);
+float       fminf(float, float);
+long double fminl(long double, long double);
+
+double      fmod(double, double);
+float       fmodf(float, float);
+long double fmodl(long double, long double);
+
+double      frexp(double, int *);
+float       frexpf(float, int *);
+long double frexpl(long double, int *);
+
+double      hypot(double, double);
+float       hypotf(float, float);
+long double hypotl(long double, long double);
+
+double      __hypot3(double, double, double);
+float       __hypot3f(float, float, float);
+long double __hypot3l(long double, long double, long double);
+
+int         ilogb(double);
+int         ilogbf(float);
+int         ilogbl(long double);
+
+double      ldexp(double, int);
+float       ldexpf(float, int);
+long double ldexpl(long double, int);
+
+double      lgamma(double);
+float       lgammaf(float);
+long double lgammal(long double);
+
+long long   llrint(double);
+long long   llrintf(float);
+long long   llrintl(long double);
+
+long long   llround(double);
+long long   llroundf(float);
+long long   llroundl(long double);
+
+double      log(double);
+float       logf(float);
+long double logl(long double);
+
+double      log10(double);
+float       log10f(float);
+long double log10l(long double);
+
+double      log1p(double);
+float       log1pf(float);
+long double log1pl(long double);
+
+double      log2(double);
+float       log2f(float);
+long double log2l(long double);
+
+double      logb(double);
+float       logbf(float);
+long double logbl(long double);
+
+long        lrint(double);
+long        lrintf(float);
+long        lrintl(long double);
+
+long        lround(double);
+long        lroundf(float);
+long        lroundl(long double);
+
+double      modf(double, double *);
+float       modff(float, float *);
+long double modfl(long double, long double *);
+
+double      nan(const char *);
+float       nanf(const char *);
+long double nanl(const char *);
+
+double      nearbyint(double);
+float       nearbyintf(float);
+long double nearbyintl(long double);
+
+double      nextafter(double, double);
+float       nextafterf(float, float);
+long double nextafterl(long double, long double);
+
+double      nextdown(double);
+float       nextdownf(float);
+long double nextdownl(long double);
+
+double      nexttoward(double, long double);
+float       nexttowardf(float, long double);
+long double nexttowardl(long double, long double);
+
+double      nextup(double);
+float       nextupf(float);
+long double nextupl(long double);
+
+double      pow(double, double);
+float       powf(float, float);
+long double powl(long double, long double);
+
+double      remainder(double, double);
+float       remainderf(float, float);
+long double remainderl(long double, long double);
+
+double      remquo(double, double, int *);
+float       remquof(float, float, int *);
+long double remquol(long double, long double, int *);
+
+double      rint(double);
+float       rintf(float);
+long double rintl(long double);
+
+double      round(double);
+float       roundf(float);
+long double roundl(long double);
+
+double      roundeven(double);
+float       roundevenf(float);
+long double roundevenl(long double);
+
+double      scalbln(double, long);
+float       scalblnf(float, long);
+long double scalblnl(long double, long);
+
+double      scalbn(double, int);
+float       scalbnf(float, int);
+long double scalbnl(long double, int);
+
+double      sin(double);
+float       sinf(float);
+long double sinl(long double);
+
+double      sinh(double);
+float       sinhf(float);
+long double sinhl(long double);
+
+double      sqrt(double);
+float       sqrtf(float);
+long double sqrtl(long double);
+
+double      tan(double);
+float       tanf(float);
+long double tanl(long double);
+
+double      tanh(double);
+float       tanhf(float);
+long double tanhl(long double);
+
+double      tgamma(double);
+float       tgammaf(float);
+long double tgammal(long double);
+
+double      trunc(double);
+float       truncf(float);
+long double truncl(long double);
+
+/* aliases */
+
+long double _debug_fabsl(long double);
+#define fabsl _debug_fabsl
+long double _debug_copysignl(long double, long double);
+#define copysignl _debug_copysignl
+long double _debug_fmaxl(long double, long double);
+#define fmaxl _debug_fmaxl
+long double _debug_fminl(long double, long double);
+#define fminl _debug_fminl
+long double _debug_truncl(long double);
+#define truncl _debug_truncl
+long double _debug_floorl(long double);
+#define floorl _debug_floorl
+long double _debug_ceill(long double);
+#define ceill _debug_ceill
+long double _debug_roundl(long double);
+#define roundl _debug_roundl
+long double _debug_nearbyintl(long double);
+#define nearbyintl _debug_nearbyintl
+long double _debug_rintl(long double);
+#define rintl _debug_rintl
+long double _debug_fmal(long double, long double, long double);
+#define fmal _debug_fmal
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MATH_DEF_H */

--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -1,41 +1,67 @@
 #ifndef _MATH_H
 #define _MATH_H
 
-#include <stdbool.h>
-
 #ifdef __cplusplus
-extern "C" {
-#endif
 
-#define NAN          __builtin_nanf("")
-#define INFINITY     __builtin_inff()
+#include <cmath>
 
-#define HUGE_VALF    __builtin_inff()
-#define HUGE_VAL     __builtin_inf()
-#define HUGE_VALL    __builtin_infl()
+#else /* __cplusplus */
 
-#define M_E           2.71828182845904523536     /* e              */
-#define M_LOG2E       1.44269504088896340736     /* log2(e)        */
-#define M_LOG10E      0.434294481903251827651    /* log10(e)       */
-#define M_LN2         0.693147180559945309417    /* ln(2)          */
-#define M_LN10        2.30258509299404568402     /* ln(10)         */
-#define M_PI          3.14159265358979323846     /* pi             */
-#define M_PI_2        1.57079632679489661923     /* pi/2           */
-#define M_PI_4        0.785398163397448309616    /* pi/4           */
-#define M_1_PI        0.318309886183790671538    /* 1/pi           */
-#define M_2_PI        0.636619772367581343076    /* 2/pi           */
-#define M_2_SQRTPI    1.12837916709551257390     /* 2/sqrt(pi)     */
-#define M_SQRT2       1.41421356237309504880     /* sqrt(2)        */
-#define M_SQRT1_2     0.707106781186547524401    /* 1/sqrt(2)      */
+#include <__math_def.h>
 
-#define FP_ILOGB0     (~__INT_MAX__)
-#define FP_ILOGBNAN     __INT_MAX__
+#define __math_promote(x) _Generic((x), \
+    float: ((float)0.f), \
+    default: ((double)0.), \
+    long double: ((long double)0.L) \
+)
 
-#define FP_ZERO      0x0
-#define FP_INFINITE  0x1
-#define FP_SUBNORMAL 0x2
-#define FP_NAN       0x3
-#define FP_NORMAL    0x4
+#define signbit(x) ((int)_Generic(__math_promote(x), \
+    long double: _signbitl, \
+    default: _signbitf, \
+    float: _signbitf \
+)(x))
+
+#define isinf(x) ((int)_Generic(__math_promote(x), \
+    long double: _isinfl, \
+    default: _isinff, \
+    float: _isinff \
+)(x))
+
+#define isnan(x) ((int)_Generic(__math_promote(x), \
+    long double: _isnanl, \
+    default: _isnanf, \
+    float: _isnanf \
+)(x))
+
+#define isnormal(x) ((int)_Generic(__math_promote(x), \
+    long double: _isnormall, \
+    default: _isnormalf, \
+    float: _isnormalf \
+)(x))
+
+#define isfinite(x) ((int)_Generic(__math_promote(x), \
+    long double: _isfinitel, \
+    default: _isfinitef, \
+    float: _isfinitef \
+)(x))
+
+#define iszero(x) ((int)_Generic(__math_promote(x), \
+    long double: _iszerol, \
+    default: _iszerof, \
+    float: _iszerof \
+)(x))
+
+#define issubnormal(x) ((int)_Generic(__math_promote(x), \
+    long double: _issubnormall, \
+    default: _issubnormalf, \
+    float: _issubnormalf \
+)(x))
+
+#define fpclassify(x) ((int)_Generic(__math_promote(x), \
+    long double: _fpclassifyl, \
+    default: _fpclassifyf, \
+    float: _fpclassifyf \
+)(x))
 
 #define isgreater(x, y)      __builtin_isgreater(x, y)
 #define isgreaterequal(x, y) __builtin_isgreaterequal(x, y)
@@ -44,383 +70,6 @@ extern "C" {
 #define islessgreater(x, y)  __builtin_islessgreater(x, y)
 #define isunordered(x, y)    __builtin_isunordered(x, y)
 
-int _isinff(float n);
-int _isnanf(float n);
-int _isnormalf(float n);
-int _isfinitef(float n);
-int _iszerof(float n);
-int _issubnormalf(float n);
-int _fpclassifyf(float n);
-
-int _isinfl(long double n);
-int _isnanl(long double n);
-int _isnormall(long double n);
-int _isfinitel(long double n);
-int _iszerol(long double n);
-int _issubnormall(long double n);
-int _fpclassifyl(long double n);
-
-#if 0
-/* disabled until builtin is optimized */
-#define _signbitf(x) __builtin_signbit(x)
-#define _signbitl(x) __builtin_signbit(x)
-#else
-bool _signbitf(float x);
-bool _signbitl(long double x);
-#endif
-
-#ifndef __cplusplus
-
-#define signbit(x) ( \
-    sizeof((x)) == sizeof(float) ? _signbitf((x)) : \
-    sizeof((x)) == sizeof(long double) ? _signbitl((x)) : \
-    (x) < 0)
-#define isinf(x) ( \
-    sizeof((x)) == sizeof(float) ? _isinff((x)) : \
-    sizeof((x)) == sizeof(long double) ? _isinfl((x)) : \
-    0)
-#define isnan(x) ( \
-    sizeof((x)) == sizeof(float) ? _isnanf((x)) : \
-    sizeof((x)) == sizeof(long double) ? _isnanl((x)) : \
-    0)
-#define isnormal(x) ( \
-    sizeof((x)) == sizeof(float) ? _isnormalf((x)) : \
-    sizeof((x)) == sizeof(long double) ? _isnormall((x)) : \
-    (x) != 0)
-#define isfinite(x) ( \
-    sizeof((x)) == sizeof(float) ? _isfinitef((x)) : \
-    sizeof((x)) == sizeof(long double) ? _isfinitel((x)) : \
-    1)
-#define iszero(x) ( \
-    sizeof((x)) == sizeof(float) ? _iszerof((x)) : \
-    sizeof((x)) == sizeof(long double) ? _iszerol((x)) : \
-    (x) == 0)
-#define issubnormal(x) ( \
-    sizeof((x)) == sizeof(float) ? _issubnormalf((x)) : \
-    sizeof((x)) == sizeof(long double) ? _issubnormall((x)) : \
-    0)
-#define fpclassify(x) ( \
-    sizeof((x)) == sizeof(float) ? _fpclassifyf((x)) : \
-    sizeof((x)) == sizeof(long double) ? _fpclassifyl((x)) : \
-    0)
-
-#else
-
-extern "C++" {
-
-inline bool signbit(float __x) { return _signbitf(__x); }
-inline bool signbit(double __x) { return _signbitf(__x); }
-inline bool signbit(long double __x) { return _signbitl(__x); }
-
-inline bool isinf(float __x) { return _isinff(__x); }
-inline bool isinf(double __x) { return _isinff(__x); }
-inline bool isinf(long double __x) { return _isinfl(__x); }
-
-inline bool isnan(float __x) { return _isnanf(__x); }
-inline bool isnan(double __x) { return _isnanf(__x); }
-inline bool isnan(long double __x) { return _isnanl(__x); }
-
-inline bool isnormal(float __x) { return _isnormalf(__x); }
-inline bool isnormal(double __x) { return _isnormalf(__x); }
-inline bool isnormal(long double __x) { return _isnormall(__x); }
-
-inline bool isfinite(float __x) { return _isfinitef(__x); }
-inline bool isfinite(double __x) { return _isfinitef(__x); }
-inline bool isfinite(long double __x) { return _isfinitel(__x); }
-
-inline bool iszero(float __x) { return _iszerof(__x); }
-inline bool iszero(double __x) { return _iszerof(__x); }
-inline bool iszero(long double __x) { return _iszerol(__x); }
-
-inline bool issubnormal(float __x) { return _issubnormalf(__x); }
-inline bool issubnormal(double __x) { return _issubnormalf(__x); }
-inline bool issubnormal(long double __x) { return _issubnormall(__x); }
-
-inline bool fpclassify(float __x) { return _fpclassifyf(__x); }
-inline bool fpclassify(double __x) { return _fpclassifyf(__x); }
-inline bool fpclassify(long double __x) { return _fpclassifyl(__x); }
-
-} /* extern "C++" */
-
-#endif
-
-typedef float float_t;
-typedef double double_t;
-
-double      acos(double);
-float       acosf(float);
-long double acosl(long double);
-
-double      acosh(double);
-float       acoshf(float);
-long double acoshl(long double);
-
-double      asin(double);
-float       asinf(float);
-long double asinl(long double);
-
-double      asinh(double);
-float       asinhf(float);
-long double asinhl(long double);
-
-double      atan(double);
-float       atanf(float);
-long double atanl(long double);
-
-double      atan2(double, double);
-float       atan2f(float, float);
-long double atan2l(long double, long double);
-
-double      atanh(double);
-float       atanhf(float);
-long double atanhl(long double);
-
-double      cbrt(double);
-float       cbrtf(float);
-long double cbrtl(long double);
-
-double      ceil(double);
-float       ceilf(float);
-long double ceill(long double);
-
-double      copysign(double, double);
-float       copysignf(float, float);
-long double copysignl(long double, long double);
-
-double      cos(double);
-float       cosf(float);
-long double cosl(long double);
-
-double      cosh(double);
-float       coshf(float);
-long double coshl(long double);
-
-double      erf(double);
-float       erff(float);
-long double erfl(long double);
-
-double      erfc(double);
-float       erfcf(float);
-long double erfcl(long double);
-
-double      exp(double);
-float       expf(float);
-long double expl(long double);
-
-double      exp2(double);
-float       exp2f(float);
-long double exp2l(long double);
-
-double      expm1(double);
-float       expm1f(float);
-long double expm1l(long double);
-
-#ifndef _ABS_FLOAT_DEFINED
-#define _ABS_FLOAT_DEFINED
-double      fabs(double);
-float       fabsf(float);
-long double fabsl(long double);
-#endif /* _ABS_FLOAT_DEFINED */
-
-double      fdim(double, double);
-float       fdimf(float, float);
-long double fdiml(long double, long double);
-
-double      floor(double);
-float       floorf(float);
-long double floorl(long double);
-
-double      fma(double, double, double);
-float       fmaf(float, float, float);
-long double fmal(long double, long double, long double);
-
-double      fmax(double, double);
-float       fmaxf(float, float);
-long double fmaxl(long double, long double);
-
-double      fmin(double, double);
-float       fminf(float, float);
-long double fminl(long double, long double);
-
-double      fmod(double, double);
-float       fmodf(float, float);
-long double fmodl(long double, long double);
-
-double      frexp(double, int *);
-float       frexpf(float, int *);
-long double frexpl(long double, int *);
-
-double      hypot(double, double);
-float       hypotf(float, float);
-long double hypotl(long double, long double);
-
-double      __hypot3(double, double, double);
-float       __hypot3f(float, float, float);
-long double __hypot3l(long double, long double, long double);
-
-int         ilogb(double);
-int         ilogbf(float);
-int         ilogbl(long double);
-
-double      ldexp(double, int);
-float       ldexpf(float, int);
-long double ldexpl(long double, int);
-
-double      lgamma(double);
-float       lgammaf(float);
-long double lgammal(long double);
-
-long long   llrint(double);
-long long   llrintf(float);
-long long   llrintl(long double);
-
-long long   llround(double);
-long long   llroundf(float);
-long long   llroundl(long double);
-
-double      log(double);
-float       logf(float);
-long double logl(long double);
-
-double      log10(double);
-float       log10f(float);
-long double log10l(long double);
-
-double      log1p(double);
-float       log1pf(float);
-long double log1pl(long double);
-
-double      log2(double);
-float       log2f(float);
-long double log2l(long double);
-
-double      logb(double);
-float       logbf(float);
-long double logbl(long double);
-
-long        lrint(double);
-long        lrintf(float);
-long        lrintl(long double);
-
-long        lround(double);
-long        lroundf(float);
-long        lroundl(long double);
-
-double      modf(double, double *);
-float       modff(float, float *);
-long double modfl(long double, long double *);
-
-double      nan(const char *);
-float       nanf(const char *);
-long double nanl(const char *);
-
-double      nearbyint(double);
-float       nearbyintf(float);
-long double nearbyintl(long double);
-
-double      nextafter(double, double);
-float       nextafterf(float, float);
-long double nextafterl(long double, long double);
-
-double      nextdown(double);
-float       nextdownf(float);
-long double nextdownl(long double);
-
-double      nexttoward(double, long double);
-float       nexttowardf(float, long double);
-long double nexttowardl(long double, long double);
-
-double      nextup(double);
-float       nextupf(float);
-long double nextupl(long double);
-
-double      pow(double, double);
-float       powf(float, float);
-long double powl(long double, long double);
-
-double      remainder(double, double);
-float       remainderf(float, float);
-long double remainderl(long double, long double);
-
-double      remquo(double, double, int *);
-float       remquof(float, float, int *);
-long double remquol(long double, long double, int *);
-
-double      rint(double);
-float       rintf(float);
-long double rintl(long double);
-
-double      round(double);
-float       roundf(float);
-long double roundl(long double);
-
-double      roundeven(double);
-float       roundevenf(float);
-long double roundevenl(long double);
-
-double      scalbln(double, long);
-float       scalblnf(float, long);
-long double scalblnl(long double, long);
-
-double      scalbn(double, int);
-float       scalbnf(float, int);
-long double scalbnl(long double, int);
-
-double      sin(double);
-float       sinf(float);
-long double sinl(long double);
-
-double      sinh(double);
-float       sinhf(float);
-long double sinhl(long double);
-
-double      sqrt(double);
-float       sqrtf(float);
-long double sqrtl(long double);
-
-double      tan(double);
-float       tanf(float);
-long double tanl(long double);
-
-double      tanh(double);
-float       tanhf(float);
-long double tanhl(long double);
-
-double      tgamma(double);
-float       tgammaf(float);
-long double tgammal(long double);
-
-double      trunc(double);
-float       truncf(float);
-long double truncl(long double);
-
-/* aliases */
-
-long double _debug_fabsl(long double);
-#define fabsl _debug_fabsl
-long double _debug_copysignl(long double, long double);
-#define copysignl _debug_copysignl
-long double _debug_fmaxl(long double, long double);
-#define fmaxl _debug_fmaxl
-long double _debug_fminl(long double, long double);
-#define fminl _debug_fminl
-long double _debug_truncl(long double);
-#define truncl _debug_truncl
-long double _debug_floorl(long double);
-#define floorl _debug_floorl
-long double _debug_ceill(long double);
-#define ceill _debug_ceill
-long double _debug_roundl(long double);
-#define roundl _debug_roundl
-long double _debug_nearbyintl(long double);
-#define nearbyintl _debug_nearbyintl
-long double _debug_rintl(long double);
-#define rintl _debug_rintl
-long double _debug_fmal(long double, long double, long double);
-#define fmal _debug_fmal
-
-#ifdef __cplusplus
-}
-#endif
+#endif /* __cplusplus */
 
 #endif /* _MATH_H */

--- a/src/libcxx/include/__cmath_type_traits
+++ b/src/libcxx/include/__cmath_type_traits
@@ -1,0 +1,35 @@
+// -*- C++ -*-
+#ifndef _EZCXX_MATH_TYPE_TRAITS
+#define _EZCXX_MATH_TYPE_TRAITS
+
+#include <__config>
+
+#pragma clang system_header
+
+template<class _Tp, _Tp __value> struct __cmath_integral_constant {
+    static const _Tp value = __value;
+    using value_type = _Tp;
+    using type = __cmath_integral_constant;
+    _EZCXX_INLINE constexpr operator value_type()   const noexcept { return value; }
+    _EZCXX_INLINE constexpr value_type operator()() const noexcept { return value; }
+};
+
+template<bool __value> using __cmath_bool_constant = __cmath_integral_constant<bool, __value>;
+using __cmath_false_type = __cmath_bool_constant<false>;
+using __cmath_true_type  = __cmath_bool_constant<true>;
+
+template<class _Tp> struct __cmath_type_identity { using type = _Tp; };
+template<class _Tp> using __cmath_type_identity_t = typename __cmath_type_identity<_Tp>::type;
+
+template<bool, class = void> struct __cmath_enable_if {};
+template<class _Tp> struct __cmath_enable_if<true, _Tp> : __cmath_type_identity<_Tp> {};
+template<bool _Ep, class _Tp = void> using __cmath_enable_if_t = typename __cmath_enable_if<_Ep, _Tp>::type;
+
+#if __has_builtin(__is_integral)
+template<class _Tp> inline constexpr bool __cmath_is_integral_v = __is_integral(_Tp);
+template<class _Tp> using __cmath_is_integral = __cmath_bool_constant<__cmath_is_integral_v<_Tp>>;
+#else
+#error "the __is_integral builtin is required"
+#endif
+
+#endif // _EZCXX_MATH_TYPE_TRAITS

--- a/src/libcxx/include/cmath
+++ b/src/libcxx/include/cmath
@@ -2,8 +2,8 @@
 #ifndef _EZCXX_CMATH
 #define _EZCXX_CMATH
 
-#include <math.h>
-#include <type_traits>
+#include <__math_def.h>
+#include <__cmath_type_traits>
 #include <__abs_overloads>
 
 #pragma clang system_header
@@ -12,21 +12,111 @@ namespace std {
 using ::float_t;
 using ::double_t;
 
-using ::signbit;
-using ::isinf;
-using ::isnan;
-using ::isnormal;
-using ::isfinite;
-using ::iszero;
-using ::issubnormal;
-using ::fpclassify;
+inline bool signbit(float __x) { return static_cast<bool>(_signbitf(__x)); }
+inline bool signbit(double __x) { return static_cast<bool>(_signbitf(__x)); }
+inline bool signbit(long double __x) { return static_cast<bool>(_signbitl(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+signbit(_Tp __x) { return signbit(__x); }
+
+inline bool isinf(float __x) { return static_cast<bool>(_isinff(__x)); }
+inline bool isinf(double __x) { return static_cast<bool>(_isinff(__x)); }
+inline bool isinf(long double __x) { return static_cast<bool>(_isinfl(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+isinf(_Tp __x) { return isinf(__x); }
+
+inline bool isnan(float __x) { return static_cast<bool>(_isnanf(__x)); }
+inline bool isnan(double __x) { return static_cast<bool>(_isnanf(__x)); }
+inline bool isnan(long double __x) { return static_cast<bool>(_isnanl(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+isnan(_Tp __x) { return isnan(__x); }
+
+inline bool isnormal(float __x) { return static_cast<bool>(_isnormalf(__x)); }
+inline bool isnormal(double __x) { return static_cast<bool>(_isnormalf(__x)); }
+inline bool isnormal(long double __x) { return static_cast<bool>(_isnormall(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+isnormal(_Tp __x) { return isnormal(__x); }
+
+inline bool isfinite(float __x) { return static_cast<bool>(_isfinitef(__x)); }
+inline bool isfinite(double __x) { return static_cast<bool>(_isfinitef(__x)); }
+inline bool isfinite(long double __x) { return static_cast<bool>(_isfinitel(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+isfinite(_Tp __x) { return isfinite(__x); }
+
+inline bool iszero(float __x) { return static_cast<bool>(_iszerof(__x)); }
+inline bool iszero(double __x) { return static_cast<bool>(_iszerof(__x)); }
+inline bool iszero(long double __x) { return static_cast<bool>(_iszerol(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+iszero(_Tp __x) { return iszero(__x); }
+
+inline bool issubnormal(float __x) { return static_cast<bool>(_issubnormalf(__x)); }
+inline bool issubnormal(double __x) { return static_cast<bool>(_issubnormalf(__x)); }
+inline bool issubnormal(long double __x) { return static_cast<bool>(_issubnormall(__x)); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
+issubnormal(_Tp __x) { return issubnormal(__x); }
+
+inline int fpclassify(float __x) { return _fpclassifyf(__x); }
+inline int fpclassify(double __x) { return _fpclassifyf(__x); }
+inline int fpclassify(long double __x) { return _fpclassifyl(__x); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, int>
+fpclassify(_Tp __x) { return fpclassify(__x); }
+
+inline constexpr bool isgreater(float __x, float __y) { return __builtin_isgreater(__x, __y); }
+inline constexpr bool isgreater(double __x, double __y) { return __builtin_isgreater(__x, __y); }
+inline constexpr bool isgreater(long double __x, long double __y) { return __builtin_isgreater(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+isgreater(_Tp __x, _Up __y) { return __builtin_isgreater(__x, __y); }
+
+inline constexpr bool isgreaterequal(float __x, float __y) { return __builtin_isgreaterequal(__x, __y); }
+inline constexpr bool isgreaterequal(double __x, double __y) { return __builtin_isgreaterequal(__x, __y); }
+inline constexpr bool isgreaterequal(long double __x, long double __y) { return __builtin_isgreaterequal(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+isgreaterequal(_Tp __x, _Up __y) { return __builtin_isgreaterequal(__x, __y); }
+
+inline constexpr bool isless(float __x, float __y) { return __builtin_isless(__x, __y); }
+inline constexpr bool isless(double __x, double __y) { return __builtin_isless(__x, __y); }
+inline constexpr bool isless(long double __x, long double __y) { return __builtin_isless(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+isless(_Tp __x, _Up __y) { return __builtin_isless(__x, __y); }
+
+inline constexpr bool islessequal(float __x, float __y) { return __builtin_islessequal(__x, __y); }
+inline constexpr bool islessequal(double __x, double __y) { return __builtin_islessequal(__x, __y); }
+inline constexpr bool islessequal(long double __x, long double __y) { return __builtin_islessequal(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+islessequal(_Tp __x, _Up __y) { return __builtin_islessequal(__x, __y); }
+
+inline constexpr bool islessgreater(float __x, float __y) { return __builtin_islessgreater(__x, __y); }
+inline constexpr bool islessgreater(double __x, double __y) { return __builtin_islessgreater(__x, __y); }
+inline constexpr bool islessgreater(long double __x, long double __y) { return __builtin_islessgreater(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+islessgreater(_Tp __x, _Up __y) { return __builtin_islessgreater(__x, __y); }
+
+inline constexpr bool isunordered(float __x, float __y) { return __builtin_isunordered(__x, __y); }
+inline constexpr bool isunordered(double __x, double __y) { return __builtin_isunordered(__x, __y); }
+inline constexpr bool isunordered(long double __x, long double __y) { return __builtin_isunordered(__x, __y); }
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, bool>
+isunordered(_Tp __x, _Up __y) { return __builtin_isunordered(__x, __y); }
 
 using ::acos;
 using ::acosf;
 using ::acosl;
 inline constexpr float acos(float __x) { return acosf(__x); }
 inline constexpr long double acos(long double __x) { return acosl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 acos(_Tp __x) { return acos(__x); }
 
 using ::acos;
@@ -34,7 +124,8 @@ using ::acoshf;
 using ::acoshl;
 inline constexpr float acosh(float __x) { return acoshf(__x); }
 inline constexpr long double acosh(long double __x) { return acoshl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 acosh(_Tp __x) { return acosh(__x); }
 
 using ::asin;
@@ -42,7 +133,8 @@ using ::asinf;
 using ::asinl;
 inline constexpr float asin(float __x) { return asinf(__x); }
 inline constexpr long double asin(long double __x) { return asinl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 asin(_Tp __x) { return asin(__x); }
 
 using ::asinh;
@@ -50,7 +142,8 @@ using ::asinhf;
 using ::asinhl;
 inline constexpr float asinh(float __x) { return asinhf(__x); }
 inline constexpr long double asinh(long double __x) { return asinhl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 asinh(_Tp __x) { return asinh(__x); }
 
 using ::atan;
@@ -58,7 +151,8 @@ using ::atanf;
 using ::atanl;
 inline constexpr float atan(float __x) { return atanf(__x); }
 inline constexpr long double atan(long double __x) { return atanl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 atan(_Tp __x) { return atan(__x); }
 
 using ::atan2;
@@ -66,8 +160,8 @@ using ::atan2f;
 using ::atan2l;
 inline constexpr float atan2(float __x, float __y) { return atan2f(__x, __y); }
 inline constexpr long double atan2(long double __x, long double __y) { return atan2l(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 atan2(_Tp __x, _Up __y) { return atan2(__x, __y); }
 
 using ::atanh;
@@ -75,7 +169,8 @@ using ::atanhf;
 using ::atanhl;
 inline constexpr float atanh(float __x) { return atanhf(__x); }
 inline constexpr long double atanh(long double __x) { return atanhl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 atanh(_Tp __x) { return atanh(__x); }
 
 using ::cbrt;
@@ -83,7 +178,8 @@ using ::cbrtf;
 using ::cbrtl;
 inline constexpr float cbrt(float __x) { return cbrtf(__x); }
 inline constexpr long double cbrt(long double __x) { return cbrtl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 cbrt(_Tp __x) { return cbrt(__x); }
 
 using ::ceil;
@@ -91,7 +187,8 @@ using ::ceilf;
 using ::ceill;
 inline constexpr float ceil(float __x) { return ceilf(__x); }
 inline constexpr long double ceil(long double __x) { return ceill(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 ceil(_Tp __x) { return ceil(__x); }
 
 using ::copysign;
@@ -99,8 +196,8 @@ using ::copysignf;
 using ::copysignl;
 inline constexpr float copysign(float __x, float __y) { return copysignf(__x, __y); }
 inline constexpr long double copysign(long double __x, long double __y) { return copysignl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 copysign(_Tp __x, _Up __y) { return copysign(__x, __y); }
 
 using ::cos;
@@ -108,7 +205,8 @@ using ::cosf;
 using ::cosl;
 inline constexpr float cos(float __x) { return cosf(__x); }
 inline constexpr long double cos(long double __x) { return cosl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 cos(_Tp __x) { return cos(__x); }
 
 using ::cosh;
@@ -116,7 +214,8 @@ using ::coshf;
 using ::coshl;
 inline constexpr float cosh(float __x) { return coshf(__x); }
 inline constexpr long double cosh(long double __x) { return coshl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 cosh(_Tp __x) { return cosh(__x); }
 
 using ::erf;
@@ -124,7 +223,8 @@ using ::erff;
 using ::erfl;
 inline constexpr float erf(float __x) { return erff(__x); }
 inline constexpr long double erf(long double __x) { return erfl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 erf(_Tp __x) { return erf(__x); }
 
 using ::erfc;
@@ -132,7 +232,8 @@ using ::erfcf;
 using ::erfcl;
 inline constexpr float erfc(float __x) { return erfcf(__x); }
 inline constexpr long double erfc(long double __x) { return erfcl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 erfc(_Tp __x) { return erfc(__x); }
 
 using ::exp;
@@ -140,7 +241,8 @@ using ::expf;
 using ::expl;
 inline constexpr float exp(float __x) { return expf(__x); }
 inline constexpr long double exp(long double __x) { return expl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 exp(_Tp __x) { return exp(__x); }
 
 using ::exp2;
@@ -148,7 +250,8 @@ using ::exp2f;
 using ::exp2l;
 inline constexpr float exp2(float __x) { return exp2f(__x); }
 inline constexpr long double exp2(long double __x) { return exp2l(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 exp2(_Tp __x) { return exp2(__x); }
 
 using ::expm1;
@@ -156,7 +259,8 @@ using ::expm1f;
 using ::expm1l;
 inline constexpr float expm1(float __x) { return expm1f(__x); }
 inline constexpr long double expm1(long double __x) { return expm1l(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 expm1(_Tp __x) { return expm1(__x); }
 
 using ::fabs;
@@ -164,7 +268,8 @@ using ::fabsf;
 using ::fabsl;
 inline constexpr float fabs(float __x) { return fabsf(__x); }
 inline constexpr long double fabs(long double __x) { return fabsl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 fabs(_Tp __x) { return fabs(__x); }
 
 using ::fdim;
@@ -172,8 +277,8 @@ using ::fdimf;
 using ::fdiml;
 inline constexpr float fdim(float __x, float __y) { return fdimf(__x, __y); }
 inline constexpr long double fdim(long double __x, long double __y) { return fdiml(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 fdim(_Tp __x, _Up __y) { return fdim(__x, __y); }
 
 using ::floor;
@@ -181,7 +286,8 @@ using ::floorf;
 using ::floorl;
 inline constexpr float floor(float __x) { return floorf(__x); }
 inline constexpr long double floor(long double __x) { return floorl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 floor(_Tp __x) { return floor(__x); }
 
 using ::fma;
@@ -189,9 +295,8 @@ using ::fmaf;
 using ::fmal;
 inline constexpr float fma(float __x, float __y, float __z) { return fmaf(__x, __y, __z); }
 inline constexpr long double fma(long double __x, long double __y, long double __z) { return fmal(__x, __y, __z); }
-template<typename _Tp, typename _Up, typename _Vp> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                                is_integral_v<_Up> &&
-                                                                                is_integral_v<_Vp>, double>
+template<typename _Tp, typename _Up, typename _Vp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up> && __cmath_is_integral_v<_Vp>, double>
 fma(_Tp __x, _Up __y, _Vp __z) { return fma(__x, __y, __z); }
 
 using ::fmax;
@@ -199,8 +304,8 @@ using ::fmaxf;
 using ::fmaxl;
 inline constexpr float fmax(float __x, float __y) { return fmaxf(__x, __y); }
 inline constexpr long double fmax(long double __x, long double __y) { return fmaxl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 fmax(_Tp __x, _Up __y) { return fmax(__x, __y); }
 
 using ::fmin;
@@ -208,8 +313,8 @@ using ::fminf;
 using ::fminl;
 inline constexpr float fmin(float __x, float __y) { return fminf(__x, __y); }
 inline constexpr long double fmin(long double __x, long double __y) { return fminl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 fmin(_Tp __x, _Up __y) { return fmin(__x, __y); }
 
 using ::fmod;
@@ -217,8 +322,8 @@ using ::fmodf;
 using ::fmodl;
 inline constexpr float fmod(float __x, float __y) { return fmodf(__x, __y); }
 inline constexpr long double fmod(long double __x, long double __y) { return fmodl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 fmod(_Tp __x, _Up __y) { return fmod(__x, __y); }
 
 using ::frexp;
@@ -226,7 +331,8 @@ using ::frexpf;
 using ::frexpl;
 inline constexpr float frexp(float __x, int *__y) { return frexpf(__x, __y); }
 inline constexpr long double frexp(long double __x, int *__y) { return frexpl(__x, __y); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 frexp(_Tp __x, int *__y) { return frexp(__x, __y); }
 
 using ::hypot;
@@ -234,14 +340,14 @@ using ::hypotf;
 using ::hypotl;
 inline constexpr float hypot(float __x, float __y) { return hypotf(__x, __y); }
 inline constexpr long double hypot(long double __x, long double __y) { return hypotl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 hypot(_Tp __x, _Up __y) { return hypot(__x, __y); }
 
 inline float hypot(float __x, float __y, float __z) { return __hypot3f(__x, __y, __z); }
 inline long double hypot(long double __x, long double __y, long double __z) { return __hypot3l(__x, __y, __z); }
-template<typename _Tp, typename _Up, typename _Vp>
-inline enable_if_t<is_integral_v<_Tp> && is_integral_v<_Up> && is_integral_v<_Vp>, double>
+template<typename _Tp, typename _Up, typename _Vp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up> && __cmath_is_integral_v<_Vp>, double>
 hypot(_Tp __x, _Up __y, _Vp __z) { return __hypot3(__x, __y, __z); }
 
 using ::ilogb;
@@ -249,7 +355,8 @@ using ::ilogbf;
 using ::ilogbl;
 inline constexpr int ilogb(float __x) { return ilogbf(__x); }
 inline constexpr int ilogb(long double __x) { return ilogbl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, int>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, int>
 ilogb(_Tp __x) { return ilogb(__x); }
 
 using ::ldexp;
@@ -257,7 +364,8 @@ using ::ldexpf;
 using ::ldexpl;
 inline constexpr float ldexp(float __x, int __y) { return ldexpf(__x, __y); }
 inline constexpr long double ldexp(long double __x, int __y) { return ldexpl(__x, __y); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 ldexp(_Tp __x, int __y) { return ldexp(__x, __y); }
 
 using ::lgamma;
@@ -265,7 +373,8 @@ using ::lgammaf;
 using ::lgammal;
 inline constexpr float lgamma(float __x) { return lgammaf(__x); }
 inline constexpr long double lgamma(long double __x) { return lgammal(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 lgamma(_Tp __x) { return lgamma(__x); }
 
 using ::llrint;
@@ -273,7 +382,8 @@ using ::llrintf;
 using ::llrintl;
 inline constexpr long long llrint(float __x) { return llrintf(__x); }
 inline constexpr long long llrint(long double __x) { return llrintl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, long long>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, long long>
 llrint(_Tp __x) { return llrint(__x); }
 
 using ::llround;
@@ -281,7 +391,8 @@ using ::llroundf;
 using ::llroundl;
 inline constexpr long long llround(float __x) { return llroundf(__x); }
 inline constexpr long long llround(long double __x) { return llroundl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, long long>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, long long>
 llround(_Tp __x) { return llround(__x); }
 
 using ::log;
@@ -289,7 +400,8 @@ using ::logf;
 using ::logl;
 inline constexpr float log(float __x) { return logf(__x); }
 inline constexpr long double log(long double __x) { return logl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 log(_Tp __x) { return log(__x); }
 
 using ::log10;
@@ -297,7 +409,8 @@ using ::log10f;
 using ::log10l;
 inline constexpr float log10(float __x) { return log10f(__x); }
 inline constexpr long double log10(long double __x) { return log10l(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 log10(_Tp __x) { return log10(__x); }
 
 using ::log1p;
@@ -305,7 +418,8 @@ using ::log1pf;
 using ::log1pl;
 inline constexpr float log1p(float __x) { return log1pf(__x); }
 inline constexpr long double log1p(long double __x) { return log1pl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 log1p(_Tp __x) { return log1p(__x); }
 
 using ::log2;
@@ -313,7 +427,8 @@ using ::log2f;
 using ::log2l;
 inline constexpr float log2(float __x) { return log2f(__x); }
 inline constexpr long double log2(long double __x) { return log2l(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 log2(_Tp __x) { return log2(__x); }
 
 using ::logb;
@@ -321,7 +436,8 @@ using ::logbf;
 using ::logbl;
 inline constexpr float logb(float __x) { return logbf(__x); }
 inline constexpr long double logb(long double __x) { return logbl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 logb(_Tp __x) { return logb(__x); }
 
 using ::lrint;
@@ -329,7 +445,8 @@ using ::lrintf;
 using ::lrintl;
 inline constexpr long lrint(float __x) { return lrintf(__x); }
 inline constexpr long lrint(long double __x) { return lrintl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, long>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, long>
 lrint(_Tp __x) { return lrint(__x); }
 
 using ::lround;
@@ -337,7 +454,8 @@ using ::lroundf;
 using ::lroundl;
 inline constexpr long lround(float __x) { return lroundf(__x); }
 inline constexpr long lround(long double __x) { return lroundl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, long>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, long>
 lround(_Tp __x) { return lround(__x); }
 
 using ::modf;
@@ -355,7 +473,8 @@ using ::nearbyintf;
 using ::nearbyintl;
 inline constexpr float nearbyint(float __x) { return nearbyintf(__x); }
 inline constexpr long double nearbyint(long double __x) { return nearbyintl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 nearbyint(_Tp __x) { return nearbyint(__x); }
 
 using ::nextafter;
@@ -363,8 +482,8 @@ using ::nextafterf;
 using ::nextafterl;
 inline constexpr float nextafter(float __x, float __y) { return nextafterf(__x, __y); }
 inline constexpr long double nextafter(long double __x, long double __y) { return nextafterl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 nextafter(_Tp __x, _Up __y) { return nextafter(__x, __y); }
 
 using ::nextup;
@@ -372,7 +491,8 @@ using ::nextupf;
 using ::nextupl;
 inline float nextup(float __x) { return nextupf(__x); }
 inline long double nextup(long double __x) { return nextupl(__x); }
-template<typename _Tp> inline enable_if_t<is_integral_v<_Tp>, double>                                                           
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>                                                           
 nextup(_Tp __x) { return nextup(__x); }
 
 using ::nexttoward;
@@ -380,8 +500,8 @@ using ::nexttowardf;
 using ::nexttowardl;
 inline constexpr float nexttoward(float __x, float __y) { return nexttowardf(__x, __y); }
 inline constexpr long double nexttoward(long double __x, long double __y) { return nexttowardl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 nexttoward(_Tp __x, _Up __y) { return nexttoward(__x, __y); }
 
 using ::nextdown;
@@ -389,7 +509,8 @@ using ::nextdownf;
 using ::nextdownl;
 inline float nextdown(float __x) { return nextdownf(__x); }
 inline long double nextdown(long double __x) { return nextdownl(__x); }
-template<typename _Tp> inline enable_if_t<is_integral_v<_Tp>, double>                                                           
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>                                                           
 nextdown(_Tp __x) { return nextdown(__x); }
 
 using ::pow;
@@ -397,8 +518,8 @@ using ::powf;
 using ::powl;
 inline constexpr float pow(float __x, float __y) { return powf(__x, __y); }
 inline constexpr long double pow(long double __x, long double __y) { return powl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 pow(_Tp __x, _Up __y) { return pow(__x, __y); }
 
 using ::remainder;
@@ -406,8 +527,8 @@ using ::remainderf;
 using ::remainderl;
 inline constexpr float remainder(float __x, float __y) { return remainderf(__x, __y); }
 inline constexpr long double remainder(long double __x, long double __y) { return remainderl(__x, __y); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 remainder(_Tp __x, _Up __y) { return remainder(__x, __y); }
 
 using ::remquo;
@@ -415,8 +536,8 @@ using ::remquof;
 using ::remquol;
 inline constexpr float remquo(float __x, float __y, int *__z) { return remquof(__x, __y, __z); }
 inline constexpr long double remquo(long double __x, long double __y, int *__z) { return remquol(__x, __y, __z); }
-template<typename _Tp, typename _Up> inline constexpr enable_if_t<is_integral_v<_Tp> &&
-                                                                  is_integral_v<_Up>, double>
+template<typename _Tp, typename _Up> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp> && __cmath_is_integral_v<_Up>, double>
 remquo(_Tp __x, _Up __y, int *__z) { return remquo(__x, __y, __z); }
 
 using ::rint;
@@ -424,7 +545,8 @@ using ::rintf;
 using ::rintl;
 inline constexpr float rint(float __x) { return rintf(__x); }
 inline constexpr long double rint(long double __x) { return rintl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 rint(_Tp __x) { return rint(__x); }
 
 using ::round;
@@ -432,7 +554,8 @@ using ::roundf;
 using ::roundl;
 inline constexpr float round(float __x) { return roundf(__x); }
 inline constexpr long double round(long double __x) { return roundl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 round(_Tp __x) { return round(__x); }
 
 using ::roundeven;
@@ -440,7 +563,8 @@ using ::roundevenf;
 using ::roundevenl;
 inline float roundeven(float __x) { return roundevenf(__x); }
 inline long double roundeven(long double __x) { return roundevenl(__x); }
-template<typename _Tp> inline enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 roundeven(_Tp __x) { return roundeven(__x); }
 
 using ::scalbln;
@@ -448,7 +572,8 @@ using ::scalblnf;
 using ::scalblnl;
 inline constexpr float scalbln(float __x, long __y) { return scalblnf(__x, __y); }
 inline constexpr long double scalbln(long double __x, long __y) { return scalblnl(__x, __y); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 scalbln(_Tp __x, long __y) { return scalbln(__x, __y); }
 
 using ::scalbn;
@@ -456,7 +581,8 @@ using ::scalbnf;
 using ::scalbnl;
 inline constexpr float scalbn(float __x, int __y) { return scalbnf(__x, __y); }
 inline constexpr long double scalbn(long double __x, int __y) { return scalbnl(__x, __y); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 scalbn(_Tp __x, int __y) { return scalbn(__x, __y); }
 
 using ::sin;
@@ -464,7 +590,8 @@ using ::sinf;
 using ::sinl;
 inline constexpr float sin(float __x) { return sinf(__x); }
 inline constexpr long double sin(long double __x) { return sinl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 sin(_Tp __x) { return sin(__x); }
 
 using ::sinh;
@@ -472,7 +599,8 @@ using ::sinhf;
 using ::sinhl;
 inline constexpr float sinh(float __x) { return sinhf(__x); }
 inline constexpr long double sinh(long double __x) { return sinhl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 sinh(_Tp __x) { return sinh(__x); }
 
 using ::sqrt;
@@ -480,7 +608,8 @@ using ::sqrtf;
 using ::sqrtl;
 inline constexpr float sqrt(float __x) { return sqrtf(__x); }
 inline constexpr long double sqrt(long double __x) { return sqrtl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 sqrt(_Tp __x) { return sqrt(__x); }
 
 using ::tan;
@@ -488,7 +617,8 @@ using ::tanf;
 using ::tanl;
 inline constexpr float tan(float __x) { return tanf(__x); }
 inline constexpr long double tan(long double __x) { return tanl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 tan(_Tp __x) { return tan(__x); }
 
 using ::tanh;
@@ -496,7 +626,8 @@ using ::tanhf;
 using ::tanhl;
 inline constexpr float tanh(float __x) { return tanhf(__x); }
 inline constexpr long double tanh(long double __x) { return tanhl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 tanh(_Tp __x) { return tanh(__x); }
 
 using ::tgamma;
@@ -504,7 +635,8 @@ using ::tgammaf;
 using ::tgammal;
 inline constexpr float tgamma(float __x) { return tgammaf(__x); }
 inline constexpr long double tgamma(long double __x) { return tgammal(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 tgamma(_Tp __x) { return tgamma(__x); }
 
 using ::trunc;
@@ -512,9 +644,26 @@ using ::truncf;
 using ::truncl;
 inline constexpr float trunc(float __x) { return truncf(__x); }
 inline constexpr long double trunc(long double __x) { return truncl(__x); }
-template<typename _Tp> inline constexpr enable_if_t<is_integral_v<_Tp>, double>
+template<typename _Tp> inline constexpr
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 trunc(_Tp __x) { return trunc(__x); }
 
 } // namespace std
+
+using std::signbit;
+using std::isinf;
+using std::isnan;
+using std::isnormal;
+using std::isfinite;
+using std::iszero;
+using std::issubnormal;
+using std::fpclassify;
+
+using std::isgreater;
+using std::isgreaterequal;
+using std::isless;
+using std::islessequal;
+using std::islessgreater;
+using std::isunordered;
 
 #endif // _EZCXX_CMATH


### PR DESCRIPTION
Changes:
* Functions like `isnan` and `islessequal` now use `_Generic` in C, and use overloads in C++. Additionally, the return value is casted to `int` in C, and `bool` in C++
* All `math.h` functions can be used in the `std::` namespace
* `<cmath>` no longer includes `<type_traits>`, instead using `<__cmath_type_traits>`. `__cmath_is_integral` being identical to `is_integral`
* Including `<math.h>` in C++ now includes `<cmath>`