### PR TITLE
Optimized strcmp and strncmp. Also added memrchr

### DIFF
--- a/src/libc/memrchr.src
+++ b/src/libc/memrchr.src
@@ -1,0 +1,24 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_memrchr
+
+_memrchr:
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 3)
+	ld	bc, (iy + 9)
+	dec	bc
+	add	hl, bc
+	jr	c, .ret_zero
+	inc	bc
+	ld	a, (iy + 6)
+	cpdr
+	inc	hl
+	ret	z	; found match
+.ret_zero:
+	; return NULL
+	or	a, a
+	sbc	hl, hl
+	ret

--- a/src/libc/os.src
+++ b/src/libc/os.src
@@ -16,16 +16,12 @@ _setjmp     := 0000B8h
 _strcat     := 0000C0h
 	public	_strchr
 _strchr     := 0000C4h
-	public	_strcmp
-_strcmp     := 0000C8h
 	public	_strcpy
 _strcpy     := 0000CCh
 	public	_strcspn
 _strcspn    := 0000D0h
 	public	_strncat
 _strncat    := 0000D8h
-	public	_strncmp
-_strncmp    := 0000DCh
 	public	_strncpy
 _strncpy    := 0000E0h
 	public	_strpbrk

--- a/src/libc/strcmp.src
+++ b/src/libc/strcmp.src
@@ -1,0 +1,34 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_strcmp
+
+if PREFER_OS_LIBC
+
+_strcmp := $0000C8
+
+else
+
+_strcmp:
+	ld	hl, 3
+	add	hl, sp
+	ld	de, (hl)
+	inc	hl
+	inc	hl
+	inc	hl
+	ld	hl, (hl)
+.loop:
+	ld	a, (de)
+	cp	a, (hl)
+	jr	nz, .finish
+	inc	hl
+	inc	de
+	or	a, a
+	jr	nz, .loop
+.finish:
+	sbc	hl, hl
+	ld	l, a
+	ret
+
+end if

--- a/src/libc/strncmp.src
+++ b/src/libc/strncmp.src
@@ -1,0 +1,42 @@
+	assume	adl=1
+
+	section	.text
+
+	public	_strncmp
+
+if PREFER_OS_LIBC
+
+_strncmp := $0000DC
+
+else
+
+_strncmp:
+	ld	iy, 0
+	add	iy, sp
+	ld	bc, (iy + 9)
+	sbc	hl, hl
+	adc	hl, bc
+	ld	hl, (iy + 6)
+	ld	de, (iy + 3)
+	call	nz, .start	; z means BC was zero
+.ret_zero:
+	sbc	hl, hl
+	ret
+.loop:
+	ret	po	; ret_zero
+	or	a, a
+	ret	z	; ret_zero
+	inc	de
+.start:
+	ld	a, (de)
+	cpi
+	jr	z, .loop
+.finish:
+	ld	sp, iy	; ret
+	dec	hl
+	sub	a, (hl)
+	sbc	hl, hl
+	ld	l, a
+	ret
+
+end if

--- a/test/standalone/asprintf_fprintf/src/rename.asm
+++ b/test/standalone/asprintf_fprintf/src/rename.asm
@@ -2,8 +2,8 @@
 
 	section	.text
 
-	public	_T_memset, _T_memcpy, _T_memcmp, _T_memccpy, _T_mempcpy
-	public	_T_strlen, _T_strcmp, _T_stpcpy
+	public	_T_memset, _T_memcpy, _T_memcmp, _T_memccpy, _T_mempcpy, _T_memrchr
+	public	_T_strlen, _T_strcmp, _T_strncmp, _T_stpcpy
 	public	_T_bzero
 
 _T_memset := _memset
@@ -11,13 +11,15 @@ _T_memcpy := _memcpy
 _T_memcmp := _memcmp
 _T_memccpy := _memccpy
 _T_mempcpy := _mempcpy
+_T_memrchr := _memrchr
 
 _T_strlen := _strlen
 _T_strcmp := _strcmp
+_T_strncmp := _strncmp
 _T_stpcpy := _stpcpy
 
 _T_bzero := _bzero
 
-	extern	_memset, _memcpy, _memcmp, _memccpy, _mempcpy
-	extern	_strlen, _strcmp, _stpcpy
+	extern	_memset, _memcpy, _memcmp, _memccpy, _mempcpy, _memrchr
+	extern	_strlen, _strcmp, _strncmp, _stpcpy
 	extern	_bzero

--- a/test/standalone/strlcpy/autotest.json
+++ b/test/standalone/strlcpy/autotest.json
@@ -1,9 +1,9 @@
 {
   "transfer_files": [
-    "bin/STRLCPY.8xp"
+    "bin/DEMO.8xp"
   ],
   "target": {
-    "name": "STRLCPY",
+    "name": "DEMO",
     "isASM": true
   },
   "sequence": [

--- a/test/standalone/strlcpy/makefile
+++ b/test/standalone/strlcpy/makefile
@@ -2,7 +2,7 @@
 # Makefile Options
 # ----------------------------
 
-NAME = STRLCPY
+NAME = DEMO
 ICON = icon.png
 DESCRIPTION = "strlcpy test"
 COMPRESSED = NO


### PR DESCRIPTION
Optimized `strcmp` and `strncmp`. Also added `memrchr`

`strncmp` has a linear speedup compared to Ti's routine (less clock cycles per character compared), making it much faster

`strcmp` has a constant speedup compared to Ti's routine (same clock cycles per character compared, but takes less clock cycles in total), which may be worth it when multiple short string comparisons need to be performed, such as when parsing text/scripts.
