### PR TITLE
Added `boot_vsprintf`

### DIFF
--- a/src/libc/asprintf.src
+++ b/src/libc/asprintf.src
@@ -2,15 +2,23 @@
 
 	section	.text
 
-if HAS_PRINTF
-
 	public	_asprintf
 	public	_vasprintf
+
+if HAS_PRINTF
 
 _asprintf := __asprintf_c
 _vasprintf := __vasprintf_c
 
 	extern	__asprintf_c
 	extern	__vasprintf_c
+
+else
+
+_asprintf := _boot_asprintf
+_vasprintf := _boot_vasprintf
+
+	extern	_boot_asprintf
+	extern	_boot_vasprintf
 
 end if

--- a/src/libc/boot_vsprintf.c
+++ b/src/libc/boot_vsprintf.c
@@ -1,0 +1,54 @@
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <ti/sprintf.h>
+
+#define SINK (char *__restrict)0xE40000
+
+int boot_vsnprintf(char *__restrict buffer, size_t count, const char *__restrict format, va_list args) {
+    int str_len = boot_vsprintf(SINK, format, args);
+    if (buffer == NULL || count == 0) {
+        return str_len;
+    }
+    if ((size_t)str_len >= count || str_len <= 0) {
+        // won't fit or invalid formatting
+        *buffer = '\0';
+        return str_len;
+    }
+    return boot_vsprintf(buffer, format, args);
+}
+
+int boot_snprintf(char *__restrict buffer, size_t count, const char *__restrict format, ...) {
+    va_list args;
+    va_start(args, format);
+    const int ret = vsnprintf(buffer, count, format, args);
+    va_end(args);
+    return ret;
+}
+
+int boot_vasprintf(char **__restrict p_buffer, const char *__restrict format, va_list args) {
+    int ret = -1;
+    *p_buffer = NULL;
+    int str_len = boot_vsprintf(SINK, format, args);
+    if (str_len < 0) {
+        // formatting error
+        return str_len;
+    }
+    size_t buffer_size = (size_t)str_len + 1;
+    *p_buffer = (char*)malloc(buffer_size);
+    if (*p_buffer != NULL) {
+        ret = boot_vsprintf(*p_buffer, format, args);
+    }
+    return ret;
+}
+
+int boot_asprintf(char **__restrict p_str, const char *__restrict format, ...) {
+    va_list args;
+    va_start(args, format);
+    const int ret = boot_vasprintf(p_str, format, args);
+    va_end(args);
+    return ret;
+}

--- a/src/libc/boot_vsprintf.src
+++ b/src/libc/boot_vsprintf.src
@@ -1,0 +1,74 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_boot_vsprintf
+
+; wraps boot_sprintf
+_boot_vsprintf:
+	call	__frameset0
+	; Get length of format string, plus 1
+	ld	hl, (ix + 9)
+	push	hl
+	push	hl
+	call	_strlen
+	pop	bc
+	ex	(sp), hl
+	pop	bc
+	inc	bc
+	; Track pointer to stack allocation
+	lea	de, ix
+.countSpecifiersLoop:
+	ld	a, '%'
+.countSpecifiersInnerLoop:
+	; Find format specifier
+	cpir
+	jr	nz, .countDone
+	; Check for escaped specifier
+	cpi
+	jr	z, .countSpecifiersInnerLoop
+	dec	hl
+	inc	bc
+	ld	a, '*'
+.countSpecifiersIncrement:
+	; Add one parameter
+	dec	de
+	dec	de
+	dec	de
+.countSpecifiersFormat:
+	; Check for end of specifier
+	bit	6, (hl)
+	jr	nz, .countSpecifiersLoop
+	; Check for additional variable-length parameter
+	cpi
+	jr	z, .countSpecifiersIncrement
+	; Check for end of string
+	jp	pe, .countSpecifiersFormat
+.countDone:
+	; Get length of parameters
+	lea	hl, ix
+	or	a, a
+	sbc	hl, de
+	jr	z, .noCopy
+	; Allocate space for parameters
+	ex	de, hl
+	ld	sp, hl
+	ex	de, hl
+	; Copy parameters
+	push	hl
+	pop	bc
+	ld	hl, (ix + 12)
+	ldir
+.noCopy:
+	ld	hl, (ix + 9)
+	push	hl
+	ld	hl, (ix + 6)
+	push	hl
+	call	_boot_sprintf
+	ld	sp, ix
+	pop	ix
+	ret
+
+	extern	_boot_sprintf
+	extern	__frameset0
+	extern	_strlen

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -4,10 +4,6 @@
 #include <cdefs.h>
 #include <stdarg.h>
 
