### PR TITLE
float classification is now constexpr, added sinpi/cospi functions

### DIFF
--- a/src/libc/include/__math_def.h
+++ b/src/libc/include/__math_def.h
@@ -110,6 +110,10 @@ double      cos(double);
 float       cosf(float);
 long double cosl(long double);
 
+double      cospi(double);
+float       cospif(float);
+long double cospil(long double);
+
 double      cosh(double);
 float       coshf(float);
 long double coshl(long double);
@@ -289,6 +293,10 @@ double      sin(double);
 float       sinf(float);
 long double sinl(long double);
 
+double      sinpi(double);
+float       sinpif(float);
+long double sinpil(long double);
+
 double      sinh(double);
 float       sinhf(float);
 long double sinhl(long double);
@@ -300,6 +308,10 @@ long double sqrtl(long double);
 double      tan(double);
 float       tanf(float);
 long double tanl(long double);
+
+double      tanpi(double);
+float       tanpif(float);
+long double tanpil(long double);
 
 double      tanh(double);
 float       tanhf(float);

--- a/src/libc/include/__math_def.h
+++ b/src/libc/include/__math_def.h
@@ -1,6 +1,7 @@
 #ifndef _MATH_DEF_H
 #define _MATH_DEF_H
 
+#include <cdefs.h>
 #include <stdbool.h>
 
 #define NAN          __builtin_nanf("")
@@ -40,30 +41,30 @@ typedef double double_t;
 extern "C" {
 #endif
 
-int _fpclassifyf(float n);
-int _fpclassifyl(long double n);
+int _fpclassifyf(float) __NOEXCEPT_CONST;
+int _fpclassifyl(long double) __NOEXCEPT_CONST;
 
-bool _isinff(float n);
-bool _isnanf(float n);
-bool _isnormalf(float n);
-bool _isfinitef(float n);
-bool _iszerof(float n);
-bool _issubnormalf(float n);
+bool _isinff(float) __NOEXCEPT_CONST;
+bool _isnanf(float) __NOEXCEPT_CONST;
+bool _isnormalf(float) __NOEXCEPT_CONST;
+bool _isfinitef(float) __NOEXCEPT_CONST;
+bool _iszerof(float) __NOEXCEPT_CONST;
+bool _issubnormalf(float) __NOEXCEPT_CONST;
 
-int _isinfl(long double n);
-int _isnanl(long double n);
-bool _isnormall(long double n);
-bool _isfinitel(long double n);
-int _iszerol(long double n);
-int _issubnormall(long double n);
+int _isinfl(long double) __NOEXCEPT_CONST;
+int _isnanl(long double) __NOEXCEPT_CONST;
+bool _isnormall(long double) __NOEXCEPT_CONST;
+bool _isfinitel(long double) __NOEXCEPT_CONST;
+int _iszerol(long double) __NOEXCEPT_CONST;
+int _issubnormall(long double) __NOEXCEPT_CONST;
 
 #if 0
 /* disabled until builtin is optimized */
 #define _signbitf(x) __builtin_signbit(x)
 #define _signbitl(x) __builtin_signbit(x)
 #else
-bool _signbitf(float x);
-bool _signbitl(long double x);
+bool _signbitf(float) __NOEXCEPT_CONST;
+bool _signbitl(long double) __NOEXCEPT_CONST;
 #endif
 
 double      acos(double);
@@ -327,9 +328,9 @@ long double truncl(long double);
 
 /* aliases */
 
-long double _debug_fabsl(long double);
+long double _debug_fabsl(long double) __NOEXCEPT_CONST;
 #define fabsl _debug_fabsl
-long double _debug_copysignl(long double, long double);
+long double _debug_copysignl(long double, long double) __NOEXCEPT_CONST;
 #define copysignl _debug_copysignl
 long double _debug_fmaxl(long double, long double);
 #define fmaxl _debug_fmaxl

--- a/src/libc/include/__math_def.h
+++ b/src/libc/include/__math_def.h
@@ -51,12 +51,12 @@ bool _isfinitef(float) __NOEXCEPT_CONST;
 bool _iszerof(float) __NOEXCEPT_CONST;
 bool _issubnormalf(float) __NOEXCEPT_CONST;
 
-int _isinfl(long double) __NOEXCEPT_CONST;
-int _isnanl(long double) __NOEXCEPT_CONST;
+bool _isinfl(long double) __NOEXCEPT_CONST;
+bool _isnanl(long double) __NOEXCEPT_CONST;
 bool _isnormall(long double) __NOEXCEPT_CONST;
 bool _isfinitel(long double) __NOEXCEPT_CONST;
-int _iszerol(long double) __NOEXCEPT_CONST;
-int _issubnormall(long double) __NOEXCEPT_CONST;
+bool _iszerol(long double) __NOEXCEPT_CONST;
+bool _issubnormall(long double) __NOEXCEPT_CONST;
 
 #if 0
 /* disabled until builtin is optimized */

--- a/src/libc/include/__math_def.h
+++ b/src/libc/include/__math_def.h
@@ -43,17 +43,17 @@ extern "C" {
 int _fpclassifyf(float n);
 int _fpclassifyl(long double n);
 
-int _isinff(float n);
-int _isnanf(float n);
-int _isnormalf(float n);
-int _isfinitef(float n);
-int _iszerof(float n);
-int _issubnormalf(float n);
+bool _isinff(float n);
+bool _isnanf(float n);
+bool _isnormalf(float n);
+bool _isfinitef(float n);
+bool _iszerof(float n);
+bool _issubnormalf(float n);
 
 int _isinfl(long double n);
 int _isnanl(long double n);
-int _isnormall(long double n);
-int _isfinitel(long double n);
+bool _isnormall(long double n);
+bool _isfinitel(long double n);
 int _iszerol(long double n);
 int _issubnormall(long double n);
 

--- a/src/libc/include/cdefs.h
+++ b/src/libc/include/cdefs.h
@@ -25,6 +25,9 @@
 # define __NOEXCEPT __attribute__((__nothrow__, __leaf__))
 #endif /* __cplusplus */
 
+#define __NOEXCEPT_CONST __NOEXCEPT __attribute__((__const__))
+#define __NOEXCEPT_PURE __NOEXCEPT __attribute__((__pure__))
+
 #ifndef NULL
 # ifndef __cplusplus
 #  define NULL ((void *)0)

--- a/src/libc/include/inttypes.h
+++ b/src/libc/include/inttypes.h
@@ -177,11 +177,9 @@ typedef struct {
 
 __BEGIN_DECLS
 
-extern intmax_t imaxabs(intmax_t __n)
-    __NOEXCEPT __attribute__((__const__));
+extern intmax_t imaxabs(intmax_t __n) __NOEXCEPT_CONST;
 
-extern imaxdiv_t imaxdiv(intmax_t __numer, intmax_t __denom)
-    __NOEXCEPT __attribute__((__const__));
+extern imaxdiv_t imaxdiv(intmax_t __numer, intmax_t __denom) __NOEXCEPT_CONST;
 
 intmax_t strtoimax(
     const char *__restrict nptr,

--- a/src/libc/include/stdlib.h
+++ b/src/libc/include/stdlib.h
@@ -108,7 +108,7 @@ long labs(long n);
 long long llabs(long long n);
 
 #ifdef __SIZEOF_INT48__
-signed __int48 i48abs(signed __int48 n);
+signed __int48 i48abs(signed __int48 n) __NOEXCEPT_CONST;
 #endif /* __SIZEOF_INT48__ */
 
 #endif /* _ABS_INT_DEFINED */
@@ -120,7 +120,7 @@ ldiv_t ldiv(long numer, long denom);
 lldiv_t lldiv(long long numer, long long denom);
 
 #ifdef __SIZEOF_INT48__
-i48div_t i48div(signed __int48 numer, signed __int48 denom);
+i48div_t i48div(signed __int48 numer, signed __int48 denom) __NOEXCEPT_CONST;
 #endif /* __SIZEOF_INT48__ */
 
 __END_DECLS

--- a/src/libc/include/tgmath.h
+++ b/src/libc/include/tgmath.h
@@ -71,6 +71,12 @@
     float: cosf \
 )(x)
 
+#define cospi(x) _Generic(__tgmath_promote(x), \
+    long double: cospil, \
+    default: cospi, \
+    float: cospif \
+)(x)
+
 #define cosh(x) _Generic(__tgmath_promote(x), \
     long double: coshl, \
     default: cosh, \
@@ -227,6 +233,12 @@
     float: sinf \
 )(x)
 
+#define sinpi(x) _Generic(__tgmath_promote(x), \
+    long double: sinpil, \
+    default: sinpi, \
+    float: sinpif \
+)(x)
+
 #define sinh(x) _Generic(__tgmath_promote(x), \
     long double: sinhl, \
     default: sinh, \
