### PR TITLE
Added C11 <complex.h>, along with CMPLX creal cimag conj

### DIFF
--- a/src/libc/cimagf.src
+++ b/src/libc/cimagf.src
@@ -1,0 +1,15 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_cimagf, _cimag
+
+; float cimagf(float _Complex)
+_cimagf:
+_cimag:
+	ld	iy, 0
+	add	iy, sp
+	ld	sp, iy
+	ld	hl, (iy + 7)
+	ld	e, (iy + 10)
+	ret

--- a/src/libc/cimagl.src
+++ b/src/libc/cimagl.src
@@ -1,0 +1,15 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_cimagl
+
+; long double cimagl(long double _Complex)
+_cimagl:
+	ld	iy, 0
+	add	iy, sp
+	ld	sp, iy
+	ld	hl, (iy + 11)
+	ld	de, (iy + 14)
+	ld	bc, (iy + 17)
+	ret

--- a/src/libc/cmplxf.src
+++ b/src/libc/cmplxf.src
@@ -1,0 +1,23 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_CMPLXF, _CMPLX
+
+; float _Complex CMPLXF(float x, float y) /* struct ABI */
+_CMPLXF:
+_CMPLX:
+	pop	iy, de
+	or	a, a
+	sbc	hl, hl
+	add	hl, sp
+	push	de	; ZDS II sret
+	ld	bc, 4	; sizeof(float _Complex)
+	ldir
+	; skip over the padding
+	inc	hl
+	inc	hl
+	ld	c, 4
+	ldir
+	ex	(sp), hl ; ZDS II sret
+	jp	(iy)

--- a/src/libc/cmplxl.src
+++ b/src/libc/cmplxl.src
@@ -1,0 +1,21 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_CMPLXL
+
+; long double _Complex CMPLXL(long double x, long double y) /* struct ABI */
+_CMPLXL:
+	pop	iy, de
+	or	a, a
+	sbc	hl, hl
+	add	hl, sp
+	push	de	; ZDS II sret
+	ld	bc, 8	; sizeof(long double _Complex)
+	ldir
+	; skip over the padding
+	inc	hl
+	ld	c, 8
+	ldir
+	ex	(sp), hl ; ZDS II sret
+	jp	(iy)

--- a/src/libc/conjf.src
+++ b/src/libc/conjf.src
@@ -1,0 +1,66 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_conjf, _conj
+
+; enable if fpneg is required
+if 1
+
+; float _Complex conjf(float _Complex) /* struct ABI */
+_conjf:
+_conj:
+	pop	iy, de
+	ld	hl, 7
+	add	hl, sp
+
+	; negate the complex part
+	ld	a, (hl)
+	or	a, a
+	jr	nz, .do_fpneg
+	; test if value is +0.0f
+	push	hl
+	dec	hl
+	dec	hl
+	dec	hl
+	ld	bc, (hl)
+	sbc	hl, hl
+	sbc	hl, bc
+	pop	hl
+	jr	z, .skip_fpneg
+.do_fpneg:
+	xor	a, $80
+	ld	(hl), a
+.skip_fpneg:
+
+	ld	bc, 8	; sizeof(float _Complex)
+	sbc	hl, bc
+	inc	hl	; hl = sp + 0
+	push	de	; ZDS II sret
+	ldir
+	ex	de, hl
+	ex	(sp), hl ; ZDS II sret
+	jp	(iy)
+
+else
+
+; float _Complex conjf(float _Complex) /* struct ABI */
+_conjf:
+_conj:
+	pop	iy, de
+	ld	hl, 7
+	add	hl, sp
+	ld	a, (hl)
+	xor	a, $80	; negate imag-part
+	ld	(hl), a
+
+	ld	bc, 8	; sizeof(float _Complex)
+	sbc	hl, bc
+	inc	hl	; hl = sp + 0
+	push	de	; ZDS II sret
+	ldir
+	ex	de, hl
+	ex	(sp), hl ; ZDS II sret
+	jp	(iy)
+
+end if

