### PR TITLE
Optimized memcpy and mempcpy

### DIFF
--- a/src/libc/bzero.src
+++ b/src/libc/bzero.src
@@ -1,0 +1,20 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_bzero
+
+; void bzero(void* buf, size_t n)
+_bzero:
+	ld	hl, 6
+	add	hl, sp
+	ld	bc, (hl)	; size
+	inc	bc
+	cpd	; dec hl
+	ret	po	; zero size
+	dec	hl
+	dec	hl
+	ld	de, (hl)	; buf
+	ld	hl, $E40000	; large region of all zeros on the Ti84CE
+	ldir
+	ret

--- a/src/libc/include/string.h
+++ b/src/libc/include/string.h
@@ -14,6 +14,9 @@ void *memmove(void *dest, const void *src, size_t n)
 void *memset(void *s, int c, size_t n)
     __attribute__((nonnull(1)));
 
+void bzero(void *s, size_t n)
+    __attribute__((nonnull(1)));
+
 int memcmp(const void *s1, const void *s2, size_t n)
     __attribute__((nonnull(1, 2)));
 

--- a/src/libc/memcpy.src
+++ b/src/libc/memcpy.src
@@ -1,6 +1,7 @@
 	assume	adl=1
 
 	section	.text
+
 	public	_memcpy
 
 if PREFER_OS_LIBC
@@ -10,19 +11,17 @@ _memcpy := $0000A4
 else
 
 _memcpy:
-	ld	iy,0
-	add	iy,sp
-	ld	bc,(iy + 9)  ; Load count
-	sbc	hl,hl
-	sbc	hl,bc
-	jr	z,.zero
-	ld	de,(iy + 3)  ; Load destination
-	ld	hl,(iy + 6)  ; Load source
+	ld	iy, -1
+	add	iy, sp
+	ld	bc, (iy + 10)  ; Load count
+	sbc	hl, hl
+	add	hl, bc
+	jr	nc, .zero
+	ld	de, (iy + 4)  ; Load destination
+	ld	hl, (iy + 7)  ; Load source
 	ldir
 .zero:
-	ld	hl,(iy + 3)  ; Return the destination pointer
+	ld	hl, (iy + 4)  ; Return the destination pointer
 	ret
 
 end if
-
-

--- a/src/libc/mempcpy.src
+++ b/src/libc/mempcpy.src
@@ -8,14 +8,14 @@ if 0
 
 ; faster when count is zero
 _mempcpy:
-	ld	iy, 0
+	ld	iy, -1
 	add	iy, sp
-	ld	bc, (iy + 9)	; Load count
+	ld	bc, (iy + 10)	; Load count
 	sbc	hl, hl
-	sbc	hl, bc
-	ld	hl, (iy + 3)	; Load destination
-	ret	z	; zero bytes to copy
-	ld	de, (iy + 6)	; Load source
+	add	hl, bc
+	ld	hl, (iy + 4)	; Load destination
+	ret	nc	; zero bytes to copy
+	ld	de, (iy + 7)	; Load source
 	ex	de, hl
 	ldir
 	ex	de, hl
@@ -25,14 +25,14 @@ else
 
 ; faster in full execution case by 0F + 1 clock cycles
 _mempcpy:
-	ld	iy, 0
+	ld	iy, -1
 	add	iy, sp
-	ld	bc, (iy + 9)	; Load count
+	ld	bc, (iy + 10)	; Load count
 	sbc	hl, hl
-	sbc	hl, bc
-	ld	de, (iy + 3)	; Load destination
-	jr	z, .zero_byte_copy	; zero bytes to copy
-	ld	hl, (iy + 6)	; Load source
+	add	hl, bc
+	ld	de, (iy + 4)	; Load destination
+	jr	nc, .zero_byte_copy	; zero bytes to copy
+	ld	hl, (iy + 7)	; Load source
 	ldir
 .zero_byte_copy:
 	ex	de, hl

--- a/src/libc/memset.src
+++ b/src/libc/memset.src
@@ -1,21 +1,20 @@
 	assume	adl=1
 
 	section	.text
+
 	public	_memset
+
 _memset:
-	pop	iy
-	pop	hl
-	pop	de
-	pop	bc
-	push	bc
-	push	de
-	push	hl
-	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 3)
+	ld	bc, (iy + 9)
 	cpi
-	add	hl,bc
+	add	hl, bc
 	ret	c
 	dec	hl
-	ld	(hl),e
+	ld	e, (iy + 6)
+	ld	(hl), e
 	ret	po
 	push	hl
 	pop	de