@@ -243,6 +255,12 @@
     long double: tanl, \
     default: tan, \
     float: tanf \
+)(x)
+
+#define tanpi(x) _Generic(__tgmath_promote(x), \
+    long double: tanpil, \
+    default: tanpi, \
+    float: tanpif \
 )(x)
 
 #define tanh(x) _Generic(__tgmath_promote(x), \

--- a/src/libc/isfinitef.src
+++ b/src/libc/isfinitef.src
@@ -1,19 +1,17 @@
 	assume	adl=1
 
 	section	.text
+
 	public	__isfinitef
+
+; bool _isfinitef(float)
 __isfinitef:
-	pop	bc
-	pop	hl
-	pop	de
-	push	de
-	push	hl
-	push	bc
-	add	hl,hl
-	ld	a,e
-	rla
-	add	a,1
-	sbc	hl,hl
-	inc	hl
+	ld	hl, 5
+	add	hl, sp
+	ld	hl, (hl)
+	add	hl, hl
+	ld	a, h
+	sub	a, $FF	; NaN/inf exponent won't underflow
+	sbc	a, a
 	ret
 

--- a/src/libc/isfinitel.src
+++ b/src/libc/isfinitel.src
@@ -4,7 +4,7 @@
 
 	public	__isfinitel
 
-; int _isfinitel(long double)
+; bool _isfinitel(long double)
 __isfinitel:
 	ld	hl, 8
 	add	hl, sp
@@ -12,6 +12,6 @@ __isfinitel:
 	add	hl, hl	; clears signbit
 	ld	de, $2000	; (1 << (5 + 8))
 	add	hl, de	; attempts to overflow the exponent
-	sbc	hl, hl
-	inc	hl
+	sbc	a, a
+	inc	a
 	ret

--- a/src/libc/isinff.src
+++ b/src/libc/isinff.src
@@ -1,19 +1,20 @@
 	assume	adl=1
 
 	section	.text
+
 	public	__isinff
+
+; bool _isinff(float)
 __isinff:
-	ld	iy,0
-	add	iy,sp
-	ld	hl,(iy+3)
-	adc	hl,hl
-	jr	nz,.finite
-	ld	a,(iy+6)
+	xor	a, a
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy+3)
+	adc	hl, hl
+	ret	nz	; finite or NaN
+	; HL is zero
+	ld	a, (iy+6)
 	rla
-	inc	a
-	inc	hl
-	ret	z
-.finite:
-	or	a,a
-	sbc	hl,hl
+	add	a, 1	; attempt to overflow the exponent
+	sbc	a, a
 	ret

--- a/src/libc/isinfl.src
+++ b/src/libc/isinfl.src
@@ -4,7 +4,7 @@
 
 	public	__isinfl
 
-; int _isinfl(long double)
+; bool _isinfl(long double)
 __isinfl:
 	pop	bc, hl, de
 	xor	a, a

--- a/src/libc/isinfl.src
+++ b/src/libc/isinfl.src
@@ -7,24 +7,17 @@
 ; int _isinfl(long double)
 __isinfl:
 	pop	bc, hl, de
-	or	a, a
+	xor	a, a
 	adc	hl, de
 	pop	de
 	push	bc, bc, bc, bc
-	jr	nz, .mant_nonzero
-	jr	c, .mant_carry
+	ret	nz	; mant_nonzero
+	ret	c	; mant_carry
 	ld	a, e
-	xor	a, $F0
-	ret	nz	; mantissa is non-zero
-	; A is zero here
+	xor	a, $F0	; sets A to zero if the bit pattern matches infinity
 	set	7, d
-	inc	d
-	ret	nz
-	inc	hl
-	ret
-	
-.mant_nonzero:
-.mant_carry:
-	or	a, a
-	sbc	hl, hl
+	inc	d	; set d to zero if it matches infinity
+	or	a, d
+	sub	a, 1
+	sbc	a, a
 	ret

--- a/src/libc/isnanf.src
+++ b/src/libc/isnanf.src
@@ -1,20 +1,19 @@
 	assume	adl=1
 
 	section	.text
-	
+
 	public	__isnanf
-	
+
+; bool _isnanf(float)
 __isnanf:
-	ld	iy,0
-	add	iy,sp
-	ld	hl,(iy+3)
-	adc	hl,hl
-	jr	z,.l
-	ld	hl,(iy+5)
-	add	hl,hl
-.l:
-	inc	h
-	ld	hl,0
-	ret	nz
-	inc	hl
+	xor	a, a
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy+3)
+	adc	hl, hl
+	ret	z	; infinity
+	ld	a, (iy+6)
+	rla
+	add	a, 1	; attempt to overflow the exponent
+	sbc	a, a
 	ret

--- a/src/libc/isnanl.src
+++ b/src/libc/isnanl.src
@@ -15,19 +15,15 @@ __isnanl:
 	jr	nz, .mant_nonzero	; normal, subnormal, or NaN
 	jr	c, .mant_nonzero	; normal, subnormal, or NaN
 	; common NaN, inf, normal, or subnormal
-	add	a, 15	; overflows 0xF1
-	jr	c, .skip_exp_check
-	ret
-.mant_nonzero:
 	or	a, a
-	sbc	hl, hl
+	ret	z
+	dec	a
+.mant_nonzero:
 	add	a, 16	; overflows 0xF0
-	ret	nc
-.skip_exp_check:
-	; carry is set here
+	sbc	a, a
+	ret	z
 	ld	a, d
-	rla	; A should be all ones if D was all ones
-	inc	a
-	ret	nz
-	inc	hl
+	add	a, a
+	add	a, 2
+	sbc	a, a
 	ret

--- a/src/libc/isnanl.src
+++ b/src/libc/isnanl.src
@@ -4,7 +4,7 @@
 
 	public	__isnanl
 
-; int _isnanl(long double)
+; bool _isnanl(long double)
 __isnanl:
 	pop	bc, hl, de
 	or	a, a

--- a/src/libc/isnormalf.src
+++ b/src/libc/isnormalf.src
@@ -4,7 +4,7 @@
 	
 	public	__isnormalf
 	
-; int _isnormalf(float)
+; bool _isnormalf(float)
 __isnormalf:
 	ld	hl, 5
 	add	hl, sp
@@ -13,6 +13,5 @@ __isnormalf:
 	ld	a, h
 	dec	a
 	cp	a, $FE	; tests for zero/denormal/inf/NaN exponents
-	sbc	hl, hl	; -1 if normal, 0 otherwise
+	sbc	a, a	; -1 if normal, 0 otherwise
 	ret
-

--- a/src/libc/isnormall.src
+++ b/src/libc/isnormall.src
@@ -4,7 +4,7 @@
 	
 	public	__isnormall
 
-; int _isnormall(long double)
+; bool _isnormall(long double)
 __isnormall:
 	; load upper 24bits
 	ld	hl, 8	
@@ -24,6 +24,6 @@ __isnormall:
 
 .exp_all_ones:
 .exp_all_zero:
-	sbc	hl, hl
-	inc	hl
+	sbc	a, a
+	inc	a
 	ret

--- a/src/libc/issubnormalf.src
+++ b/src/libc/issubnormalf.src
@@ -4,16 +4,16 @@
 
 	public	__issubnormalf
 
-; int _issubnormalf(float)
+; bool _issubnormalf(float)
 __issubnormalf:
-	pop	bc, hl, de
-	push	de, hl, bc
-	or	a, a
+	xor	a, a
+	pop	bc, hl
 	adc	hl, hl
-	ret z	; zero mantissa is not subnormal
-	ld	a, e
-	adc	a, a
-	ret z	; zero exponent is subnormal
-	or	a, a
-	sbc	hl, hl
+	ex	(sp), hl
+	push	hl, bc
+	ret	z	; zero mantissa is not subnormal
+	adc	hl, hl
+	sub	a, l
+	sbc	a, a
+	inc	a
 	ret

--- a/src/libc/issubnormall.src
+++ b/src/libc/issubnormall.src
@@ -21,10 +21,8 @@ __issubnormall:
 .mant_carry:
 	ld	a, e
 	and	a, $F0
-	sbc	hl, hl
-	rra
 	res	7, d
-	add	a, d
-	ret	nz
-	inc	hl
+	or	a, d
+	sub	a, 1
+	sbc	a, a
 	ret