--- a/src/libc/conjl.src
+++ b/src/libc/conjl.src
@@ -1,0 +1,23 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_conjl
+
+; long double _Complex conjl(long double _Complex) /* struct ABI */
+_conjl:
+	pop	iy, de
+	ld	hl, 15
+	add	hl, sp
+	ld	a, (hl)
+	xor	a, $80	; negate imag-part
+	ld	(hl), a
+
+	ld	bc, 16	; sizeof(long double _Complex)
+	sbc	hl, bc
+	inc	hl	; hl = sp + 0
+	push	de	; ZDS II sret
+	ldir
+	ex	de, hl
+	ex	(sp), hl ; ZDS II sret
+	jp	(iy)

--- a/src/libc/crealf.src
+++ b/src/libc/crealf.src
@@ -1,0 +1,12 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_crealf, _creal
+
+; float crealf(float _Complex)
+_crealf:
+_creal:
+	pop	bc, hl, de
+	push	de, hl, bc
+	ret

--- a/src/libc/creall.src
+++ b/src/libc/creall.src
@@ -1,0 +1,11 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_creall
+
+; long double creall(long double _Complex)
+_creall:
+	pop	iy, hl, de, bc
+	push	bc, de, hl
+	jp	(iy)

--- a/src/libc/header_test.c
+++ b/src/libc/header_test.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <byteswap.h>
 #include <cdefs.h>
+#include <complex.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fenv.h>

--- a/src/libc/include/complex.h
+++ b/src/libc/include/complex.h
@@ -1,0 +1,124 @@
+#ifndef _COMPLEX_H
+#define _COMPLEX_H
+
+#ifndef __FAST_MATH__
+#warning "-ffast-math is required for complex multiplication and division to work properly at this time"
+#endif
+
+#ifndef __cplusplus
+#define complex _Complex
+#endif
+
+#ifdef _Imaginary
+#define imaginary _Imaginary
+#endif
+
+#ifndef I
+# ifdef _Imaginary_I
+#  define I _Imaginary_I
+# else
+#  define I _Complex_I
+# endif
+#endif
+
+double _Complex CMPLX(double x, double y);
+float _Complex CMPLXF(float x, float y);
+long double _Complex CMPLXL(long double x, long double y);
+
+#ifdef _Imaginary_I
+
+#define CMPLX(x, y) ((double _Complex)((double)(x) + _Imaginary_I * (double)(y)))
+#define CMPLXF(x, y) ((float _Complex)((float)(x) + _Imaginary_I * (float)(y)))
+#define CMPLXL(x, y) ((long double _Complex)((long double)(x) + _Imaginary_I * (long double)(y)))
+
+#endif /* _Imaginary_I */
+
+double creal(double _Complex);
+float crealf(float _Complex);
+long double creall(long double _Complex);
+
+double cimag(double _Complex);
+float cimagf(float _Complex);
+long double cimagl(long double _Complex);
+
+double cabs(double _Complex);
+float cabsf(float _Complex);
+long double cabsl(long double _Complex);
+
+double carg(double _Complex);
+float cargf(float _Complex);
+long double cargl(long double _Complex);
+
+double _Complex conj(double _Complex);
+float _Complex conjf(float _Complex);
+long double _Complex conjl(long double _Complex);
+
+double _Complex cproj(double _Complex);
+float _Complex cprojf(float _Complex);
+long double _Complex cprojl(long double _Complex);
+
+double _Complex csqrt(double _Complex);
+float _Complex csqrtf(float _Complex);
+long double _Complex csqrtl(long double _Complex);
+
+double _Complex cexp(double _Complex);
+float _Complex cexpf(float _Complex);
+long double _Complex cexpl(long double _Complex);
+
+double _Complex clog(double _Complex);
+float _Complex clogf(float _Complex);
+long double _Complex clogl(long double _Complex);
+
+double _Complex cpow(double _Complex, double _Complex);
+float _Complex cpowf(float _Complex, float _Complex);
+long double _Complex cpowl(long double _Complex, long double _Complex);
+
+double _Complex csin(double _Complex);
+float _Complex csinf(float _Complex);
+long double _Complex csinl(long double _Complex);
+
+double _Complex ccos(double _Complex);
+float _Complex ccosf(float _Complex);
+long double _Complex ccosl(long double _Complex);
+
+double _Complex ctan(double _Complex);
+float _Complex ctanf(float _Complex);
+long double _Complex ctanl(long double _Complex);
+
+double _Complex casin(double _Complex);
+float _Complex casinf(float _Complex);
+long double _Complex casinl(long double _Complex);
+
+double _Complex cacos(double _Complex);
+float _Complex cacosf(float _Complex);
+long double _Complex cacosl(long double _Complex);
+
+double _Complex catan(double _Complex);
+float _Complex catanf(float _Complex);
+long double _Complex catanl(long double _Complex);
+
+double _Complex csinh(double _Complex);
+float _Complex csinhf(float _Complex);
+long double _Complex csinhl(long double _Complex);
+
+double _Complex ccosh(double _Complex);
+float _Complex ccoshf(float _Complex);
+long double _Complex ccoshl(long double _Complex);
+
+double _Complex ctanh(double _Complex);
+float _Complex ctanhf(float _Complex);
+long double _Complex ctanhl(long double _Complex);
+
+double _Complex casinh(double _Complex);
+float _Complex casinhf(float _Complex);
+long double _Complex casinhl(long double _Complex);
+
+double _Complex cacosh(double _Complex);
+float _Complex cacoshf(float _Complex);
+long double _Complex cacoshl(long double _Complex);
+
+double _Complex catanh(double _Complex);
+float _Complex catanhf(float _Complex);
+long double _Complex catanhl(long double _Complex);
+
+#endif /* _COMPLEX_H */

