### PR TITLE
boot_sprintf docs, fixed fprintf

### DIFF
--- a/docs/headers/boot_sprintf.rst
+++ b/docs/headers/boot_sprintf.rst
@@ -1,0 +1,76 @@
+.. _boot_sprintf:
+
+boot_sprintf
+======================
+
+.. code-block:: c
+
+    #include <boot_sprintf.h>
+
+The OS comes with an implementation of ANSI C89 `sprintf`, which can reduce the size of a program by ~8 KiB. However, it is very limited in functionality. It does not support width specifiers, and it won't accept :code:`long` or :code:`float` arguments.
+
+The following type specifiers are supported :code:`%s %c %d %i %u %o %x %X %p %n`, alongside the flags :code:`-+ #0*` in addition to the width field.
+
+All length modifiers :code:`hh h l ll j z t L` and floating point specifiers :code:`%f %g %e %a` are **not** supported.
+
+Additionally, each individual argument will write no more than 255 characters each. This means that any strings written with :code:`%s` will be truncated after 255 characters.
+
+The :code:`<boot_sprintf.h>` header provides `boot_sprintf`. `boot_snprintf` and `boot_asprintf` are also provided as macros
+
+.. code-block:: c
+
+    int boot_sprintf(char *restrict buffer, const char *restrict format, ...)
+
+    int boot_snprintf(char *buffer, size_t count, const char *restrict format, ...)
+
+    int boot_asprintf(char **restrict p_buffer, const char *restrict format, ...)
+
+Because the OS does not provide `vsprintf`, `boot_snprintf` and `boot_asprintf` are implemented as macros. This means that :code:`...` or :code:`__VA_ARGS__` will be evaluated twice when the macro is expanded. `sprintf` is traditionally "unsafe" because a maximum output length cannot be specified, which can cause buffer overflows. By writing to an unmapped memory address :code:`0xE40000`, `boot_sprintf` can safely write up to ~786000 bytes which can then be used to determine the length of the output.
+
+replacing printf functions
+----------------------------
+
+To disable all other printf functions with `boot_sprintf`, `boot_snprintf`, and `boot_asprintf`, add the following line to the Makefile. More information `here <https://ce-programming.github.io/toolchain/static/printf.html>`
+
+.. code-block:: makefile
+
+    HAS_PRINTF = NO
+
+.. warning::
+
+    :code:`std::snprintf` and :code:`std::asprintf` will cause errors if :code:`HAS_PRINTF = NO`
+
+boot_asprintf
+----------------------------
+
+`boot_asprintf` functions similarly to `asprintf <https://www.man7.org/linux/man-pages/man3/asprintf.3.html>`_. It will automatically allocate a buffer containing the output from `boot_sprintf`. The buffer shall be deallocated with :code:`free`. The returned buffer will be :code:`NULL` if an allocation or formatting error occurs.
+
+boot_snprintf
+----------------------------
+
+`boot_snprintf` is similar to `snprintf`, except that it returns an empty string if the result of `boot_sprintf` won't fit inside the buffer. Otherwise passing in :code:`boot_snprintf(NULL, 0, format, args)` can be used to query the length of the output without writing to a buffer.
+
+The truncating behavior of C99 `snprintf` can be replicated with `boot_asprintf`
+
+.. code-block:: c
+    char buf[20];
+    char* temp;
+    boot_asprintf(&temp, format, ...);
+    if (temp != NULL) {
+        strncpy(buf, temp, sizeof(buf));
+        buf[sizeof(buf) - 1] = '\0'; // null terminate the end of the buffer
+        free(temp);
+    }
+
+printf and fprintf
+----------------------------
+`printf` and `fprintf` can be replicated by using `boot_asprintf` and `fputs`
+
+.. code-block:: c
+    char* output;
+    boot_asprintf(&output, format, ...);
+    if (output != NULL) {
+        // fprintf(stdout, ...) == printf(...)
+        fputs(stdout, output);
+        free(output);
+    }

--- a/docs/static/printf.rst
+++ b/docs/static/printf.rst
@@ -11,8 +11,7 @@ However, they contribute around 8 KiB to the resultant program.
 It is highly recommended to not use `printf` and related functions at all because of this.
 If you insist on using these functions, this page details how to do so in the next section.
 
