### PR TITLE
Implement strlcpy

### DIFF
--- a/src/libc/include/string.h
+++ b/src/libc/include/string.h
@@ -44,7 +44,7 @@ char *stpcpy(char *__restrict dest, const char *__restrict src)
 char *stpncpy(char *__restrict dest, const char *__restrict src, size_t n)
     __NOEXCEPT __attribute__((nonnull(1, 2)));
 
-char *strlcpy(char *__restrict dest, const char *__restrict src, size_t n)
+size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t n)
     __NOEXCEPT __attribute__((nonnull(1, 2)));
 
 char *strcat(char *__restrict dest, const char *__restrict src)

--- a/src/libc/strlcpy.src
+++ b/src/libc/strlcpy.src
@@ -25,29 +25,30 @@ _strlcpy:
 	sbc hl, bc ; always sets carry flag
 	; now hl = strlen(src)
 
-	push hl ; save this for after dsize check
-
 	ld bc, (iy + 9) ; bc = dsize
 	ex de, hl ; de = strlen(src)
 
 	; check if dsize is zero
 	sbc hl, hl ; set hl to -1, carry was already set
 	add hl, bc ; hl = -1 + dsize
-	jr nc, .strlcpy_done ; do nothing if dsize is zero
+        ex de, hl ; hl = strlen(src), de = dsize - 1
+	ret nc ; do nothing and return strlen(src) if dsize is zero
+
+	push hl ; save strlen(src) for after copy
 
 	; dsize is not zero, compare them
-	; hl = dsize - 1
-	; de = strlen(src)
+	; hl = strlen(src)
+	; de = dsize - 1
 
 	; carry flag is set, so calculate hl - (de + 1)
 	sbc hl, de
 
-	; if hl <= de, (dsize - 1) <= strlen(src); keep bc as dsize
-	jr c, .ready_for_ldir
+	; if hl > de, strlen(src) > (dsize - 1); string is truncated, keep bc as dsize
+	jr nc, .ready_for_ldir
 
-	; hl > de, so (dsize - 1) > strlen(src); set bc to strlen(src) + 1
-	push de
+	; hl <= de, so strlen(src) <= (dsize - 1); string is not truncated, set bc to strlen(src) + 1
 	pop bc
+	push bc
 	inc bc
 
 .ready_for_ldir:
@@ -61,14 +62,13 @@ _strlcpy:
 	; bc has the length (including space for null terminator)
 	ldir
 
-	; replace final byte with NUL, in case src null terminator wasn't reached
+	pop hl ; get the result of strlen(src) from earlier and put into hl
+
+	ret c ; return strlen(src) if string was not truncated
+
+	; string was truncated, so replace final byte with NUL
 	dec de
 	; a is already 0
 	ld (de), a ; store null terminator at the address pointed to by de
 
-.strlcpy_done:
-	; return strlen(src)
-
-	pop hl ; get the result of strlen(src) from earlier and put into hl
-
-	ret
+	ret ; return strlen(src)

--- a/src/libc/strlcpy.src
+++ b/src/libc/strlcpy.src
@@ -14,18 +14,6 @@ _strlcpy:
 
 	; do min(strlen(src), dsize-1)
 
-	ld bc, (iy + 9) ; bc = dsize
-
-	; check if dsize is zero
-	xor a,a ; clear carry and set a to 0
-	ld hl, 0
-	sbc hl, bc
-	jr z, .strlcpy_done ; do nothing if dsize is zero
-
-	dec bc ; bc = dsize - 1
-
-	push bc ; cpir-based strlen touches bc, so put it on the stack
-
 	; strlen(src)
 	ld hl, (iy + 6) ; hl = pointer to src
 	xor a,a ; clear carry and set a to 0
@@ -37,7 +25,21 @@ _strlcpy:
 	sbc hl,bc
 	; now hl = strlen(src)
 