--- a/test/floating_point/complex/autotest.json
+++ b/test/floating_point/complex/autotest.json
@@ -1,0 +1,43 @@
+{
+	"transfer_files": [
+	  "bin/DEMO.8xp"
+	],
+	"target": {
+	  "name": "DEMO",
+	  "isASM": true
+	},
+	"sequence": [
+	  "action|launch",
+	  "delay|1000",
+	  "hashWait|1",
+	  "key|enter",
+	  "delay|200",
+	  "hashWait|2"
+	],
+	"hashes": {
+	  "1": {
+		"description": "All tests passed or GDB1 error",
+		"timeout": 5000,
+		"start": "vram_start",
+		"size": "vram_16_size",
+		"expected_CRCs": [
+		  "38E2AD5A",
+		  "2C812DC2"
+		]
+	  },
+	  "2": {
+		"description": "Exit or GDB1 error",
+		"start": "vram_start",
+		"size": "vram_16_size",
+		"expected_CRCs": [
+		  "FFAF89BA",
+		  "101734A5",
+		  "9DA19F44",
+		  "A32840C8",
+		  "349F4775",
+		  "271A9FBF",
+		  "82FD0B1E"
+		]
+	  }
+	}
+}

--- a/test/floating_point/complex/makefile
+++ b/test/floating_point/complex/makefile
@@ -1,0 +1,17 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+
+CFLAGS = -Wall -Wextra -Wshadow -Wimplicit-float-conversion -Wimplicit-int-float-conversion -std=c17 -Ofast
+CXXFLAGS = -Wall -Wextra -Wshadow -Wimplicit-float-conversion -Wimplicit-int-float-conversion -std=c++20 -Ofast
+
+PREFER_OS_LIBC = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/floating_point/complex/src/complex_alias.asm
+++ b/test/floating_point/complex/src/complex_alias.asm
@@ -1,0 +1,29 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_T_CMPLXF, _T_CMPLX, _T_CMPLXL
+	public	_T_creal, _T_crealf, _T_creall
+	public	_T_cimag, _T_cimagf, _T_cimagl
+	public	_T_conj, _T_conjf, _T_conjl
+
+_T_CMPLXF := _CMPLXF
+_T_CMPLX := _CMPLX
+_T_CMPLXL := _CMPLXL
+
+_T_creal := _creal
+_T_crealf := _crealf
+_T_creall := _creall
+
+_T_cimag := _cimag
+_T_cimagf := _cimagf
+_T_cimagl := _cimagl
+
+_T_conj := _conj
+_T_conjf := _conjf
+_T_conjl := _conjl
+
+	extern	_CMPLXF, _CMPLX, _CMPLXL
+	extern	_creal, _crealf, _creall
+	extern	_cimag, _cimagf, _cimagl
+	extern	_conj, _conjf, _conjl