--- a/src/libc/issubnormall.src
+++ b/src/libc/issubnormall.src
@@ -4,7 +4,7 @@
 
 	public	__issubnormall
 
-; int _issubnormall(long double)
+; bool _issubnormall(long double)
 __issubnormall:
 	pop	bc, hl, de
 	or	a, a

--- a/src/libc/iszerof.src
+++ b/src/libc/iszerof.src
@@ -1,21 +1,19 @@
 	assume	adl=1
 
 	section	.text
-	
+
 	public	__iszerof
 
-; int iszerof(float)
+; bool _iszerof(float)
 __iszerof:
-	pop	bc, hl, de
-	push	de, hl, bc
-	or	a, a
+	xor	a, a
+	pop	bc, hl
 	adc	hl, hl
-	jr	nz, .not_zero_f32
-	rl	e
-	jr	nz, .not_zero_f32
-	inc	hl
-	ret
-.not_zero_f32:
-	or	a, a
-	sbc	hl, hl
+	ex	(sp), hl
+	push	hl, bc
+	ret	nz	; non-zero mantissa
+	ld	a, l
+	adc	a, a
+	sub a, 1
+	sbc	a, a
 	ret

--- a/src/libc/iszerol.src
+++ b/src/libc/iszerol.src
@@ -7,23 +7,16 @@
 ; int iszerol(long double)
 __iszerol:
 	pop	bc, hl, de
-	or	a, a
+	xor	a, a
 	adc	hl, de
 	pop	de
 	push	bc, bc, bc, bc
 	; return if mantissa is non-zero
-	jr	nz, .mant_nonzero
-	jr	c, .mant_carry
+	ret	nz	; mant_nonzero
+	ret	c	; mant_carry
 	ld	a, d
 	rla	; clear the signbit
 	or	a, e
-	inc	hl
-	ret	z
-	; upper 16 bits non-zero
-;	dec	hl
-;	ret
-.mant_nonzero:
-.mant_carry:
-	or	a, a
-	sbc	hl, hl
+	sub	a, 1
+	sbc	a, a
 	ret

--- a/src/libc/iszerol.src
+++ b/src/libc/iszerol.src
@@ -4,7 +4,7 @@
 	
 	public	__iszerol
 
-; int iszerol(long double)
+; bool iszerol(long double)
 __iszerol:
 	pop	bc, hl, de
 	xor	a, a

--- a/src/libc/signbitf.src
+++ b/src/libc/signbitf.src
@@ -9,6 +9,5 @@ __signbitf:
 	ld	hl, 6
 	add	hl, sp
 	ld	a, (hl)
-	rla
-	sbc	a, a
+	rlca	; faster than rla \ sbc a, a
 	ret

--- a/src/libc/signbitl.src
+++ b/src/libc/signbitl.src
@@ -9,6 +9,5 @@ __signbitl:
 	ld	hl, 10
 	add	hl, sp
 	ld	a, (hl)
-	rla
-	sbc	a, a
+	rlca	; faster than rla \ sbc a, a
 	ret

--- a/src/libc/trigpif.c
+++ b/src/libc/trigpif.c
@@ -1,0 +1,23 @@
+#include <math.h>
+#include "__float32_constants.h"
+
+static float reduce_f32(float x) {
+    // x is (-2.0, +2.0)
+    return (x - 2.0f * truncf(x * 0.5f)) * F32_PI;
+}
+
+float sinpif(float x) {
+    return sinf(reduce_f32(x));
+}
+
+float cospif(float x) {
+    return cosf(reduce_f32(x));
+}
+
+float tanpif(float x) {
+    return tanf(reduce_f32(x));
+}
+
+double sinpi(double) __attribute__((alias("sinpif")));
+double cospi(double) __attribute__((alias("cospif")));
+double tanpi(double) __attribute__((alias("tanpif")));

--- a/src/libc/trigpil.c
+++ b/src/libc/trigpil.c
@@ -1,0 +1,19 @@
+#include <math.h>
+#include "__float64_constants.h"
+
+static long double reduce_f64(long double x) {
+    // x is (-2.0, +2.0)
+    return (x - 2.0L * truncl(x * 0.5L)) * F64_PI;
+}
+
+long double sinpil(long double x) {
+    return sinl(reduce_f64(x));
+}
+
+long double cospil(long double x) {
+    return cosl(reduce_f64(x));
+}
+
+long double tanpil(long double x) {
+    return tanl(reduce_f64(x));
+}

--- a/src/libcxx/include/__abs_overloads
+++ b/src/libcxx/include/__abs_overloads
@@ -18,7 +18,7 @@ long labs(long n);
 long long llabs(long long n);
 
 #ifdef __SIZEOF_INT48__
-signed __int48 i48abs(signed __int48 n);
+signed __int48 i48abs(signed __int48 n) __NOEXCEPT_CONST;
 #endif // __SIZEOF_INT48__
 
 __END_DECLS

