### PR TITLE
Optimized nanoprintf, and fixed boot_sprintf macro aliases

### DIFF
--- a/src/libc/fprintf.src
+++ b/src/libc/fprintf.src
@@ -10,7 +10,26 @@ if HAS_PRINTF
 _fprintf := __fprintf_c
 _vfprintf := __vfprintf_c
 
+	public	_npf_fputc_std
+_npf_fputc_std:
+;	call	__frameset0
+;	ld	hl, (ix + 6)
+;	ld	de, (ix + 9)
+;	ld	(ix + 6), hl
+;	ld	(ix + 9), de
+;	pop	ix
+;	jp	_fputc
+	ld	hl, 9
+	add	hl, sp
+	ld	de, (hl)
+	dec	hl
+	dec	hl
+	dec	hl
+	ld	hl, (hl)
+	jp	_fputc
+
 	extern	__fprintf_c
 	extern	__vfprintf_c
+	extern	_fputc
 
 end if

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -4,7 +4,7 @@
 #include <cdefs.h>
 #include <stdarg.h>
 
-#ifndef HAS_PRINTF
+#if defined(HAS_PRINTF) && HAS_PRINTF == 0
 # include <ti/sprintf.h>
 #endif /* HAS_PRINTF */
 
@@ -159,7 +159,7 @@ namespace std {
 } /* namespace std */
 #endif /* __cplusplus */
 
-#ifndef HAS_PRINTF
+#if defined(HAS_PRINTF) && HAS_PRINTF == 0
 # define snprintf boot_snprintf
 # define asprintf boot_asprintf
 #endif /* HAS_PRINTF */

--- a/src/libc/nanoprintf.c
+++ b/src/libc/nanoprintf.c
@@ -240,9 +240,40 @@ typedef struct {
   size_t cur;
 } npf_bufputc_ctx_t;
 
-static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec);
+#if 0
+
 static void npf_bufputc(int c, void *ctx);
 static void npf_bufputc_nop(int c, void *ctx);
+
+static void npf_bufputc(int c, void *ctx) {
+  npf_bufputc_ctx_t *bpc = (npf_bufputc_ctx_t *)ctx;
+  if (bpc->cur < bpc->len) { bpc->dst[bpc->cur++] = (char)c; }
+}
+
+static void npf_bufputc_nop(int c, void *ctx) { (void)c; (void)ctx; }
+
+static void npf_putc_std(int c, void *ctx) {
+  (void)ctx;
+  outchar(c);
+}
+
+static void npf_fputc_std(int c, void *ctx) {
+  fputc(c, (FILE*)ctx);
+}
+
+#else
+
+void npf_bufputc(int c, void *ctx);
+
+void npf_bufputc_nop(int c, void *ctx) __attribute__((__const__, __leaf__, __nothrow__));
+
+void npf_putc_std(int c, void *ctx);
+
+void npf_fputc_std(int c, void *ctx);
+
+#endif
+
+static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec);
 static int npf_itoa_rev(char *buf, npf_int_t i);
 static int npf_utoa_rev(char *buf, npf_uint_t i, unsigned base, unsigned case_adjust);
 
@@ -628,22 +659,6 @@ static int npf_bin_len(npf_uint_t u) {
 #endif
 }
 #endif
-
-static void npf_bufputc(int c, void *ctx) {
-  npf_bufputc_ctx_t *bpc = (npf_bufputc_ctx_t *)ctx;
-  if (bpc->cur < bpc->len) { bpc->dst[bpc->cur++] = (char)c; }
-}
-
-static void npf_bufputc_nop(int c, void *ctx) { (void)c; (void)ctx; }
-
-static void npf_putc_std(int c, void *ctx) {
-  (void)ctx;
-  outchar(c);
-}
-
-static void npf_fputc_std(int c, void *ctx) {
-  fputc(c, (FILE*)ctx);
-}
 
 typedef struct npf_cnt_putc_ctx {
   npf_putc pc;

--- a/src/libc/nanoprintf.src
+++ b/src/libc/nanoprintf.src
@@ -1,0 +1,45 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_npf_bufputc_nop
+	public	_npf_bufputc
+
+_npf_bufputc:
+;	call	__frameset0
+;	ld	iy, (ix + 9)
+;	ld	de, (iy + 6)
+;	ld	bc, (iy + 3)
+;	push	de
+;	pop	hl
+;	or	a, a
+;	sbc	hl, bc
+;	jr	nc, .finish
+;	ld	a, (ix + 6)
+;	ld	hl, (iy)
+;	push	de
+;	pop	bc
+;	inc	bc
+;	ld	(iy + 6), bc
+;	add	hl, de
+;	ld	(hl), a
+;.finish:
+;	pop	ix
+;	ret
+	ld	iy, 0
+	add	iy, sp
+	ld	a, (iy + 3)
+	ld	iy, (iy + 6)
+	ld	hl, (iy + 6)
+	ld	bc, (iy + 3)
+	sbc	hl, bc	; carry not set
+	ret	nc
+	add	hl, bc
+	ex	de, hl
+	ld	hl, (iy)
+	add	hl, de
+	inc	de
+	ld	(iy + 6), de
+	ld	(hl), a
+_npf_bufputc_nop:
+	ret

--- a/src/libc/printf.src
+++ b/src/libc/printf.src
@@ -10,7 +10,21 @@ if HAS_PRINTF
 _printf := __printf_c
 _vprintf := __vprintf_c
 
+	public	_npf_putc_std
+
+_npf_putc_std:
+;	call	__frameset0
+;	ld	a, (ix + 6)
+;	ld	(ix + 6), a
+;	pop	ix
+;	jp	_outchar
+	ld	hl, 6
+	add	hl, sp
+	ld	a, (hl)
+	jp	_outchar
+
 	extern	__printf_c
 	extern	__vprintf_c
+	extern	_outchar
 
 end if


### PR DESCRIPTION
implemented `npf_bufputc`, `npf_bufputc_nop`, `npf_putc_std`, and `npf_fputc_std` in assembly. This results in both smaller and faster routines

I also realized that `HAS_PRINTF` is not defined in C, which meant that the `boot_sprintf` macro aliases were always defined when including `<stdio.h>`
```c++
#ifndef HAS_PRINTF
# define snprintf boot_snprintf
# define asprintf boot_asprintf
#endif /* HAS_PRINTF */
```
This has now been fixed so they will only be enabled when HAS_PRINTF is defined and zero in C
```c++
#if defined(HAS_PRINTF) && HAS_PRINTF == 0
# define snprintf boot_snprintf
# define asprintf boot_asprintf
#endif /* HAS_PRINTF */
```