-Alternatively, a limited `sprintf` implementation is baked into the OS which doesn't add any extra size to the resultant program.
-Only the 'c', 'd', 'u', 'x', and 's' format specifiers will probably work.
+Alternatively, a limited `sprintf` (no `long` or `float` support) implementation is baked into the OS which doesn't add any extra size to the resultant program. See the dedicated page for more information `<boot_sprintf.h> <https://ce-programming.github.io/toolchain/headers/boot_sprintf.html>`_.
 To disable all other printf functions and use this `sprintf` implementation, add the following line to the Makefile:
 
 .. code-block:: makefile

--- a/src/ce/boot_sprintf.src
+++ b/src/ce/boot_sprintf.src
@@ -5,5 +5,5 @@
 ; to reduce binary size (or performance in the case of sprintf), ti's routines
 ; can be linked instead of the toolchain's routines
 
-	public	_ti_sprintf
-_ti_sprintf := 0000BCh
+	public	_boot_sprintf
+_boot_sprintf := 0000BCh

--- a/src/ce/include/boot_sprintf.h
+++ b/src/ce/include/boot_sprintf.h
@@ -1,5 +1,5 @@
-#ifndef TI_SPRINTF_H
-#define TI_SPRINTF_H
+#ifndef CE_SPRINTF_H
+#define CE_SPRINTF_H
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -12,27 +12,26 @@ extern "C" {
  * @brief C89 `sprintf`. `long` arguments and width specifiers are unsupported.
  * @note `%s` will write up to 255 characters.
  */
-int ti_sprintf(
+int boot_sprintf(
     char *__restrict buffer, const char *__restrict format, ...
 ) __attribute__((format (__printf__, 2, 3)));
 
 /**
  * @brief Returns an empty string if the output from sprintf does not fit.
  * @warning `__VA_ARGS__` is evaluated twice.
- * @note Undefined behaviour if the output is longer than ~258000 characters.
  */
-#define ti_snprintf(buffer, count, ...)\
+#define boot_snprintf(buffer, count, ...)\
 ({\
     char * const __buffer = buffer;\
     const int __count = count;\
     int __ret = -1;\
-    int __str_len = ti_sprintf((char*)0xFC1000, __VA_ARGS__);\
+    int __str_len = boot_sprintf((char*)0xE40000, __VA_ARGS__);\
     if (__buffer == NULL || __count == 0) {\
         __ret = __str_len;\
     } else if ((size_t)__str_len > __count) {\
         *__buffer = '\0'; /* won't fit or invalid formatting */\
     } else {\
-        __ret = ti_sprintf(__buffer, __VA_ARGS__);\
+        __ret = boot_sprintf(__buffer, __VA_ARGS__);\
     }\
     __ret;\
 })
@@ -41,18 +40,17 @@ int ti_sprintf(
  * @brief Allocates a null terminated string containing the output of sprintf.
  * The returned pointer shall be deallocated with `free`.
  * @warning `__VA_ARGS__` is evaluated twice.
- * @note Undefined behaviour if the output is longer than ~258000 characters.
  */
-#define ti_asprintf(p_buffer, ...)\
+#define boot_asprintf(p_buffer, ...)\
 ({\
     char** const __p_buffer = p_buffer;\
     int __ret = -1;\
-    int __str_len = ti_sprintf((char*)0xFC1000, __VA_ARGS__);\
+    int __str_len = boot_sprintf((char*)0xE40000, __VA_ARGS__);\
     if (__str_len >= 0) {\
         size_t __buffer_size = (size_t)__str_len + 1;\
         *__p_buffer = (char*)malloc(__buffer_size);\
         if (*__p_buffer != NULL) {\
-            __ret = ti_sprintf(*__p_buffer, __VA_ARGS__);\
+            __ret = boot_sprintf(*__p_buffer, __VA_ARGS__);\
         }\
     }\
     __ret;\
@@ -62,4 +60,4 @@ int ti_sprintf(
 }
 #endif
 
-#endif /* TI_SPRINTF_H */
+#endif /* CE_SPRINTF_H */

--- a/src/libc/asprintf.src
+++ b/src/libc/asprintf.src
@@ -1,0 +1,16 @@
+	assume	adl=1
+
+	section	.text
+
+if HAS_PRINTF
+
+	public	_asprintf
+	public	_vasprintf
+
+_asprintf := __asprintf_c
+_vasprintf := __vasprintf_c
+
+	extern	__asprintf_c
+	extern	__vasprintf_c
+
+end if

--- a/src/libc/errno_str.c
+++ b/src/libc/errno_str.c
@@ -2,7 +2,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <ti_sprintf.h>
+#include <boot_sprintf.h>
 
 static char const * const errno_strings[] = {
     "no error",
@@ -29,7 +29,7 @@ static_assert(
 
 char* strerror(int errnum) {
     if ((unsigned int)errnum >= errno_strings_count) {
-        ti_sprintf(&(unknown_errno_string[unknown_errno_number_offset]), "%d", errnum);
+        boot_sprintf(&(unknown_errno_string[unknown_errno_number_offset]), "%d", errnum);
         return (char*)unknown_errno_string;
     }
     return (char*)errno_strings[errnum];

--- a/src/libc/fprintf.src
+++ b/src/libc/fprintf.src
@@ -1,0 +1,16 @@
+	assume	adl=1
+
+	section	.text
+
+if HAS_PRINTF
+
+	public	_fprintf
+	public	_vfprintf
+
+_fprintf := __fprintf_c
+_vfprintf := __vfprintf_c
+
+	extern	__fprintf_c
+	extern	__vfprintf_c
+
+end if

--- a/src/libc/header_test.c
+++ b/src/libc/header_test.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <byteswap.h>
 #include <cdefs.h>
-#include <complex.h>
+// #include <complex.h> // supress -ffast-math warnings for now
 #include <ctype.h>
 #include <errno.h>
 #include <fenv.h>

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -4,6 +4,10 @@
 #include <cdefs.h>
 #include <stdarg.h>
 
+#ifndef HAS_PRINTF
+# include <boot_sprintf.h>
+#endif /* HAS_PRINTF */
+
 #ifdef HAS_CUSTOM_FILE
 #include CUSTOM_FILE_FILE
 #else
@@ -95,16 +99,16 @@ int sprintf(char *__restrict buffer, const char *__restrict format, ...)
 int vsprintf(char *__restrict buffer, const char *__restrict format, va_list va)
     __attribute__((format(__printf__, 2, 0)));
 
-int snprintf(char* buffer, size_t count, const char *__restrict format, ...)
+int snprintf(char *__restrict buffer, size_t count, const char *__restrict format, ...)
     __attribute__((format(__printf__, 3, 4)));
 
-int vsnprintf(char* buffer, size_t count, const char *__restrict format, va_list va)
+int vsnprintf(char *__restrict buffer, size_t count, const char *__restrict format, va_list va)
     __attribute__((format(__printf__, 3, 0)));
 
-int fprintf(FILE* __restrict stream, const char* __restrict format, ...)
+int fprintf(FILE *__restrict stream, const char *__restrict format, ...)
     __attribute__((format (__printf__, 2, 3)));
 
-int vfprintf(FILE* __restrict stream, const char* __restrict format, va_list va)
+int vfprintf(FILE *__restrict stream, const char *__restrict format, va_list va)
     __attribute__((format(__printf__, 2, 0)));
 
 int asprintf(char **__restrict p_buffer, const char *__restrict format, ...)
@@ -113,8 +117,51 @@ int asprintf(char **__restrict p_buffer, const char *__restrict format, ...)
 int vasprintf(char **__restrict p_buffer, const char *__restrict format, va_list va)
     __attribute__((format(__printf__, 2, 0))) __attribute__((nonnull(1)));
 
-void perror(const char* str);
+void perror(const char *str);
 
 __END_DECLS
+
+#ifdef __cplusplus
+namespace std {
+    using ::size_t;
+    using ::FILE;
+    
+    using ::fopen;
+    using ::fclose;
+    using ::fflush;
+    using ::ferror;
+    using ::feof;
+    using ::clearerr;
+    using ::fputs;
+    using ::fread;
+    using ::fwrite;
+    using ::ftell;
+    using ::fseek;
+    using ::fgetc;
+    using ::fputc;
+    using ::fgets;
+    using ::remove;
+    using ::rewind;
+    using ::getchar;
+    using ::putchar;
+    using ::puts;
+    using ::printf;
+    using ::vprintf;
+    using ::sprintf;
+    using ::vsprintf;
+    using ::snprintf;
+    using ::vsnprintf;
+    using ::fprintf;
+    using ::vfprintf;
+    using ::asprintf;
+    using ::vasprintf;
+    using ::perror;
+} /* namespace std */
+#endif /* __cplusplus */
+
+#ifndef HAS_PRINTF
+# define snprintf boot_snprintf
+# define asprintf boot_asprintf
+#endif /* HAS_PRINTF */
 
 #endif /* _STDIO_H */

--- a/src/libc/include/string.h
+++ b/src/libc/include/string.h
@@ -44,7 +44,7 @@ char *stpcpy(char *__restrict dest, const char *__restrict src)
 char *stpncpy(char *__restrict dest, const char *__restrict src, size_t n)
     __NOEXCEPT __attribute__((nonnull(1, 2)));
 
-char *strlcpy(char *__restrict dest, const char *__restrict src, size_t n)
+size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t n)
     __NOEXCEPT __attribute__((nonnull(1, 2)));
 
 char *strcat(char *__restrict dest, const char *__restrict src)
@@ -53,7 +53,7 @@ char *strcat(char *__restrict dest, const char *__restrict src)
 char *strncat(char *__restrict dest, const char *__restrict src, size_t n)
     __attribute__((nonnull(1, 2)));
 
-char *strlcat(char *__restrict dest, const char *__restrict src, size_t n)
+size_t strlcat(char *__restrict dest, const char *__restrict src, size_t n)
     __NOEXCEPT __attribute__((nonnull(1, 2)));
 
 char *strchr(const char *s, int c)

--- a/src/libc/include/wchar.h
+++ b/src/libc/include/wchar.h
@@ -17,7 +17,9 @@ typedef __WCHAR_TYPE__ wchar_t;
 #define WCHAR_MAX   __WCHAR_MAX__
 #endif
 
+#ifndef WEOF
 #define WEOF -1
+#endif
 
 __BEGIN_DECLS
 

--- a/src/libc/nanoprintf.c
+++ b/src/libc/nanoprintf.c
@@ -641,11 +641,9 @@ static void npf_putc_std(int c, void *ctx) {
   outchar(c);
 }
 
-#if 0
 static void npf_fputc_std(int c, void *ctx) {
   fputc(c, (FILE*)ctx);
 }
-#endif
 
 typedef struct npf_cnt_putc_ctx {
   npf_putc pc;
@@ -1067,7 +1065,6 @@ int _asprintf_c(char **__restrict p_str, const char *__restrict format, ...) {
   return ret;
 }
 
-#if 0
 int _vfprintf_c(FILE* __restrict stream, const char* __restrict format, va_list vlist)
 {
   return npf_vpprintf(npf_fputc_std, (void*)stream, format, vlist);
@@ -1081,7 +1078,6 @@ int _fprintf_c(FILE* __restrict stream, const char* __restrict format, ...)
   va_end(va);
   return ret;
 }
-#endif
 
 #if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
   #pragma GCC diagnostic pop

--- a/src/libc/printf.src
+++ b/src/libc/printf.src
@@ -1,45 +1,16 @@
 	assume	adl=1
 
 	section	.text
-	public	_sprintf
 
 if HAS_PRINTF
 
 	public	_printf
 	public	_vprintf
-	public	_vsprintf
-	public	_snprintf
-	public	_vsnprintf
-	public	_asprintf
-	public	_vasprintf
-	;public	_fprintf
-	;public	_vfprintf
 
 _printf := __printf_c
 _vprintf := __vprintf_c
-_sprintf := __sprintf_c
-_vsprintf := __vsprintf_c
-_snprintf := __snprintf_c
-_vsnprintf := __vsnprintf_c
-_asprintf := __asprintf_c
-_vasprintf := __vasprintf_c
-;_fprintf := __fprintf_c
-;_vfprintf := __vfprintf_c
 
 	extern	__printf_c
 	extern	__vprintf_c
-	extern	__sprintf_c
-	extern	__vsprintf_c
-	extern	__snprintf_c
-	extern	__vsnprintf_c
-	extern	__asprintf_c
-	extern	__vasprintf_c
-	;extern	__fprintf_c
-	;extern	__vfprintf_c
-
-else
-
-_sprintf := 0000BCh
 
 end if
-

--- a/src/libc/snprintf.src
+++ b/src/libc/snprintf.src
@@ -1,0 +1,16 @@
+	assume	adl=1
+
+	section	.text
+
+if HAS_PRINTF
+
+	public	_snprintf
+	public	_vsnprintf
+
+_snprintf := __snprintf_c
+_vsnprintf := __vsnprintf_c
+
+	extern	__snprintf_c
+	extern	__vsnprintf_c
+
+end if

--- a/src/libc/sprintf.src
+++ b/src/libc/sprintf.src
@@ -1,0 +1,22 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_sprintf
+
+if HAS_PRINTF
+
+	public	_vsprintf
+
+_sprintf := __sprintf_c
+_vsprintf := __vsprintf_c
+
+	extern	__sprintf_c
+	extern	__vsprintf_c
+
+else
+
+; OS routine
+_sprintf := 0000BCh
+
+end if

--- a/src/libcxx/include/climits
+++ b/src/libcxx/include/climits
@@ -2,7 +2,7 @@
 #ifndef _EZCXX_CLIMITS
 #define _EZCXX_CLIMITS
 
-#include <climits>
+#include <limits.h>
 
 #pragma clang system_header
 

--- a/src/libcxx/include/cstdio
+++ b/src/libcxx/include/cstdio
@@ -6,42 +6,4 @@
 
 #pragma clang system_header
 
-namespace std {
-using ::size_t;
-using ::FILE;
-
-using ::fopen;
-using ::fclose;
-using ::fflush;
-using ::ferror;
-using ::feof;
-using ::clearerr;
-using ::fputs;
-using ::fread;
-using ::fwrite;
-using ::ftell;
-using ::fseek;
-using ::fgetc;
-using ::fputc;
-using ::fgets;
-using ::remove;
-using ::rewind;
-using ::getchar;
-using ::putchar;
-using ::puts;
-using ::printf;
-using ::vprintf;
-using ::sprintf;
-using ::vsprintf;
-using ::snprintf;
-using ::vsnprintf;
-#if 0
-using ::fprintf;
-using ::vfprintf;
-#endif
-using ::asprintf;
-using ::vasprintf;
-using ::perror;
-} // namespace std
-
 #endif // _EZCXX_CSTDINT

--- a/test/standalone/asprintf_fprintf/src/main.c
+++ b/test/standalone/asprintf_fprintf/src/main.c
@@ -5,16 +5,16 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
-#include <ti_sprintf.h>
+#include <boot_sprintf.h>
 #include <ctype.h>
 
 /**
  * @brief Tests the following functions/macros:
- * ti_sprintf
- * ti_snprintf
- * ti_asprintf
+ * boot_sprintf
+ * boot_snprintf
+ * boot_asprintf
  * asprintf
- * fprintf // disabled for now
+ * fprintf
  * stpcpy
  * memccpy
  */
@@ -69,11 +69,9 @@ static const int pos_2 = 42;
 static char* buf = NULL;
 static FILE* file = NULL;
 
-static char sprintfbuf[200] = {0};
-
-int ti_tests(void) {
+int boot_sprintf_tests(void) {
     int pos;
-    int len = ti_asprintf(
+    int len = boot_asprintf(
         &buf, "%+d %s%% %#o %#x %n %#X %i\n",
         123, "asprintf", 076543, 0x9abcd, &pos, 0xFE1, 0
     );
@@ -99,12 +97,12 @@ int ti_tests(void) {
         return __LINE__;
     }
     char append[128];
-    int snprintf_test = ti_snprintf(append, 20, "%s", test_1);
+    int snprintf_test = boot_snprintf(append, 20, "%s", test_1);
     if (snprintf_test >= 0) {
         printf("sprintf_test: %d\n", snprintf_test);
         return __LINE__;
     }
-    int len_2 = ti_snprintf(append, sizeof(append), "%s", test_1);
+    int len_2 = boot_snprintf(append, sizeof(append), "%s", test_1);
     if (len_2 != (int)T_strlen(test_1)) {
         printf("E: %d != %zu\n", len_2, T_strlen(test_1));
         return __LINE__;
@@ -159,7 +157,6 @@ int nano_tests(void) {
     return 0;
 }
 
-#if 0
 static char const * const fprintf_test =
     "Terminal ':' (found):\t\"Stars:\"\n"
     "Terminal ' ' (found):\t\"Stars: \"\n"
@@ -170,7 +167,6 @@ static char const * const fprintf_test =
     "Separate star names from distances (ly):\n"
     "Arcturus Vega Capella Rigel Procyon \n"
 /* fprintf_test */;
-#endif
 
 static char const * const file_name = "FPRINTST";
 
@@ -212,9 +208,8 @@ int memccpy_tests(void) {
     for (size_t i = 0; i != sizeof terminal; ++i)
     {
         void* to = T_memccpy(dest, src, terminal[i], sizeof dest);
-
-        sprintf(sprintfbuf, "Terminal '%c' (%s):\t\"", terminal[i], to ? "found" : "absent");
-        fputs(sprintfbuf, file);
+ 
+        fprintf(file,"Terminal '%c' (%s):\t\"", terminal[i], to ? "found" : "absent");
  
         // if `terminal` character was not found - print the whole `dest`
         to = to ? to : dest + sizeof dest;
@@ -227,8 +222,7 @@ int memccpy_tests(void) {
     }
  
  
-    sprintf(sprintfbuf, "%c%s", '\n', "Separate star names from distances (ly):\n");
-    fputs(sprintfbuf, file);
+    fprintf(file, "%c%s", '\n', "Separate star names from distances (ly):\n");
     const char *star_distance[] = {
         "Arcturus : 37", "Vega : 25", "Capella : 43", "Rigel : 860", "Procyon : 11"
     };
@@ -247,8 +241,7 @@ int memccpy_tests(void) {
 
     if (first) {
         *first = '\0';
-        sprintf(sprintfbuf, "%s%c", names_only, '\n');
-        fputs(sprintfbuf, file);
+        fprintf(file, "%s%c", names_only, '\n');
     } else {
         printf("Error Buffer is too small.\n");
     }
@@ -273,7 +266,6 @@ int memccpy_tests(void) {
         perror("Error reading from file");
         return __LINE__;
     }
-#if 0
     if (T_strlen(buf) != T_strlen(fprintf_test)) {
         printf("E: %zu != %zu\n", T_strlen(buf), T_strlen(fprintf_test));
         get_diff_char(buf, fprintf_test);
@@ -285,7 +277,6 @@ int memccpy_tests(void) {
         get_diff_char(buf, fprintf_test);
         return __LINE__;
     }
-#endif
     return 0;
 }
 
@@ -323,8 +314,8 @@ int mempcpy_test(void) {
 
 int run_tests(void) {
     int ret = 0;
-    /* ti_asprintf */
-        ret = ti_tests();
+    /* boot_asprintf */
+        ret = boot_sprintf_tests();
         free(buf); buf = NULL;
         if (ret != 0) { return ret; }
 
@@ -356,7 +347,11 @@ int main(void)
     if (ret != 0) {
         printf("Failed test L%d\n", ret);
     } else {
-        printf("All tests passed\n");
+        #if 1
+            fprintf(stdout, "All tests %s", "passed");
+        #else
+            printf("All tests %s", "passed");
+        #endif
     }
     
     while (!os_GetCSC());


### PR DESCRIPTION
Currently writing documentation for `boot_sprintf`

One thing to decide on is if `boot_snprintf` and `boot_asprintf` should be defined to `snprintf` and `asprintf` if `HAS_PRINTF = NO` 