### PR TITLE
fixed boot_snprintf, and nanoprintf linking bugs

### DIFF
--- a/docs/headers/ti/sprintf.rst
+++ b/docs/headers/ti/sprintf.rst
@@ -12,7 +12,7 @@ The OS comes with an implementation of ANSI C89 `sprintf`, which can reduce the 
 boot_sprintf
 ------------
 
-The following type specifiers are supported :code:`%s %c %d %i %u %o %x %X %p %n`. The minimum field width :code:`*`, precision :code:`.*`, alongside :code:`-+#0` and the space flag are also supported.
+The following type specifiers are supported :code:`%s %c %d %i %u %o %x %X %p %n`. The minimum field width :code:`*`, precision :code:`.*`, alongside :code:`-+#0` and the space flag are also supported. However, the precision :code:`.*` field is ignored for integers.
 
 All length modifiers :code:`hh h l ll j z t L` and floating point specifiers :code:`%f %g %e %a` are **not** supported.
 

--- a/src/libc/boot_vsprintf.c
+++ b/src/libc/boot_vsprintf.c
@@ -24,7 +24,7 @@ int boot_vsnprintf(char *__restrict buffer, size_t count, const char *__restrict
 int boot_snprintf(char *__restrict buffer, size_t count, const char *__restrict format, ...) {
     va_list args;
     va_start(args, format);
-    const int ret = vsnprintf(buffer, count, format, args);
+    const int ret = boot_vsnprintf(buffer, count, format, args);
     va_end(args);
     return ret;
 }

--- a/test/standalone/asprintf_fprintf/src/main.c
+++ b/test/standalone/asprintf_fprintf/src/main.c
@@ -73,7 +73,7 @@ static char const * const test_3 =
 "sprintf%%%% %%is unsafe";
 static const int pos_3 = 20;
 
-static const int pos_4 = 209;
+static const int pos_4 = 212;
 
 static char* buf = NULL;
 static FILE* file = NULL;
@@ -153,7 +153,7 @@ int boot_sprintf_tests(void) {
         "%%%.*s\n"
         "Characters:\t%c %%\n"
         "Integers:\n"
-        "%%*Decimal:\t%i %d %.6i %i %.0i %+i %i\n"
+        "%%*Decimal:\t%i %d %.6i %i %3u %+i %i\n"
         "*%%Hexadecimal:\t%x %x %X %#x\n"
         "%%*.*%%Octal:\t%o %#o %#o\n"
         "Width trick: %*d \n",
@@ -256,7 +256,7 @@ int nano_tests(void) {
         "%%%.*s\n"
         "Characters:\t%c %%\n"
         "Integers:\n"
-        "%%*Decimal:\t%i %d %.6i %i %.0i %+i %i\n"
+        "%%*Decimal:\t%i %d %.6i %i %3u %+i %i\n"
         "*%%Hexadecimal:\t%x %x %X %#x\n"
         "%%*.*%%Octal:\t%o %#o %#o\n"
         "Width trick: %*d \n",
@@ -466,6 +466,27 @@ int run_tests(void) {
 
     return 0;
 }
+
+#if 0
+static void write_letter(char c) {
+    if (isgraph(c)) {
+        fputc(c, stdout);
+        return;
+    }
+    fputc('\\', stdout);
+    switch (c) {
+        case '\0': fputc('0', stdout); return;
+        case ' ': fputc('s', stdout); return;
+        case '\n': fputc('n', stdout); return;
+        case '\t': fputc('t', stdout); return;
+        case '\v': fputc('v', stdout); return;
+        case '\r': fputc('r', stdout); return;
+        case '\f': fputc('f', stdout); return;
+        case '\b': fputc('b', stdout); return;
+        default: printf("x%02X", (unsigned int)c); return;
+    }
+}
+#endif
 
 int main(void)
 {


### PR DESCRIPTION
`boot_snprintf` had a call to `vnsprintf` instead of `boot_vnsprintf` by mistake.

The user is unlikely to directly call `vprintf` or `vfprintf`, so they have been forced inlined into `printf` and `fprintf`. This saves space as code for `vprintf` and `vfprintf` won't need to be linked in most cases. I would've done this with `vasprintf`, and `vsnprintf`, but they are considerably larger
```c++
__attribute__((__always_inline__))
int _vprintf_c(const char *__restrict format, va_list vlist)
{
  return npf_vpprintf(npf_putc_std, NULL, format, vlist);
}

int _printf_c(char const *__restrict format, ...) {
  va_list va;
  va_start(va, format);
  int const rv = _vprintf_c(format, va);
  va_end(va);
  return rv;
}
```