--- a/test/floating_point/complex/src/main.c
+++ b/test/floating_point/complex/src/main.c
@@ -1,0 +1,202 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+
+#include <complex.h>
+
+typedef union CF32_pun {
+    float complex c;
+    float f[2];
+} CF32_pun;
+
+static_assert(sizeof(CF32_pun) == sizeof(float) * 2, "sizeof(float _Complex) has changed");
+
+typedef union CFD2_pun {
+    double complex c;
+    double f[2];
+} CD32_pun;
+
+static_assert(sizeof(CD32_pun) == sizeof(double) * 2, "sizeof(double _Complex) has changed");
+
+
+typedef union CF64_pun {
+    long double complex c;
+    long double f[2];
+} CF64_pun;
+
+static_assert(sizeof(CF64_pun) == sizeof(long double) * 2, "sizeof(long double _Complex) has changed");
+
+#define CF32_RE (1.23f)
+#define CF32_IM (-4.56f)
+
+#define CD32_RE (1.23)
+#define CD32_IM (-4.56)
+
+#define CF64_RE (1.23L)
+#define CF64_IM (-4.56L)
+
+double _Complex T_CMPLX(double x, double y);
+float _Complex T_CMPLXF(float x, float y);
+long double _Complex T_CMPLXL(long double x, long double y);
+
+double T_creal(double _Complex);
+float T_crealf(float _Complex);
+long double T_creall(long double _Complex);
+
+double T_cimag(double _Complex);
+float T_cimagf(float _Complex);
+long double T_cimagl(long double _Complex);
+
+double _Complex T_conj(double _Complex);
+float _Complex T_conjf(float _Complex);
+long double _Complex T_conjl(long double _Complex);
+
+static size_t run_test(void) {
+    /* test float _Complex without any Clang chicanery */
+    {
+        CF32_pun c32;
+        c32.c = T_CMPLXF(CF32_RE, CF32_IM);
+        if (c32.f[0] != CF32_RE) { return __LINE__; }
+        if (c32.f[1] != CF32_IM) { return __LINE__; }
+        if (T_crealf(c32.c) != CF32_RE) { return __LINE__; }
+        if (T_cimagf(c32.c) != CF32_IM) { return __LINE__; }
+        c32.c = conjf(c32.c);
+        if (c32.f[0] != CF32_RE) { return __LINE__; }
+        if (c32.f[1] != -CF32_IM) { return __LINE__; }
+        if (T_crealf(c32.c) != CF32_RE) { return __LINE__; }
+        if (T_cimagf(c32.c) != -CF32_IM) { return __LINE__; }
+        c32.c = T_conjf(T_CMPLXF(T_cimagf(c32.c), T_crealf(c32.c)));
+        if (T_crealf(c32.c) != -CF32_IM) { return __LINE__; }
+        if (T_cimagf(c32.c) != -CF32_RE) { return __LINE__; }
+    }
+
+    /* test double _Complex without any Clang chicanery */
+    {
+        CD32_pun c32;
+        c32.c = T_CMPLX(CD32_RE, CD32_IM);
+        if (c32.f[0] != CD32_RE) { return __LINE__; }
+        if (c32.f[1] != CD32_IM) { return __LINE__; }
+        if (T_creal(c32.c) != CD32_RE) { return __LINE__; }
+        if (T_cimag(c32.c) != CD32_IM) { return __LINE__; }
+        c32.c = conj(c32.c);
+        if (c32.f[0] != CD32_RE) { return __LINE__; }
+        if (c32.f[1] != -CD32_IM) { return __LINE__; }
+        if (T_creal(c32.c) != CD32_RE) { return __LINE__; }
+        if (T_cimag(c32.c) != -CD32_IM) { return __LINE__; }
+        c32.c = T_conj(T_CMPLX(T_cimag(c32.c), T_creal(c32.c)));
+        if (T_creal(c32.c) != -CD32_IM) { return __LINE__; }
+        if (T_cimag(c32.c) != -CD32_RE) { return __LINE__; }
+    }
+
+    /* test long double _Complex without any Clang chicanery */
+    {
+        CF64_pun c64;
+        c64.c = T_CMPLXL(CF64_RE, CF64_IM);
+        if (c64.f[0] != CF64_RE) { return __LINE__; }
+        if (c64.f[1] != CF64_IM) { return __LINE__; }
+        if (T_creall(c64.c) != CF64_RE) { return __LINE__; }
+        if (T_cimagl(c64.c) != CF64_IM) { return __LINE__; }
+        c64.c = T_conjl(c64.c);
+        if (c64.f[0] != CF64_RE) { return __LINE__; }
+        if (c64.f[1] != -CF64_IM) { return __LINE__; }
+        if (T_creall(c64.c) != CF64_RE) { return __LINE__; }
+        if (T_cimagl(c64.c) != -CF64_IM) { return __LINE__; }
+        c64.c = T_conjl(T_CMPLXL(T_cimagl(c64.c), T_creall(c64.c)));
+        if (T_creall(c64.c) != -CF64_IM) { return __LINE__; }
+        if (T_cimagl(c64.c) != -CF64_RE) { return __LINE__; }
+    }
+
+    /* special zero test for TiOS floats (-0.0f != +0.0f) */
+    {
+        CF32_pun c32;
+        c32.c = T_CMPLXF(0.0f, 0.0f);
+        if (c32.f[0] != 0.0f) { return __LINE__; }
+        if (c32.f[1] != 0.0f) { return __LINE__; }
+        if (T_crealf(c32.c) != 0.0f) { return __LINE__; }
+        if (T_cimagf(c32.c) != 0.0f) { return __LINE__; }
+        c32.c = conjf(c32.c); /* ensure that fneg is skipped for +0.0f */
+        if (c32.f[0] != 0.0f) { return __LINE__; }
+        if (c32.f[1] != 0.0f) { return __LINE__; } /* fails if c32.f[1] == -0.0f */
+        if (T_crealf(c32.c) != 0.0f) { return __LINE__; }
+        if (T_cimagf(c32.c) != 0.0f) { return __LINE__; }
+        c32.c = T_conjf(T_CMPLXF(T_cimagf(c32.c), T_crealf(c32.c)));
+        if (T_crealf(c32.c) != 0.0f) { return __LINE__; }
+        if (T_cimagf(c32.c) != 0.0f) { return __LINE__; }
+    }
+
+    /* test if Clang handles float _Complex correctly */
+    {
+        CF32_pun c32;
+        c32.c = CMPLXF(CF32_RE, CF32_IM);
+        if (c32.f[0] != CF32_RE) { return __LINE__; }
+        if (c32.f[1] != CF32_IM) { return __LINE__; }
+        if (crealf(c32.c) != CF32_RE) { return __LINE__; }
+        if (cimagf(c32.c) != CF32_IM) { return __LINE__; }
+        c32.c = conjf(c32.c);
+        if (c32.f[0] != CF32_RE) { return __LINE__; }
+        if (c32.f[1] != -CF32_IM) { return __LINE__; }
+        if (crealf(c32.c) != CF32_RE) { return __LINE__; }
+        if (cimagf(c32.c) != -CF32_IM) { return __LINE__; }
+        c32.c = conjf(CMPLXF(cimagf(c32.c), crealf(c32.c)));
+        if (crealf(c32.c) != -CF32_IM) { return __LINE__; }
+        if (cimagf(c32.c) != -CF32_RE) { return __LINE__; }
+    }
+
+    /* test if Clang handles double _Complex correctly */
+    {
+        CD32_pun c32;
+        c32.c = CMPLX(CD32_RE, CD32_IM);
+        if (c32.f[0] != CD32_RE) { return __LINE__; }
+        if (c32.f[1] != CD32_IM) { return __LINE__; }
+        if (creal(c32.c) != CD32_RE) { return __LINE__; }
+        if (cimag(c32.c) != CD32_IM) { return __LINE__; }
+        c32.c = conj(c32.c);
+        if (c32.f[0] != CD32_RE) { return __LINE__; }
+        if (c32.f[1] != -CD32_IM) { return __LINE__; }
+        if (creal(c32.c) != CD32_RE) { return __LINE__; }
+        if (cimag(c32.c) != -CD32_IM) { return __LINE__; }
+        c32.c = conj(CMPLX(cimag(c32.c), creal(c32.c)));
+        if (creal(c32.c) != -CD32_IM) { return __LINE__; }
+        if (cimag(c32.c) != -CD32_RE) { return __LINE__; }
+    }
+
+    /* test if Clang handles long double _Complex correctly */
+    {
+        CF64_pun c64;
+        c64.c = CMPLXL(CF64_RE, CF64_IM);
+        if (c64.f[0] != CF64_RE) { return __LINE__; }
+        if (c64.f[1] != CF64_IM) { return __LINE__; }
+        if (creall(c64.c) != CF64_RE) { return __LINE__; }
+        if (cimagl(c64.c) != CF64_IM) { return __LINE__; }
+        c64.c = conjl(c64.c);
+        if (c64.f[0] != CF64_RE) { return __LINE__; }
+        if (c64.f[1] != -CF64_IM) { return __LINE__; }
+        if (creall(c64.c) != CF64_RE) { return __LINE__; }
+        if (cimagl(c64.c) != -CF64_IM) { return __LINE__; }
+        c64.c = conjl(CMPLXL(cimagl(c64.c), creall(c64.c)));
+        if (creall(c64.c) != -CF64_IM) { return __LINE__; }
+        if (cimagl(c64.c) != -CF64_RE) { return __LINE__; }
+    }
+
+    /* passed all */
+    return SIZE_MAX;
+}
+
+int main(void) {
+    os_ClrHome();
+    size_t fail_index = run_test();
+    if (fail_index == SIZE_MAX) {
+        printf("All tests passed");
+    } else {
+        printf("Failed test: L%zu\n", fail_index);
+    }
+
+    while (!os_GetCSC());
+
+    return 0;
+}


### PR DESCRIPTION
Added C11 `<complex.h>` prototypes and implemented `CMPLX creal cimag conj` in assembly.

Notes:
* `I` is defined to `_Complex_I`
* `#define complex _Complex` is skipped in C++ to avoid conflicts with `<complex>`/`<ccomplex>` should they be implemented.
* `__mulsc3 __divsc3 __muldc3 __divdc3` are not implemented yet, so I added a warning stating that complex multiplication and division can only be done with `-ffast-math` applied when `<complex.h>` is included.
* `<complex.h>` has not been added to `<tgmath.h>`