-	pop bc ; get bc back from the stack
+	push hl ; save this for after dsize check
+
+	ld bc, (iy + 9) ; bc = dsize
+
+	; check if dsize is zero
+	xor a,a ; clear carry and set a to 0
+	sbc hl, hl
+	sbc hl, bc
+	jr z, .strlcpy_done ; do nothing if dsize is zero
+
+	dec bc ; bc = dsize - 1
+
+	; restore hl without changing the stack
+	pop hl ; get it back
+	push hl ; save it for the end
 
 	; dsize is not zero, compare them
 	; hl = strlen(src)
@@ -61,7 +63,7 @@ _strlcpy:
 	
 	; check if bc is zero
 	xor a,a ; clear carry and set a to 0
-	ld hl, 0
+	sbc hl, hl
 	sbc hl, bc
 	jr z, .null_terminate ; null terminate if bc is zero
 
@@ -83,15 +85,6 @@ _strlcpy:
 .strlcpy_done:
 	; return strlen(src)
 
-	; strlen(src)
-	ld hl, (iy + 6) ; hl = pointer to src
-	xor a,a ; clear carry and set a to 0
-	ld bc, 0
-	cpir ; dec bc until byte at (hl) matches a (= NUL)
-	; calculate HL=-BC-1
-	sbc hl,hl
-	scf
-	sbc hl,bc
-	; now hl = strlen(src)
+	pop hl ; get the result of strlen(src) from earlier and put into hl
 
 	ret

--- a/src/libc/strlcpy.src
+++ b/src/libc/strlcpy.src
@@ -10,76 +10,60 @@
 _strlcpy:
 
 	ld iy, 0
+	lea bc, iy ; set bc to 0
 	add iy, sp
 
 	; do min(strlen(src), dsize-1)
 
 	; strlen(src)
 	ld hl, (iy + 6) ; hl = pointer to src
-	xor a,a ; clear carry and set a to 0
-	ld bc, 0
+	xor a, a ; clear carry and set a to 0
 	cpir ; dec bc until byte at (hl) matches a (= NUL)
 	; calculate HL=-BC-1
-	sbc hl,hl
+	sbc hl, hl
 	scf
-	sbc hl,bc
+	sbc hl, bc ; always sets carry flag
 	; now hl = strlen(src)
 
 	push hl ; save this for after dsize check
 
 	ld bc, (iy + 9) ; bc = dsize
+	ex de, hl ; de = strlen(src)
 
 	; check if dsize is zero
-	xor a,a ; clear carry and set a to 0
-	sbc hl, hl
-	sbc hl, bc
-	jr z, .strlcpy_done ; do nothing if dsize is zero
-
-	dec bc ; bc = dsize - 1
-
-	; restore hl without changing the stack
-	pop hl ; get it back
-	push hl ; save it for the end
+	sbc hl, hl ; set hl to -1, carry was already set
+	add hl, bc ; hl = -1 + dsize
+	jr nc, .strlcpy_done ; do nothing if dsize is zero
 
 	; dsize is not zero, compare them
-	; hl = strlen(src)
-	; bc = dsize - 1
-	
-	; https://www.msx.org/forum/development/msx-development/how-compare-16bits-registers-z80
-	or a ; clear carry flag
-	sbc hl, bc
-	add hl, bc
+	; hl = dsize - 1
+	; de = strlen(src)
 
-	; if hl >= bc, c = 0; keep bc as is
-	; if strlen(src) >= (dsize - 1), c = 0; keep bc as is
-	jr nc, .ready_for_ldir
-	
-	; hl < bc, so strlen(src) < (dsize - 1); set bc to the value in hl
-	push hl
+	; carry flag is set, so calculate hl - (de + 1)
+	sbc hl, de
+
+	; if hl <= de, (dsize - 1) <= strlen(src); keep bc as dsize
+	jr c, .ready_for_ldir
+
+	; hl > de, so (dsize - 1) > strlen(src); set bc to strlen(src) + 1
+	push de
 	pop bc