--- a/src/libcxx/include/cmath
+++ b/src/libcxx/include/cmath
@@ -13,153 +13,183 @@ using ::float_t;
 using ::double_t;
 
 inline constexpr bool signbit(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_signbitf(__x);
-	}
-	return static_cast<bool>(_signbitf(__x));
+    if (__builtin_constant_p(__x)) {
+        return (__builtin_copysign(1.0f, __x) < 0.0f);
+    }
+    return static_cast<bool>(_signbitf(__x));
 }
 inline constexpr bool signbit(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_signbit(__x);
-	}
-	return static_cast<bool>(_signbitf(__x));
+    if (__builtin_constant_p(__x)) {
+        return (__builtin_copysign(1.0, __x)  < 0.0);
+    }
+    return static_cast<bool>(_signbitf(__x));
 }
 inline constexpr bool signbit(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_signbitl(__x);
-	}
-	return static_cast<bool>(_signbitl(__x));
+    if (__builtin_constant_p(__x)) {
+        return (__builtin_copysign(1.0L, __x) < 0.0L);
+    }
+    return static_cast<bool>(_signbitl(__x));
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-signbit(_Tp __x) { return signbit(__x); }
+signbit(_Tp __x) { return (__x < 0); }
 
 inline constexpr bool isinf(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isinf(__x);
-	}
-	return static_cast<bool>(_isinff(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isinf(__x);
+    }
+    return static_cast<bool>(_isinff(__x));
 }
 inline constexpr bool isinf(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isinf(__x);
-	}
-	return static_cast<bool>(_isinff(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isinf(__x);
+    }
+    return static_cast<bool>(_isinff(__x));
 }
 inline constexpr bool isinf(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isinf(__x);
-	}
-	return static_cast<bool>(_isinfl(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isinf(__x);
+    }
+    return static_cast<bool>(_isinfl(__x));
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-isinf(_Tp __x) { return isinf(__x); }
+isinf(_Tp __x) { return false; }
 
 inline constexpr bool isnan(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnan(__x);
-	}
-	return static_cast<bool>(_isnanf(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnan(__x);
+    }
+    return static_cast<bool>(_isnanf(__x));
 }
 inline constexpr bool isnan(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnan(__x);
-	}
-	return static_cast<bool>(_isnanf(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnan(__x);
+    }
+    return static_cast<bool>(_isnanf(__x));
 }
 inline constexpr bool isnan(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnan(__x);
-	}
-	return static_cast<bool>(_isnanl(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnan(__x);
+    }
+    return static_cast<bool>(_isnanl(__x));
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-isnan(_Tp __x) { return isnan(__x); }
+isnan(_Tp __x) { return false; }
 
 inline constexpr bool isnormal(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnormal(__x);
-	}
-	return static_cast<bool>(_isnormalf(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnormal(__x);
+    }
+    return static_cast<bool>(_isnormalf(__x));
 }
 inline constexpr bool isnormal(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnormal(__x);
-	}
-	return static_cast<bool>(_isnormalf(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnormal(__x);
+    }
+    return static_cast<bool>(_isnormalf(__x));
 }
 inline constexpr bool isnormal(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isnormal(__x);
-	}
-	return static_cast<bool>(_isnormall(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isnormal(__x);
+    }
+    return static_cast<bool>(_isnormall(__x));
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-isnormal(_Tp __x) { return isnormal(__x); }
+isnormal(_Tp __x) { return (__x != 0); }
 
 inline constexpr bool isfinite(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isfinite(__x);
-	}
-	return static_cast<bool>(_isfinitef(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isfinite(__x);
+    }
+    return static_cast<bool>(_isfinitef(__x));
 }
 inline constexpr bool isfinite(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isfinite(__x);
-	}
-	return static_cast<bool>(_isfinitef(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isfinite(__x);
+    }
+    return static_cast<bool>(_isfinitef(__x));
 }
 inline constexpr bool isfinite(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_isfinite(__x);
-	}
-	return static_cast<bool>(_isfinitel(__x));
+    if (__builtin_constant_p(__x)) {
+        return __builtin_isfinite(__x);
+    }
+    return static_cast<bool>(_isfinitel(__x));
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-isfinite(_Tp __x) { return isfinite(__x); }
+isfinite(_Tp __x) { return true; }
 
-inline bool iszero(float __x) { return static_cast<bool>(_iszerof(__x)); }
-inline bool iszero(double __x) { return static_cast<bool>(_iszerof(__x)); }
-inline bool iszero(long double __x) { return static_cast<bool>(_iszerol(__x)); }
-template<typename _Tp> inline
+inline constexpr bool iszero(float __x) {
+    if (__builtin_constant_p(__x)) {
+        return (__x == 0.0f);
+    }
+    return static_cast<bool>(_iszerof(__x));
+}
+inline constexpr bool iszero(double __x) {
+    if (__builtin_constant_p(__x)) {
+        return (__x == 0.0);
+    }
+    return static_cast<bool>(_iszerof(__x));
+}
+inline constexpr bool iszero(long double __x) {
+    if (__builtin_constant_p(__x)) {
+        return (__x == 0.0L);
+    }
+    return static_cast<bool>(_iszerol(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-iszero(_Tp __x) { return iszero(__x); }
+iszero(_Tp __x) { return (__x == 0); }
 
-inline bool issubnormal(float __x) { return static_cast<bool>(_issubnormalf(__x)); }
-inline bool issubnormal(double __x) { return static_cast<bool>(_issubnormalf(__x)); }
-inline bool issubnormal(long double __x) { return static_cast<bool>(_issubnormall(__x)); }
-template<typename _Tp> inline
+inline constexpr bool issubnormal(float __x) {
+    if (__builtin_constant_p(__x)) {
+        return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
+    }
+    return static_cast<bool>(_issubnormalf(__x));
+}
+inline constexpr bool issubnormal(double __x) {
+    if (__builtin_constant_p(__x)) {
+        return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
+    }
+    return static_cast<bool>(_issubnormalf(__x));
+}
+inline constexpr bool issubnormal(long double __x) {
+    if (__builtin_constant_p(__x)) {
+        return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
+    }
+    return static_cast<bool>(_issubnormall(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
-issubnormal(_Tp __x) { return issubnormal(__x); }
+issubnormal(_Tp __x) { return false; }
 
 inline constexpr int fpclassify(float __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
-	} else {
-		return _fpclassifyf(__x);
-	}
+    if (__builtin_constant_p(__x)) {
+        return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+    } else {
+        return _fpclassifyf(__x);
+    }
 }
 inline constexpr int fpclassify(double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
-	} else {
-		return _fpclassifyf(__x);
-	}
+    if (__builtin_constant_p(__x)) {
+        return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+    } else {
+        return _fpclassifyf(__x);
+    }
 }
 inline constexpr int fpclassify(long double __x) {
-	if (__builtin_constant_p(__x)) {
-		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
-	} else {
-		return _fpclassifyl(__x);
-	}
+    if (__builtin_constant_p(__x)) {
+        return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+    } else {
+        return _fpclassifyl(__x);
+    }
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, int>
-fpclassify(_Tp __x) { return fpclassify(__x); }
+fpclassify(_Tp __x) { return (__x != 0) ? FP_NORMAL : FP_ZERO; }
 
 inline constexpr bool isgreater(float __x, float __y) { return __builtin_isgreater(__x, __y); }
 inline constexpr bool isgreater(double __x, double __y) { return __builtin_isgreater(__x, __y); }

--- a/src/libcxx/include/cmath
+++ b/src/libcxx/include/cmath
@@ -16,19 +16,19 @@ inline constexpr bool signbit(float __x) {
     if (__builtin_constant_p(__x)) {
         return (__builtin_copysign(1.0f, __x) < 0.0f);
     }
-    return static_cast<bool>(_signbitf(__x));
+    return _signbitf(__x);
 }
 inline constexpr bool signbit(double __x) {
     if (__builtin_constant_p(__x)) {
         return (__builtin_copysign(1.0, __x)  < 0.0);
     }
-    return static_cast<bool>(_signbitf(__x));
+    return _signbitf(__x);
 }
 inline constexpr bool signbit(long double __x) {
     if (__builtin_constant_p(__x)) {
         return (__builtin_copysign(1.0L, __x) < 0.0L);
     }
-    return static_cast<bool>(_signbitl(__x));
+    return _signbitl(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -38,19 +38,19 @@ inline constexpr bool isinf(float __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isinf(__x);
     }
-    return static_cast<bool>(_isinff(__x));
+    return _isinff(__x);
 }
 inline constexpr bool isinf(double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isinf(__x);
     }
-    return static_cast<bool>(_isinff(__x));
+    return _isinff(__x);
 }
 inline constexpr bool isinf(long double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isinf(__x);
     }
-    return static_cast<bool>(_isinfl(__x));
+    return _isinfl(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -60,19 +60,19 @@ inline constexpr bool isnan(float __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnan(__x);
     }
-    return static_cast<bool>(_isnanf(__x));
+    return _isnanf(__x);
 }
 inline constexpr bool isnan(double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnan(__x);
     }
-    return static_cast<bool>(_isnanf(__x));
+    return _isnanf(__x);
 }
 inline constexpr bool isnan(long double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnan(__x);
     }
-    return static_cast<bool>(_isnanl(__x));
+    return _isnanl(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -82,19 +82,19 @@ inline constexpr bool isnormal(float __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnormal(__x);
     }
-    return static_cast<bool>(_isnormalf(__x));
+    return _isnormalf(__x);
 }
 inline constexpr bool isnormal(double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnormal(__x);
     }
-    return static_cast<bool>(_isnormalf(__x));
+    return _isnormalf(__x);
 }
 inline constexpr bool isnormal(long double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isnormal(__x);
     }
-    return static_cast<bool>(_isnormall(__x));
+    return _isnormall(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -104,19 +104,19 @@ inline constexpr bool isfinite(float __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isfinite(__x);
     }
-    return static_cast<bool>(_isfinitef(__x));
+    return _isfinitef(__x);
 }
 inline constexpr bool isfinite(double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isfinite(__x);
     }
-    return static_cast<bool>(_isfinitef(__x));
+    return _isfinitef(__x);
 }
 inline constexpr bool isfinite(long double __x) {
     if (__builtin_constant_p(__x)) {
         return __builtin_isfinite(__x);
     }
-    return static_cast<bool>(_isfinitel(__x));
+    return _isfinitel(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -126,19 +126,19 @@ inline constexpr bool iszero(float __x) {
     if (__builtin_constant_p(__x)) {
         return (__x == 0.0f);
     }
-    return static_cast<bool>(_iszerof(__x));
+    return _iszerof(__x);
 }
 inline constexpr bool iszero(double __x) {
     if (__builtin_constant_p(__x)) {
         return (__x == 0.0);
     }
-    return static_cast<bool>(_iszerof(__x));
+    return _iszerof(__x);
 }
 inline constexpr bool iszero(long double __x) {
     if (__builtin_constant_p(__x)) {
         return (__x == 0.0L);
     }
-    return static_cast<bool>(_iszerol(__x));
+    return _iszerol(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
@@ -148,19 +148,19 @@ inline constexpr bool issubnormal(float __x) {
     if (__builtin_constant_p(__x)) {
         return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
     }
-    return static_cast<bool>(_issubnormalf(__x));
+    return _issubnormalf(__x);
 }
 inline constexpr bool issubnormal(double __x) {
     if (__builtin_constant_p(__x)) {
         return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
     }
-    return static_cast<bool>(_issubnormalf(__x));
+    return _issubnormalf(__x);
 }
 inline constexpr bool issubnormal(long double __x) {
     if (__builtin_constant_p(__x)) {
         return (FP_SUBNORMAL == __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x));
     }
-    return static_cast<bool>(_issubnormall(__x));
+    return _issubnormall(__x);
 }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>

--- a/src/libcxx/include/cmath
+++ b/src/libcxx/include/cmath
@@ -12,38 +12,113 @@ namespace std {
 using ::float_t;
 using ::double_t;
 
-inline bool signbit(float __x) { return static_cast<bool>(_signbitf(__x)); }
-inline bool signbit(double __x) { return static_cast<bool>(_signbitf(__x)); }
-inline bool signbit(long double __x) { return static_cast<bool>(_signbitl(__x)); }
-template<typename _Tp> inline
+inline constexpr bool signbit(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_signbitf(__x);
+	}
+	return static_cast<bool>(_signbitf(__x));
+}
+inline constexpr bool signbit(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_signbit(__x);
+	}
+	return static_cast<bool>(_signbitf(__x));
+}
+inline constexpr bool signbit(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_signbitl(__x);
+	}
+	return static_cast<bool>(_signbitl(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 signbit(_Tp __x) { return signbit(__x); }
 
-inline bool isinf(float __x) { return static_cast<bool>(_isinff(__x)); }
-inline bool isinf(double __x) { return static_cast<bool>(_isinff(__x)); }
-inline bool isinf(long double __x) { return static_cast<bool>(_isinfl(__x)); }
-template<typename _Tp> inline
+inline constexpr bool isinf(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isinf(__x);
+	}
+	return static_cast<bool>(_isinff(__x));
+}
+inline constexpr bool isinf(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isinf(__x);
+	}
+	return static_cast<bool>(_isinff(__x));
+}
+inline constexpr bool isinf(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isinf(__x);
+	}
+	return static_cast<bool>(_isinfl(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 isinf(_Tp __x) { return isinf(__x); }
 
-inline bool isnan(float __x) { return static_cast<bool>(_isnanf(__x)); }
-inline bool isnan(double __x) { return static_cast<bool>(_isnanf(__x)); }
-inline bool isnan(long double __x) { return static_cast<bool>(_isnanl(__x)); }
-template<typename _Tp> inline
+inline constexpr bool isnan(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnan(__x);
+	}
+	return static_cast<bool>(_isnanf(__x));
+}
+inline constexpr bool isnan(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnan(__x);
+	}
+	return static_cast<bool>(_isnanf(__x));
+}
+inline constexpr bool isnan(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnan(__x);
+	}
+	return static_cast<bool>(_isnanl(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 isnan(_Tp __x) { return isnan(__x); }
 
-inline bool isnormal(float __x) { return static_cast<bool>(_isnormalf(__x)); }
-inline bool isnormal(double __x) { return static_cast<bool>(_isnormalf(__x)); }
-inline bool isnormal(long double __x) { return static_cast<bool>(_isnormall(__x)); }
-template<typename _Tp> inline
+inline constexpr bool isnormal(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnormal(__x);
+	}
+	return static_cast<bool>(_isnormalf(__x));
+}
+inline constexpr bool isnormal(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnormal(__x);
+	}
+	return static_cast<bool>(_isnormalf(__x));
+}
+inline constexpr bool isnormal(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isnormal(__x);
+	}
+	return static_cast<bool>(_isnormall(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 isnormal(_Tp __x) { return isnormal(__x); }
 
-inline bool isfinite(float __x) { return static_cast<bool>(_isfinitef(__x)); }
-inline bool isfinite(double __x) { return static_cast<bool>(_isfinitef(__x)); }
-inline bool isfinite(long double __x) { return static_cast<bool>(_isfinitel(__x)); }
-template<typename _Tp> inline
+inline constexpr bool isfinite(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isfinite(__x);
+	}
+	return static_cast<bool>(_isfinitef(__x));
+}
+inline constexpr bool isfinite(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isfinite(__x);
+	}
+	return static_cast<bool>(_isfinitef(__x));
+}
+inline constexpr bool isfinite(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_isfinite(__x);
+	}
+	return static_cast<bool>(_isfinitel(__x));
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 isfinite(_Tp __x) { return isfinite(__x); }
 
@@ -61,10 +136,28 @@ template<typename _Tp> inline
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, bool>
 issubnormal(_Tp __x) { return issubnormal(__x); }
 
-inline int fpclassify(float __x) { return _fpclassifyf(__x); }
-inline int fpclassify(double __x) { return _fpclassifyf(__x); }
-inline int fpclassify(long double __x) { return _fpclassifyl(__x); }
-template<typename _Tp> inline
+inline constexpr int fpclassify(float __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+	} else {
+		return _fpclassifyf(__x);
+	}
+}
+inline constexpr int fpclassify(double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+	} else {
+		return _fpclassifyf(__x);
+	}
+}
+inline constexpr int fpclassify(long double __x) {
+	if (__builtin_constant_p(__x)) {
+		return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+	} else {
+		return _fpclassifyl(__x);
+	}
+}
+template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, int>
 fpclassify(_Tp __x) { return fpclassify(__x); }
 

--- a/src/libcxx/include/cmath
+++ b/src/libcxx/include/cmath
@@ -209,6 +209,15 @@ template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 cos(_Tp __x) { return cos(__x); }
 
+using ::cospi;
+using ::cospif;
+using ::cospil;
+inline float cospi(float __x) { return cospif(__x); }
+inline long double cospi(long double __x) { return cospil(__x); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
+cospi(_Tp __x) { return cospi(__x); }
+
 using ::cosh;
 using ::coshf;
 using ::coshl;
@@ -594,6 +603,15 @@ template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 sin(_Tp __x) { return sin(__x); }
 
+using ::sinpi;
+using ::sinpif;
+using ::sinpil;
+inline float sinpi(float __x) { return sinpif(__x); }
+inline long double sinpi(long double __x) { return sinpil(__x); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
+sinpi(_Tp __x) { return sinpi(__x); }
+
 using ::sinh;
 using ::sinhf;
 using ::sinhl;
@@ -620,6 +638,15 @@ inline constexpr long double tan(long double __x) { return tanl(__x); }
 template<typename _Tp> inline constexpr
 __cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
 tan(_Tp __x) { return tan(__x); }
+
+using ::tanpi;
+using ::tanpif;
+using ::tanpil;
+inline float tanpi(float __x) { return tanpif(__x); }
+inline long double tanpi(long double __x) { return tanpil(__x); }
+template<typename _Tp> inline
+__cmath_enable_if_t<__cmath_is_integral_v<_Tp>, double>
+tanpi(_Tp __x) { return tanpi(__x); }
 
 using ::tanh;
 using ::tanhf;

--- a/src/libcxx/math_test.cpp
+++ b/src/libcxx/math_test.cpp
@@ -1,0 +1,559 @@
+#include <math.h>
+#include <cmath>
+#include <tgmath.h>
+#include <ctgmath>
+#include <float.h>
+#include <cfloat>
+#include <limits>
+
+#define C(expr) static_assert(expr, #expr)
+
+//------------------------------------------------------------------------------
+// Positive value tests
+//------------------------------------------------------------------------------
+
+/* ZERO */
+
+C((!signbit    (0.0f)));
+C(( isfinite   (0.0f)));
+C((!isnan      (0.0f)));
+C((!isinf      (0.0f)));
+C((!isnormal   (0.0f)));
+C((!issubnormal(0.0f)));
+C(( iszero     (0.0f)));
+
+C((!signbit    (0.0)));
+C(( isfinite   (0.0)));
+C((!isnan      (0.0)));
+C((!isinf      (0.0)));
+C((!isnormal   (0.0)));
+C((!issubnormal(0.0)));
+C(( iszero     (0.0)));
+
+C((!signbit    (0.0L)));
+C(( isfinite   (0.0L)));
+C((!isnan      (0.0L)));
+C((!isinf      (0.0L)));
+C((!isnormal   (0.0L)));
+C((!issubnormal(0.0L)));
+C(( iszero     (0.0L)));
+
+/* TRUE_MIN */
+
+C((!signbit    (std::numeric_limits<float>::denorm_min())));
+C(( isfinite   (std::numeric_limits<float>::denorm_min())));
+C((!isnan      (std::numeric_limits<float>::denorm_min())));
+C((!isinf      (std::numeric_limits<float>::denorm_min())));
+C((!isnormal   (std::numeric_limits<float>::denorm_min())));
+C(( issubnormal(std::numeric_limits<float>::denorm_min())));
+C((!iszero     (std::numeric_limits<float>::denorm_min())));
+
+C((!signbit    (std::numeric_limits<double>::denorm_min())));
+C(( isfinite   (std::numeric_limits<double>::denorm_min())));
+C((!isnan      (std::numeric_limits<double>::denorm_min())));
+C((!isinf      (std::numeric_limits<double>::denorm_min())));
+C((!isnormal   (std::numeric_limits<double>::denorm_min())));
+C(( issubnormal(std::numeric_limits<double>::denorm_min())));
+C((!iszero     (std::numeric_limits<double>::denorm_min())));
+
+C((!signbit    (std::numeric_limits<long double>::denorm_min())));
+C(( isfinite   (std::numeric_limits<long double>::denorm_min())));
+C((!isnan      (std::numeric_limits<long double>::denorm_min())));
+C((!isinf      (std::numeric_limits<long double>::denorm_min())));
+C((!isnormal   (std::numeric_limits<long double>::denorm_min())));
+C(( issubnormal(std::numeric_limits<long double>::denorm_min())));
+C((!iszero     (std::numeric_limits<long double>::denorm_min())));
+
+/* MIN */
+
+C((!signbit    (std::numeric_limits<long double>::min())));
+C(( isfinite   (std::numeric_limits<long double>::min())));
+C((!isnan      (std::numeric_limits<long double>::min())));
+C((!isinf      (std::numeric_limits<long double>::min())));
+C(( isnormal   (std::numeric_limits<long double>::min())));
+C((!issubnormal(std::numeric_limits<long double>::min())));
+C((!iszero     (std::numeric_limits<long double>::min())));
+
+C((!signbit    (std::numeric_limits<long double>::min())));
+C(( isfinite   (std::numeric_limits<long double>::min())));
+C((!isnan      (std::numeric_limits<long double>::min())));
+C((!isinf      (std::numeric_limits<long double>::min())));
+C(( isnormal   (std::numeric_limits<long double>::min())));
+C((!issubnormal(std::numeric_limits<long double>::min())));
+C((!iszero     (std::numeric_limits<long double>::min())));
+
+C((!signbit    (std::numeric_limits<long double>::min())));
+C(( isfinite   (std::numeric_limits<long double>::min())));
+C((!isnan      (std::numeric_limits<long double>::min())));
+C((!isinf      (std::numeric_limits<long double>::min())));
+C(( isnormal   (std::numeric_limits<long double>::min())));
+C((!issubnormal(std::numeric_limits<long double>::min())));
+C((!iszero     (std::numeric_limits<long double>::min())));
+
+/* RECIP PI */
+
+C((!signbit    (0.31830988618379067153776752674503f)));
+C(( isfinite   (0.31830988618379067153776752674503f)));
+C((!isnan      (0.31830988618379067153776752674503f)));
+C((!isinf      (0.31830988618379067153776752674503f)));
+C(( isnormal   (0.31830988618379067153776752674503f)));
+C((!issubnormal(0.31830988618379067153776752674503f)));
+C((!iszero     (0.31830988618379067153776752674503f)));
+
+C((!signbit    (0.31830988618379067153776752674503)));
+C(( isfinite   (0.31830988618379067153776752674503)));
+C((!isnan      (0.31830988618379067153776752674503)));
+C((!isinf      (0.31830988618379067153776752674503)));
+C(( isnormal   (0.31830988618379067153776752674503)));
+C((!issubnormal(0.31830988618379067153776752674503)));
+C((!iszero     (0.31830988618379067153776752674503)));
+
+C((!signbit    (0.31830988618379067153776752674503L)));
+C(( isfinite   (0.31830988618379067153776752674503L)));
+C((!isnan      (0.31830988618379067153776752674503L)));
+C((!isinf      (0.31830988618379067153776752674503L)));
+C(( isnormal   (0.31830988618379067153776752674503L)));
+C((!issubnormal(0.31830988618379067153776752674503L)));
+C((!iszero     (0.31830988618379067153776752674503L)));
+
+/* ONE */
+
+C((!signbit    (1.0f)));
+C(( isfinite   (1.0f)));
+C((!isnan      (1.0f)));
+C((!isinf      (1.0f)));
+C(( isnormal   (1.0f)));
+C((!issubnormal(1.0f)));
+C((!iszero     (1.0f)));
+
+C((!signbit    (1.0)));
+C(( isfinite   (1.0)));
+C((!isnan      (1.0)));
+C((!isinf      (1.0)));
+C(( isnormal   (1.0)));
+C((!issubnormal(1.0)));
+C((!iszero     (1.0)));
+
+C((!signbit    (1.0L)));
+C(( isfinite   (1.0L)));
+C((!isnan      (1.0L)));
+C((!isinf      (1.0L)));
+C(( isnormal   (1.0L)));
+C((!issubnormal(1.0L)));
+C((!iszero     (1.0L)));
+
+/* PI */
+
+C((!signbit    (3.1415926535897932384626433832795f)));
+C(( isfinite   (3.1415926535897932384626433832795f)));
+C((!isnan      (3.1415926535897932384626433832795f)));
+C((!isinf      (3.1415926535897932384626433832795f)));
+C(( isnormal   (3.1415926535897932384626433832795f)));
+C((!issubnormal(3.1415926535897932384626433832795f)));
+C((!iszero     (3.1415926535897932384626433832795f)));
+
+C((!signbit    (3.1415926535897932384626433832795)));
+C(( isfinite   (3.1415926535897932384626433832795)));
+C((!isnan      (3.1415926535897932384626433832795)));
+C((!isinf      (3.1415926535897932384626433832795)));
+C(( isnormal   (3.1415926535897932384626433832795)));
+C((!issubnormal(3.1415926535897932384626433832795)));
+C((!iszero     (3.1415926535897932384626433832795)));
+
+C((!signbit    (3.1415926535897932384626433832795L)));
+C(( isfinite   (3.1415926535897932384626433832795L)));
+C((!isnan      (3.1415926535897932384626433832795L)));
+C((!isinf      (3.1415926535897932384626433832795L)));
+C(( isnormal   (3.1415926535897932384626433832795L)));
+C((!issubnormal(3.1415926535897932384626433832795L)));
+C((!iszero     (3.1415926535897932384626433832795L)));
+
+/* MAX */
+
+C((!signbit    (std::numeric_limits<long double>::max())));
+C(( isfinite   (std::numeric_limits<long double>::max())));
+C((!isnan      (std::numeric_limits<long double>::max())));
+C((!isinf      (std::numeric_limits<long double>::max())));
+C(( isnormal   (std::numeric_limits<long double>::max())));
+C((!issubnormal(std::numeric_limits<long double>::max())));
+C((!iszero     (std::numeric_limits<long double>::max())));
+
+C((!signbit    (std::numeric_limits<long double>::max())));
+C(( isfinite   (std::numeric_limits<long double>::max())));
+C((!isnan      (std::numeric_limits<long double>::max())));
+C((!isinf      (std::numeric_limits<long double>::max())));
+C(( isnormal   (std::numeric_limits<long double>::max())));
+C((!issubnormal(std::numeric_limits<long double>::max())));
+C((!iszero     (std::numeric_limits<long double>::max())));
+
+C((!signbit    (std::numeric_limits<long double>::max())));
+C(( isfinite   (std::numeric_limits<long double>::max())));
+C((!isnan      (std::numeric_limits<long double>::max())));
+C((!isinf      (std::numeric_limits<long double>::max())));
+C(( isnormal   (std::numeric_limits<long double>::max())));
+C((!issubnormal(std::numeric_limits<long double>::max())));
+C((!iszero     (std::numeric_limits<long double>::max())));
+
+/* INFINITY */
+
+C((!signbit    (__builtin_inff())));
+C((!isfinite   (__builtin_inff())));
+C((!isnan      (__builtin_inff())));
+C(( isinf      (__builtin_inff())));
+C((!isnormal   (__builtin_inff())));
+C((!issubnormal(__builtin_inff())));
+C((!iszero     (__builtin_inff())));
+
+C((!signbit    (__builtin_inf())));
+C((!isfinite   (__builtin_inf())));
+C((!isnan      (__builtin_inf())));
+C(( isinf      (__builtin_inf())));
+C((!isnormal   (__builtin_inf())));
+C((!issubnormal(__builtin_inf())));
+C((!iszero     (__builtin_inf())));
+
+C((!signbit    (__builtin_infl())));
+C((!isfinite   (__builtin_infl())));
+C((!isnan      (__builtin_infl())));
+C(( isinf      (__builtin_infl())));
+C((!isnormal   (__builtin_infl())));
+C((!issubnormal(__builtin_infl())));
+C((!iszero     (__builtin_infl())));
+
+/* NAN */
+
+C((!signbit    (__builtin_nanf(""))));
+C((!isfinite   (__builtin_nanf(""))));
+C(( isnan      (__builtin_nanf(""))));
+C((!isinf      (__builtin_nanf(""))));
+C((!isnormal   (__builtin_nanf(""))));
+C((!issubnormal(__builtin_nanf(""))));
+C((!iszero     (__builtin_nanf(""))));
+
+C((!signbit    (__builtin_nan(""))));
+C((!isfinite   (__builtin_nan(""))));
+C(( isnan      (__builtin_nan(""))));
+C((!isinf      (__builtin_nan(""))));
+C((!isnormal   (__builtin_nan(""))));
+C((!issubnormal(__builtin_nan(""))));
+C((!iszero     (__builtin_nan(""))));
+
+C((!signbit    (__builtin_nanl(""))));
+C((!isfinite   (__builtin_nanl(""))));
+C(( isnan      (__builtin_nanl(""))));
+C((!isinf      (__builtin_nanl(""))));
+C((!isnormal   (__builtin_nanl(""))));
+C((!issubnormal(__builtin_nanl(""))));
+C((!iszero     (__builtin_nanl(""))));
+
+//------------------------------------------------------------------------------
+// Negative value tests
+//------------------------------------------------------------------------------
+
+/* ZERO */
+
+C(( signbit    (-0.0f)));
+C(( isfinite   (-0.0f)));
+C((!isnan      (-0.0f)));
+C((!isinf      (-0.0f)));
+C((!isnormal   (-0.0f)));
+C((!issubnormal(-0.0f)));
+C(( iszero     (-0.0f)));
+
+C(( signbit    (-0.0)));
+C(( isfinite   (-0.0)));
+C((!isnan      (-0.0)));
+C((!isinf      (-0.0)));
+C((!isnormal   (-0.0)));
+C((!issubnormal(-0.0)));
+C(( iszero     (-0.0)));
+
+C(( signbit    (-0.0L)));
+C(( isfinite   (-0.0L)));
+C((!isnan      (-0.0L)));
+C((!isinf      (-0.0L)));
+C((!isnormal   (-0.0L)));
+C((!issubnormal(-0.0L)));
+C(( iszero     (-0.0L)));
+
+/* TRUE_MIN */
+
+C(( signbit    (-std::numeric_limits<float>::denorm_min())));
+C(( isfinite   (-std::numeric_limits<float>::denorm_min())));
+C((!isnan      (-std::numeric_limits<float>::denorm_min())));
+C((!isinf      (-std::numeric_limits<float>::denorm_min())));
+C((!isnormal   (-std::numeric_limits<float>::denorm_min())));
+C(( issubnormal(-std::numeric_limits<float>::denorm_min())));
+C((!iszero     (-std::numeric_limits<float>::denorm_min())));
+
+C(( signbit    (-std::numeric_limits<double>::denorm_min())));
+C(( isfinite   (-std::numeric_limits<double>::denorm_min())));
+C((!isnan      (-std::numeric_limits<double>::denorm_min())));
+C((!isinf      (-std::numeric_limits<double>::denorm_min())));
+C((!isnormal   (-std::numeric_limits<double>::denorm_min())));
+C(( issubnormal(-std::numeric_limits<double>::denorm_min())));
+C((!iszero     (-std::numeric_limits<double>::denorm_min())));
+
+C(( signbit    (-std::numeric_limits<long double>::denorm_min())));
+C(( isfinite   (-std::numeric_limits<long double>::denorm_min())));
+C((!isnan      (-std::numeric_limits<long double>::denorm_min())));
+C((!isinf      (-std::numeric_limits<long double>::denorm_min())));
+C((!isnormal   (-std::numeric_limits<long double>::denorm_min())));
+C(( issubnormal(-std::numeric_limits<long double>::denorm_min())));
+C((!iszero     (-std::numeric_limits<long double>::denorm_min())));
+
+/* MIN */
+
+C(( signbit    (-std::numeric_limits<long double>::min())));
+C(( isfinite   (-std::numeric_limits<long double>::min())));
+C((!isnan      (-std::numeric_limits<long double>::min())));
+C((!isinf      (-std::numeric_limits<long double>::min())));
+C(( isnormal   (-std::numeric_limits<long double>::min())));
+C((!issubnormal(-std::numeric_limits<long double>::min())));
+C((!iszero     (-std::numeric_limits<long double>::min())));
+
+C(( signbit    (-std::numeric_limits<long double>::min())));
+C(( isfinite   (-std::numeric_limits<long double>::min())));
+C((!isnan      (-std::numeric_limits<long double>::min())));
+C((!isinf      (-std::numeric_limits<long double>::min())));
+C(( isnormal   (-std::numeric_limits<long double>::min())));
+C((!issubnormal(-std::numeric_limits<long double>::min())));
+C((!iszero     (-std::numeric_limits<long double>::min())));
+
+C(( signbit    (-std::numeric_limits<long double>::min())));
+C(( isfinite   (-std::numeric_limits<long double>::min())));
+C((!isnan      (-std::numeric_limits<long double>::min())));
+C((!isinf      (-std::numeric_limits<long double>::min())));
+C(( isnormal   (-std::numeric_limits<long double>::min())));
+C((!issubnormal(-std::numeric_limits<long double>::min())));
+C((!iszero     (-std::numeric_limits<long double>::min())));
+
+/* RECIP PI */
+
+C(( signbit    (-0.31830988618379067153776752674503f)));
+C(( isfinite   (-0.31830988618379067153776752674503f)));
+C((!isnan      (-0.31830988618379067153776752674503f)));
+C((!isinf      (-0.31830988618379067153776752674503f)));
+C(( isnormal   (-0.31830988618379067153776752674503f)));
+C((!issubnormal(-0.31830988618379067153776752674503f)));
+C((!iszero     (-0.31830988618379067153776752674503f)));
+
+C(( signbit    (-0.31830988618379067153776752674503)));
+C(( isfinite   (-0.31830988618379067153776752674503)));
+C((!isnan      (-0.31830988618379067153776752674503)));
+C((!isinf      (-0.31830988618379067153776752674503)));
+C(( isnormal   (-0.31830988618379067153776752674503)));
+C((!issubnormal(-0.31830988618379067153776752674503)));
+C((!iszero     (-0.31830988618379067153776752674503)));
+
+C(( signbit    (-0.31830988618379067153776752674503L)));
+C(( isfinite   (-0.31830988618379067153776752674503L)));
+C((!isnan      (-0.31830988618379067153776752674503L)));
+C((!isinf      (-0.31830988618379067153776752674503L)));
+C(( isnormal   (-0.31830988618379067153776752674503L)));
+C((!issubnormal(-0.31830988618379067153776752674503L)));
+C((!iszero     (-0.31830988618379067153776752674503L)));
+
+/* ONE */
+
+C(( signbit    (-1.0f)));
+C(( isfinite   (-1.0f)));
+C((!isnan      (-1.0f)));
+C((!isinf      (-1.0f)));
+C(( isnormal   (-1.0f)));
+C((!issubnormal(-1.0f)));
+C((!iszero     (-1.0f)));
+
+C(( signbit    (-1.0)));
+C(( isfinite   (-1.0)));
+C((!isnan      (-1.0)));
+C((!isinf      (-1.0)));
+C(( isnormal   (-1.0)));
+C((!issubnormal(-1.0)));
+C((!iszero     (-1.0)));
+
+C(( signbit    (-1.0L)));
+C(( isfinite   (-1.0L)));
+C((!isnan      (-1.0L)));
+C((!isinf      (-1.0L)));
+C(( isnormal   (-1.0L)));
+C((!issubnormal(-1.0L)));
+C((!iszero     (-1.0L)));
+
+/* PI */
+
+C(( signbit    (-3.1415926535897932384626433832795f)));
+C(( isfinite   (-3.1415926535897932384626433832795f)));
+C((!isnan      (-3.1415926535897932384626433832795f)));
+C((!isinf      (-3.1415926535897932384626433832795f)));
+C(( isnormal   (-3.1415926535897932384626433832795f)));
+C((!issubnormal(-3.1415926535897932384626433832795f)));
+C((!iszero     (-3.1415926535897932384626433832795f)));
+
+C(( signbit    (-3.1415926535897932384626433832795)));
+C(( isfinite   (-3.1415926535897932384626433832795)));
+C((!isnan      (-3.1415926535897932384626433832795)));
+C((!isinf      (-3.1415926535897932384626433832795)));
+C(( isnormal   (-3.1415926535897932384626433832795)));
+C((!issubnormal(-3.1415926535897932384626433832795)));
+C((!iszero     (-3.1415926535897932384626433832795)));
+
+C(( signbit    (-3.1415926535897932384626433832795L)));
+C(( isfinite   (-3.1415926535897932384626433832795L)));
+C((!isnan      (-3.1415926535897932384626433832795L)));
+C((!isinf      (-3.1415926535897932384626433832795L)));
+C(( isnormal   (-3.1415926535897932384626433832795L)));
+C((!issubnormal(-3.1415926535897932384626433832795L)));
+C((!iszero     (-3.1415926535897932384626433832795L)));
+
+/* MAX */
+
+C(( signbit    (-std::numeric_limits<long double>::max())));
+C(( isfinite   (-std::numeric_limits<long double>::max())));
+C((!isnan      (-std::numeric_limits<long double>::max())));
+C((!isinf      (-std::numeric_limits<long double>::max())));
+C(( isnormal   (-std::numeric_limits<long double>::max())));
+C((!issubnormal(-std::numeric_limits<long double>::max())));
+C((!iszero     (-std::numeric_limits<long double>::max())));
+
+C(( signbit    (-std::numeric_limits<long double>::max())));
+C(( isfinite   (-std::numeric_limits<long double>::max())));
+C((!isnan      (-std::numeric_limits<long double>::max())));
+C((!isinf      (-std::numeric_limits<long double>::max())));
+C(( isnormal   (-std::numeric_limits<long double>::max())));
+C((!issubnormal(-std::numeric_limits<long double>::max())));
+C((!iszero     (-std::numeric_limits<long double>::max())));
+
+C(( signbit    (-std::numeric_limits<long double>::max())));
+C(( isfinite   (-std::numeric_limits<long double>::max())));
+C((!isnan      (-std::numeric_limits<long double>::max())));
+C((!isinf      (-std::numeric_limits<long double>::max())));
+C(( isnormal   (-std::numeric_limits<long double>::max())));
+C((!issubnormal(-std::numeric_limits<long double>::max())));
+C((!iszero     (-std::numeric_limits<long double>::max())));
+
+/* INFINITY */
+
+C(( signbit    (-__builtin_inff())));
+C((!isfinite   (-__builtin_inff())));
+C((!isnan      (-__builtin_inff())));
+C(( isinf      (-__builtin_inff())));
+C((!isnormal   (-__builtin_inff())));
+C((!issubnormal(-__builtin_inff())));
+C((!iszero     (-__builtin_inff())));
+
+C(( signbit    (-__builtin_inf())));
+C((!isfinite   (-__builtin_inf())));
+C((!isnan      (-__builtin_inf())));
+C(( isinf      (-__builtin_inf())));
+C((!isnormal   (-__builtin_inf())));
+C((!issubnormal(-__builtin_inf())));
+C((!iszero     (-__builtin_inf())));
+
+C(( signbit    (-__builtin_infl())));
+C((!isfinite   (-__builtin_infl())));
+C((!isnan      (-__builtin_infl())));
+C(( isinf      (-__builtin_infl())));
+C((!isnormal   (-__builtin_infl())));
+C((!issubnormal(-__builtin_infl())));
+C((!iszero     (-__builtin_infl())));
+
+/* NAN */
+
+C(( signbit    (-__builtin_nanf(""))));
+C((!isfinite   (-__builtin_nanf(""))));
+C(( isnan      (-__builtin_nanf(""))));
+C((!isinf      (-__builtin_nanf(""))));
+C((!isnormal   (-__builtin_nanf(""))));
+C((!issubnormal(-__builtin_nanf(""))));
+C((!iszero     (-__builtin_nanf(""))));
+
+C(( signbit    (-__builtin_nan(""))));
+C((!isfinite   (-__builtin_nan(""))));
+C(( isnan      (-__builtin_nan(""))));
+C((!isinf      (-__builtin_nan(""))));
+C((!isnormal   (-__builtin_nan(""))));
+C((!issubnormal(-__builtin_nan(""))));
+C((!iszero     (-__builtin_nan(""))));
+
+C(( signbit    (-__builtin_nanl(""))));
+C((!isfinite   (-__builtin_nanl(""))));
+C(( isnan      (-__builtin_nanl(""))));
+C((!isinf      (-__builtin_nanl(""))));
+C((!isnormal   (-__builtin_nanl(""))));
+C((!issubnormal(-__builtin_nanl(""))));
+C((!iszero     (-__builtin_nanl(""))));
+
+//------------------------------------------------------------------------------
+// Integer value tests
+//------------------------------------------------------------------------------
+
+/* int */
+
+C((!signbit    (0)));
+C(( isfinite   (0)));
+C((!isnan      (0)));
+C((!isinf      (0)));
+C((!isnormal   (0)));
+C((!issubnormal(0)));
+C(( iszero     (0)));
+
+C((!signbit    (1)));
+C(( isfinite   (1)));
+C((!isnan      (1)));
+C((!isinf      (1)));
+C(( isnormal   (1)));
+C((!issubnormal(1)));
+C((!iszero     (1)));
+
+C((!signbit    (10)));
+C(( isfinite   (10)));
+C((!isnan      (10)));
+C((!isinf      (10)));
+C(( isnormal   (10)));
+C((!issubnormal(10)));
+C((!iszero     (10)));
+
+C(( signbit    (-1)));
+C(( isfinite   (-1)));
+C((!isnan      (-1)));
+C((!isinf      (-1)));
+C(( isnormal   (-1)));
+C((!issubnormal(-1)));
+C((!iszero     (-1)));
+
+C(( signbit    (-10)));
+C(( isfinite   (-10)));
+C((!isnan      (-10)));
+C((!isinf      (-10)));
+C(( isnormal   (-10)));
+C((!issubnormal(-10)));
+C((!iszero     (-10)));
+
+/* unsigned long long */
+
+C((!signbit    (0ull)));
+C(( isfinite   (0ull)));
+C((!isnan      (0ull)));
+C((!isinf      (0ull)));
+C((!isnormal   (0ull)));
+C((!issubnormal(0ull)));
+C(( iszero     (0ull)));
+
+C((!signbit    (1ull)));
+C(( isfinite   (1ull)));
+C((!isnan      (1ull)));
+C((!isinf      (1ull)));
+C(( isnormal   (1ull)));
+C((!issubnormal(1ull)));
+C((!iszero     (1ull)));
+
+C((!signbit    (10ull)));
+C(( isfinite   (10ull)));
+C((!isnan      (10ull)));
+C((!isinf      (10ull)));
+C(( isnormal   (10ull)));
+C((!issubnormal(10ull)));
+C((!iszero     (10ull)));
+
+#undef C

--- a/test/floating_point/float32_classification/src/main.c
+++ b/test/floating_point/float32_classification/src/main.c
@@ -137,7 +137,7 @@ int main(void) {
     } else {
         printf(
             "Failed test:\n0x%08lX\nTruth: %06X_%d\nGuess: %06X_%d",
-            ret.failed_index, ret.guess, ret.guess_fp, ret.truth, ret.truth_fp
+            ret.failed_index, ret.truth, ret.truth_fp, ret.guess, ret.guess_fp
         );
     }
 

--- a/test/floating_point/float32_classification/src/main.c
+++ b/test/floating_point/float32_classification/src/main.c
@@ -136,7 +136,7 @@ int main(void) {
         printf("All tests passed");
     } else {
         printf(
-            "Failed test:\n0x%08lX\nTruth: %X_%d\nGuess: %X_%d",
+            "Failed test:\n0x%08lX\nTruth: %06X_%d\nGuess: %06X_%d",
             ret.failed_index, ret.guess, ret.guess_fp, ret.truth, ret.truth_fp
         );
     }

--- a/test/floating_point/float64_classification/src/main.c
+++ b/test/floating_point/float64_classification/src/main.c
@@ -139,7 +139,7 @@ int main(void) {
         const uint32_t* failed_index_split = (const uint32_t*)((const void*)&(ret.failed_index));
         printf(
             "Failed test:\n0x%08lX%08lX\nTruth: %06X_%d\nGuess: %06X_%d",
-            failed_index_split[1], failed_index_split[0], ret.guess, ret.guess_fp, ret.truth, ret.truth_fp
+            failed_index_split[1], failed_index_split[0], ret.truth, ret.truth_fp, ret.guess, ret.guess_fp
         );
     }
 


### PR DESCRIPTION
changes:
* float classification can now be done at compile time in C++. This only worked when I added `constexpr` to the function prototype in C++, so I'm not sure if it can also be done for C.
* Added `__NOEXCEPT __attribute__((const))` to non-standard function prototypes, such as `_fpclassifyf`
* optimzied the float classification routines. Most of them return bool (which gets stored in the carry flag from what I've seen) instead of int
* added sin(pi * x), cos(pi * x), and tan(pi * x) from C23, which allow for accurate range reduction. I didn't add `asinpi acospi atanpi atan2pi` since they are trivial to implement `atan2(y, x) / pi`