-#ifndef HAS_PRINTF
-# include <ti/sprintf.h>
-#endif /* HAS_PRINTF */
-
 #ifdef HAS_CUSTOM_FILE
 #include CUSTOM_FILE_FILE
 #else
@@ -158,10 +154,5 @@ namespace std {
     using ::perror;
 } /* namespace std */
 #endif /* __cplusplus */
-
-#ifndef HAS_PRINTF
-# define snprintf boot_snprintf
-# define asprintf boot_asprintf
-#endif /* HAS_PRINTF */
 
 #endif /* _STDIO_H */

--- a/src/libc/snprintf.src
+++ b/src/libc/snprintf.src
@@ -2,15 +2,23 @@
 
 	section	.text
 
-if HAS_PRINTF
-
 	public	_snprintf
 	public	_vsnprintf
+
+if HAS_PRINTF
 
 _snprintf := __snprintf_c
 _vsnprintf := __vsnprintf_c
 
 	extern	__snprintf_c
 	extern	__vsnprintf_c
+
+else
+
+_snprintf := _boot_snprintf
+_vsnprintf := _boot_vsnprintf
+
+	extern	_boot_snprintf
+	extern	_boot_vsnprintf
 
 end if

--- a/src/libc/sprintf.src
+++ b/src/libc/sprintf.src
@@ -6,13 +6,9 @@
 
 if HAS_PRINTF
 
-	public	_vsprintf
-
 _sprintf := __sprintf_c
-_vsprintf := __vsprintf_c
 
 	extern	__sprintf_c
-	extern	__vsprintf_c
 
 else
 

--- a/src/libc/vsprintf.src
+++ b/src/libc/vsprintf.src
@@ -1,0 +1,19 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_vsprintf
+
+if HAS_PRINTF
+
+_vsprintf := __vsprintf_c
+
+	extern	__vsprintf_c
+
+else
+
+_vsprintf := _boot_vsprintf
+
+	extern	_boot_vsprintf
+
+end if

--- a/test/graphx/zx0/.gitignore
+++ b/test/graphx/zx0/.gitignore
@@ -4,3 +4,4 @@ src/gfx/*.c
 src/gfx/*.h
 .DS_Store
 convimg.out
+src/gfx/convimg.yaml.lst

--- a/test/standalone/asprintf_fprintf/autotest.json
+++ b/test/standalone/asprintf_fprintf/autotest.json
@@ -8,7 +8,7 @@
   },
   "sequence": [
     "action|launch",
-    "delay|1500",
+    "delay|2000",
     "hashWait|1",
     "key|enter",
     "delay|300",

--- a/test/standalone/asprintf_fprintf/makefile
+++ b/test/standalone/asprintf_fprintf/makefile
@@ -13,6 +13,8 @@ CXXFLAGS = -Wall -Wextra -Wformat=2 -Wshadow -Oz
 
 PREFER_OS_LIBC = NO
 
+HAS_PRINTF = YES
+
 # ----------------------------
 
 include $(shell cedev-config --makefile)


### PR DESCRIPTION
Changes:
* `boot_vsprintf` was added, allowing for `boot_snprintf boot_asprintf` to be implemented as functions instead of macros