+	inc bc
 
 .ready_for_ldir:
 	ld de, (iy + 3) ; put dst in de
-	
-	; check if bc is zero
-	xor a,a ; clear carry and set a to 0
-	sbc hl, hl
-	sbc hl, bc
-	jr z, .null_terminate ; null terminate if bc is zero
-
 	ld hl, (iy + 6) ; put src in hl
-	; bc is filled already
+	; bc is filled already and greater than 0
 
 	; at this point we are set up for an ldir:
 	; hl has the start address
 	; de has the destination address
-	; bc has the length
-
+	; bc has the length (including space for null terminator)
 	ldir
 
-.null_terminate:
-	; dsize is nonzero, null terminate dst
-	xor a,a ; clear carry and set a to 0 (= NUL)
+	; replace final byte with NUL, in case src null terminator wasn't reached
+	dec de
+	; a is already 0
 	ld (de), a ; store null terminator at the address pointed to by de
 
 .strlcpy_done:

--- a/src/libc/strlcpy.src
+++ b/src/libc/strlcpy.src
@@ -1,0 +1,97 @@
+	assume	adl=1
+
+	section	.text
+	public	_strlcpy
+
+; BSD variant of strncpy that ensures the destination is null-terminated.
+; OpenBSD reference: https://github.com/openbsd/src/blob/master/lib/libc/string/strlcpy.c
+; size_t strlcpy(char *dst, const char *src, size_t dsize)
+
+_strlcpy:
+
+	ld iy, 0
+	add iy, sp
+
+	; do min(strlen(src), dsize-1)
+
+	ld bc, (iy + 9) ; bc = dsize
+
+	; check if dsize is zero
+	xor a,a ; clear carry and set a to 0
+	ld hl, 0
+	sbc hl, bc
+	jr z, .strlcpy_done ; do nothing if dsize is zero
+
+	dec bc ; bc = dsize - 1
+
+	push bc ; cpir-based strlen touches bc, so put it on the stack
+
+	; strlen(src)
+	ld hl, (iy + 6) ; hl = pointer to src
+	xor a,a ; clear carry and set a to 0
+	ld bc, 0
+	cpir ; dec bc until byte at (hl) matches a (= NUL)
+	; calculate HL=-BC-1
+	sbc hl,hl
+	scf
+	sbc hl,bc
+	; now hl = strlen(src)
+
+	pop bc ; get bc back from the stack
+
+	; dsize is not zero, compare them
+	; hl = strlen(src)
+	; bc = dsize - 1
+	
+	; https://www.msx.org/forum/development/msx-development/how-compare-16bits-registers-z80
+	or a ; clear carry flag
+	sbc hl, bc
+	add hl, bc
+
+	; if hl >= bc, c = 0; keep bc as is
+	; if strlen(src) >= (dsize - 1), c = 0; keep bc as is
+	jr nc, .ready_for_ldir
+	
+	; hl < bc, so strlen(src) < (dsize - 1); set bc to the value in hl
+	push hl
+	pop bc
+
+.ready_for_ldir:
+	ld de, (iy + 3) ; put dst in de
+	
+	; check if bc is zero
+	xor a,a ; clear carry and set a to 0
+	ld hl, 0
+	sbc hl, bc
+	jr z, .null_terminate ; null terminate if bc is zero
+
+	ld hl, (iy + 6) ; put src in hl
+	; bc is filled already
+
+	; at this point we are set up for an ldir:
+	; hl has the start address
+	; de has the destination address
+	; bc has the length
+
+	ldir
+
+.null_terminate:
+	; dsize is nonzero, null terminate dst
+	xor a,a ; clear carry and set a to 0 (= NUL)
+	ld (de), a ; store null terminator at the address pointed to by de
+
+.strlcpy_done:
+	; return strlen(src)
+
+	; strlen(src)
+	ld hl, (iy + 6) ; hl = pointer to src
+	xor a,a ; clear carry and set a to 0
+	ld bc, 0
+	cpir ; dec bc until byte at (hl) matches a (= NUL)
+	; calculate HL=-BC-1
+	sbc hl,hl
+	scf
+	sbc hl,bc
+	; now hl = strlen(src)
+
+	ret