--- a/src/libc/strlen.src
+++ b/src/libc/strlen.src
@@ -10,17 +10,14 @@ _strlen := $0000D4
 else
 
 _strlen:
-	pop	bc
-	ex	(sp),hl
-	push	bc
-	xor	a,a
-	ld	bc,0
+	pop	iy
+	ex	(sp), hl
+	xor	a, a
+	ld	bc, 0
 	cpir
-	or	a,a
-	sbc	hl,hl
+	sbc	hl, hl
 	scf
-	sbc	hl,bc
-	ret
+	sbc	hl, bc
+	jp	(iy)
 
 end if
-

--- a/src/libcxx/include/cstring
+++ b/src/libcxx/include/cstring
@@ -12,6 +12,7 @@ using ::size_t;
 using ::memcpy;
 using ::memmove;
 using ::memset;
+using ::bzero;
 using ::memcmp;
 using ::memchr;
 using ::memrchr;

--- a/test/standalone/asprintf_fprintf/src/main.c
+++ b/test/standalone/asprintf_fprintf/src/main.c
@@ -49,6 +49,8 @@ size_t T_strlen(const char *s)
 int T_strcmp(const char *s1, const char *s2)
     __attribute__((nonnull(1, 2)));
 
+void T_bzero(void* s, size_t n);
+
 #else
 
 #define T_memcpy memcpy
@@ -59,6 +61,7 @@ int T_strcmp(const char *s1, const char *s2)
 #define T_stpcpy stpcpy
 #define T_strlen strlen
 #define T_strcmp strcmp
+#define T_bzero bzero
 
 #endif
 
@@ -439,6 +442,35 @@ int mempcpy_test(void) {
     return 0;
 }
 
+int bzero_test(void) {
+    char truth[32];
+    char data[32];
+    T_memset(data, 0x8F, sizeof(data));
+    T_memset(&truth[ 0], 0x8F,  8);
+    T_memset(&truth[ 2], 0x00,  1);
+    T_memset(&truth[ 8], 0x00, 17);
+    T_memset(&truth[25], 0x8F,  7);
+    T_bzero(&data[2], 0);
+    T_bzero(&data[2], 1);
+    if (T_strlen(&data[0]) != 2) {
+        return __LINE__;
+    }
+    if (T_strlen(&data[1]) != 1) {
+        return __LINE__;
+    }
+    if (T_strlen(&data[2]) != 0) {
+        return __LINE__;
+    }
+    T_bzero(NULL, 0);
+    T_bzero(&data[8], 17);
+    int cmp = T_memcmp(data, truth, 32);
+    if (cmp != 0) {
+        printf("cmp: %d\n", cmp);
+        return __LINE__;
+    }
+    return 0;
+}
+
 int run_tests(void) {
     int ret = 0;
     /* boot_asprintf */
@@ -462,6 +494,10 @@ int run_tests(void) {
 
     /* mempcpy */
         ret = mempcpy_test();
+        if (ret != 0) { return ret; }
+
+    /* bzero */
+        ret = bzero_test();
         if (ret != 0) { return ret; }
 
     return 0;

--- a/test/standalone/asprintf_fprintf/src/rename.asm
+++ b/test/standalone/asprintf_fprintf/src/rename.asm
@@ -4,6 +4,7 @@
 
 	public	_T_memset, _T_memcpy, _T_memcmp, _T_memccpy, _T_mempcpy
 	public	_T_strlen, _T_strcmp, _T_stpcpy
+	public	_T_bzero
 
 _T_memset := _memset
 _T_memcpy := _memcpy
@@ -15,5 +16,8 @@ _T_strlen := _strlen
 _T_strcmp := _strcmp
 _T_stpcpy := _stpcpy
 
+_T_bzero := _bzero
+
 	extern	_memset, _memcpy, _memcmp, _memccpy, _mempcpy
 	extern	_strlen, _strcmp, _stpcpy
+	extern	_bzero


### PR DESCRIPTION
Changes:
- optimized `memcpy` and `mempcpy`
- optimized `strlen`
- optimized `memset` for speed (Adds 6 bytes and 6F, but removes 5R + 12W in full execution case)
- Added `bzero`. This copies zeros from `0xE40000` which has less read states, thereby making it significantly faster than `memset`.

`memcpy` and `mempcpy` were optimized by turning `NC \ sbc hl, hl \ sbc hl, bc \ ret z` into `C \ sbc hl, hl \ add hl, bc \ ret nc`, saving 1 byte and 1F in all cases. The carry flag is set by doing `ld iy, -1 \ add iy, sp` instead of the usual `ld iy, 0 \ add iy, sp`


