### PR TITLE
Fixed std::bit_ceil, made it behave the same as C23 stdc_bit_ceil

### DIFF
--- a/src/libcxx/include/bit
+++ b/src/libcxx/include/bit
@@ -326,44 +326,32 @@ _Tp bit_ceil(_Tp __t) noexcept;
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned char bit_ceil(unsigned char __t) noexcept {
-    return
-        (__t <= static_cast<unsigned char>(std::numeric_limits<signed char>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned char>(1) << bit_width<unsigned char>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned char>(2) << (bit_width<unsigned char>(__t - 1) - 1)));
 }
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned short bit_ceil(unsigned short __t) noexcept {
-    return
-        (__t <= static_cast<unsigned short>(std::numeric_limits<signed short>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned short>(1) << bit_width<unsigned short>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned short>(2) << (bit_width<unsigned short>(__t - 1) - 1)));
 }
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned int bit_ceil(unsigned int __t) noexcept {
-    return
-        (__t <= static_cast<unsigned int>(std::numeric_limits<signed int>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned int>(1) << bit_width<unsigned int>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned int>(2) << (bit_width<unsigned int>(__t - 1) - 1)));
 }
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned long bit_ceil(unsigned long __t) noexcept {
-    return
-        (__t <= static_cast<unsigned long>(std::numeric_limits<signed long>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned long>(1) << bit_width<unsigned long>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned long>(2) << (bit_width<unsigned long>(__t - 1) - 1)));
 }
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned __int48 bit_ceil(unsigned __int48 __t) noexcept {
-    return
-        (__t <= static_cast<unsigned __int48>(std::numeric_limits<signed __int48>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned __int48>(1) << bit_width<unsigned __int48>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned __int48>(2) << (bit_width<unsigned __int48>(__t - 1) - 1)));
 }
 
 template <> _EZCXX_NODISCARD _EZCXX_INLINE constexpr
 unsigned long long bit_ceil(unsigned long long __t) noexcept {
-    return
-        (__t <= static_cast<unsigned long long>(std::numeric_limits<signed long long>::min()))
-        ? ((__t != 0) ? (static_cast<unsigned long long>(1) << bit_width<unsigned long long>(__t - 1)) : 1) : 0;
+    return ((__t < 2) ? 1 : (static_cast<unsigned long long>(2) << (bit_width<unsigned long long>(__t - 1) - 1)));
 }
 
 //------------------------------------------------------------------------------

--- a/test/standalone/stdbit/src/main.cpp
+++ b/test/standalone/stdbit/src/main.cpp
@@ -349,15 +349,12 @@ int test_bit_ceil(void) {
     C((std::bit_ceil( one_u32) ==  one_u32));
     C((std::bit_ceil( one_u48) ==  one_u48));
     C((std::bit_ceil( one_u64) ==  one_u64));
-    // optional undefined behaviour
-#if 0
     C((std::bit_ceil(umax_u8 ) == zero_u8 ));
     C((std::bit_ceil(umax_u16) == zero_u16));
     C((std::bit_ceil(umax_u24) == zero_u24));
     C((std::bit_ceil(umax_u32) == zero_u32));
     C((std::bit_ceil(umax_u48) == zero_u48));
     C((std::bit_ceil(umax_u64) == zero_u64));
-#endif
     C((std::bit_ceil(smax_u8 ) == smin_u8 ));
     C((std::bit_ceil(smax_u16) == smin_u16));
     C((std::bit_ceil(smax_u24) == smin_u24));


### PR DESCRIPTION
calc84maniac suggested this code to allow `std::bit_ceil` to avoid UB
`(value < 2 ? 1 : 2 << (stdc_bit_width(value - 1) - 1)`