--- a/test/standalone/strlcpy/.gitignore
+++ b/test/standalone/strlcpy/.gitignore
@@ -1,0 +1,7 @@
+obj/
+bin/
+src/gfx/*.c
+src/gfx/*.h
+src/gfx/*.8xv
+.DS_Store
+convimg.yaml.lst

--- a/test/standalone/strlcpy/autotest.json
+++ b/test/standalone/strlcpy/autotest.json
@@ -1,0 +1,64 @@
+{
+  "transfer_files": [
+    "bin/STRLCPY.8xp"
+  ],
+  "target": {
+    "name": "STRLCPY",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|1000",
+    "hashWait|2",
+    "key|enter",
+    "delay|1000",
+    "hashWait|3",
+    "key|enter",
+    "delay|1000",
+    "hashWait|4"
+  ],
+  "hashes": {
+    "1": {
+      "description": "First set of tests passed",
+	  "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "0835F244"
+      ]
+    },
+    "2": {
+      "description": "Second set of tests passed",
+	  "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "2CABBF0E"
+      ]
+    },
+    "3": {
+      "description": "Third set of tests passed",
+	  "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "508333F7"
+      ]
+    },
+    "4": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/standalone/strlcpy/makefile
+++ b/test/standalone/strlcpy/makefile
@@ -1,0 +1,15 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = STRLCPY
+ICON = icon.png
+DESCRIPTION = "strlcpy test"
+COMPRESSED = NO
+
+CFLAGS = -Wall -Wextra -O0
+CXXFLAGS = -Wall -Wextra -O0
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/standalone/strlcpy/src/main.c
+++ b/test/standalone/strlcpy/src/main.c
@@ -1,0 +1,58 @@
+#include <ti/getcsc.h>
+#include <ti/screen.h>
+#include <stdio.h>
+#include <string.h>
+
+void test_strlcpy_impl(size_t size) {
+    char string[] = "Hello there, Venus";
+    char buffer[20] = "xxxxxxxxxxxxxxxxxxx";
+    size_t r = strlcpy(buffer, string, size);
+    size_t len = strlen(buffer);
+
+    printf("Source: '%s', size: %d, buffer: '%s', len: %d, result: %d\n",
+           string, size, buffer, len, r);
+}
+
+
+void test_strlcpy_impl_empty_src(size_t size) {
+    char string[] = "";
+    char buffer[20] = "xxxxxxxxxxxxxxxxxxx";
+    size_t r = strlcpy(buffer, string, size);
+    size_t len = strlen(buffer);
+
+    printf("Source: '%s', size: %d, buffer: '%s', len: %d, result: %d\n",
+           string, size, buffer, len, r);
+}
+
+
+/* Main function, called first */
+int main(void)
+{
+    /* Clear the homescreen */
+    os_ClrHome();
+
+    /* Print a string */
+
+    printf("Testing strlcpy...\n\n");
+
+    test_strlcpy_impl(19);
+    test_strlcpy_impl(10);
+    
+    while (!os_GetCSC()) {};
+
+    test_strlcpy_impl(1);
+    test_strlcpy_impl(0);
+
+    while (!os_GetCSC()) {};
+
+    test_strlcpy_impl_empty_src(10);
+    test_strlcpy_impl_empty_src(1);
+
+    printf("all done!\n");
+
+    /* Waits for a key */
+    while (!os_GetCSC());
+
+    /* Return 0 for success */
+    return 0;
+}


### PR DESCRIPTION
This PR adds an implementation and tests for `strlcpy`, and corrects its signature in string.h. `strlcpy` is a BSD variant of strncpy that ensures the destination is null-terminated. More info about strlcpy here: https://linux.die.net/man/3/strlcpy