### PR TITLE
fixed ldexpf, and reduced GDB1 autotest errors

### DIFF
--- a/src/libc/ldexpf.src
+++ b/src/libc/ldexpf.src
@@ -47,9 +47,11 @@ _scalbn:
 	bit	7, (iy + 11)	; scale sign
 	jr	z, .scale_up
 .scale_down:
-	; test signbit
+	; HL is not INT_MIN here
+	dec	hl
 	add	hl, hl
-	jr	nc, .finish
+	jr	nc, .finish	; expon > 0
+	; expon <= 0 or subnormal
 .underflow_to_zero:
 	ld	hl, ___fe_cur_env
 	set	5, (hl)	; FE_INEXACT
@@ -99,7 +101,6 @@ end if
 	ld	e, (iy + 6)
 	ret
 
-
 else
 
 ; normal inputs are handled correctly, unless the output is subnormal
@@ -132,9 +133,12 @@ _scalbn:
 .scale_down:
 	; test signbit
 	push	hl
+	; HL is not INT_MIN here
+	dec	hl
 	add	hl, hl
 	pop	hl
-	jr	nc, .finish
+	jr	nc, .finish	; expon > 0
+	; expon <= 0 or subnormal
 ;	jr	.underflow_to_zero
 .underflow_to_zero:
 	ld	hl, ___fe_cur_env

--- a/test/floating_point/complex/src/main.c
+++ b/test/floating_point/complex/src/main.c
@@ -6,6 +6,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include <complex.h>
 
@@ -191,9 +192,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: L%zu\n", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_classification/src/main.c
+++ b/test/floating_point/float32_classification/src/main.c
@@ -136,11 +136,11 @@ static test_result fpclassify_test(void) {
 
 int main(void) {
     os_ClrHome();
-    printf("Testing 2^" NUM_TO_STR(test_count) " inputs");
+    fputs("Testing 2^" NUM_TO_STR(test_count) " inputs", stdout);
     test_result ret = fpclassify_test();
     os_ClrHome();
     if (ret.passed) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
         printf(
             "Failed test:\n0x%08lX\nTruth: %06o_%d\nGuess: %06o_%d",

--- a/test/floating_point/float32_frexp/src/main.c
+++ b/test/floating_point/float32_frexp/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f32_frexp_LUT.h"
 
@@ -48,9 +49,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_ilogb/src/main.c
+++ b/test/floating_point/float32_ilogb/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f32_ilogb_LUT.h"
 
@@ -23,8 +24,9 @@ size_t run_test(void) {
     for (size_t i = 0; i < length; i++) {
         int result = ilogbf(input[i]);
         if (result != output[i]) {
-            // printf("%3zu: %08lX\n\t%d != %d\n", i, input[i], result, output[i]);
-            // while (!os_GetCSC());
+            #if 0
+                printf("%3zu: %08lX\n\t%d != %d\n", i, input[i], result, output[i]);
+            #endif
             return i;
         }
     }
@@ -34,13 +36,14 @@ size_t run_test(void) {
 }
 
 int main(void) {
-
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_ldexp/src/main.c
+++ b/test/floating_point/float32_ldexp/src/main.c
@@ -29,20 +29,16 @@ size_t run_test(void) {
     for (size_t i = 0; i < length; i++) {
         F32_pun result;
         result.flt = ldexpf(input[i].value, input[i].expon);
-        // ignoring subnormal inputs for now
-        if (issubnormal(input[i].value) || issubnormal(output[i].flt)) {
-            continue;
-        }
         if (result.bin != output[i].bin) {
             // ignore NaN's with differing payloads
             // treat signed zeros as equal for now
             if (
                 (!(isnan(result.flt) && isnan(output[i].flt))) &&
-                (!(iszero(result.flt) && iszero(output[i].flt)))
+                (!(result.bin == 0 && iszero(output[i].flt)))
             ) {
                 /* Float multiplication does not handle subnormals yet */
-                if (!(iszero(result.flt) && issubnormal(output[i].flt))) {
-                    #if 0
+                if (!(iszero(result.flt) && (issubnormal(output[i].flt) || issubnormal(input[i].value)))) {
+                    #if 1
                         printf(
                             "%zu:\nI: %08lX %+d\nG: %08lX\nT: %08lX\n",
                             i, *(uint32_t*)(void*)&(input[i].value), input[i].expon,

--- a/test/floating_point/float32_ldexp/src/main.c
+++ b/test/floating_point/float32_ldexp/src/main.c
@@ -61,7 +61,7 @@ int main(void) {
     if (fail_index == SIZE_MAX) {
         fputs("All tests passed", stdout);
     } else {
-        char buf[sizeof("Failed test: -8388608\n")];
+        char buf[sizeof("Failed test: 16777215\n")];
         boot_sprintf(buf, "Failed test: %u\n", fail_index);
         fputs(buf, stdout);
     }

--- a/test/floating_point/float32_math/src/main.cpp
+++ b/test/floating_point/float32_math/src/main.cpp
@@ -6,6 +6,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include <bit>
 #include <cmath>
@@ -38,7 +39,7 @@ static bool test_result(float guess, float truth) {
 
 #define TEST(guess, truth) if (test_result(guess, truth)) { return __LINE__; }
 
-static size_t run_test(void) {
+static int run_test(void) {
     
     TEST(std::exp   (    6.3f),  544.5719101259290330593886677332f);
     TEST(std::exp   (   -4.2f),  0.014995576820477706211984360229f);
@@ -91,16 +92,22 @@ static size_t run_test(void) {
     TEST(std::hypot(1.23f, 4.56f, 7.89f), 9.195575022803087326242198470012610630662f);
 
     /* passed all */
-    return SIZE_MAX;
+    return 0;
 }
 
 int main(void) {
     os_ClrHome();
-    size_t fail_index = run_test();
-    if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+    int failed_test = run_test();
+    if (failed_test != 0) {
+        char buf[sizeof("Failed test L-8388608\n")];
+        boot_sprintf(buf, "Failed test L%d\n", failed_test);
+        fputs(buf, stdout);
+        #if 0
+            /* debugging */
+            printf("ULP: %ld\n", fail_ulp);
+        #endif
     } else {
-        printf("Failed test: L%zu\nULP: %ld", fail_index, fail_ulp);
+        fputs("All tests passed", stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_modf/src/main.c
+++ b/test/floating_point/float32_modf/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f32_modf_LUT.h"
 
@@ -36,12 +37,14 @@ size_t run_test(void) {
                 isnan(frac_part.flt) && isnan(output[i].frac_part.flt) &&
                 isnan(trunc_part.flt) && isnan(output[i].trunc_part.flt)
             )) {
-                printf(
-                    "I: %08lX T: %zu\nG: %08lX %08lX\nT: %08lX %08lX\n",
-                    input[i].bin, i,
-                    frac_part.bin, trunc_part.bin,
-                    output[i].frac_part.bin, output[i].trunc_part.bin
-                );
+                #if 0
+                    printf(
+                        "I: %08lX T: %zu\nG: %08lX %08lX\nT: %08lX %08lX\n",
+                        input[i].bin, i,
+                        frac_part.bin, trunc_part.bin,
+                        output[i].frac_part.bin, output[i].trunc_part.bin
+                    );
+                #endif
                 return i;
             }
         }
@@ -55,9 +58,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_to_float64/src/main.c
+++ b/test/floating_point/float32_to_float64/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f32_to_f64_LUT.h"
 
@@ -30,10 +31,12 @@ size_t run_test(void) {
         result.flt = (long double)input[i];
         if (result.bin != output[i].bin) {
             if (!(isnan(result.flt) && isnan(output[i].flt))) {
-                printf(
-                    "I: %08lX\nG: %016llX\nT: %016llX\n",
-                    *((const uint32_t*)input + i), result.bin, output[i].bin
-                );
+                #if 0
+                    printf(
+                        "I: %08lX\nG: %016llX\nT: %016llX\n",
+                        *((const uint32_t*)input + i), result.bin, output[i].bin
+                    );
+                #endif
                 return i;
             }
         }
@@ -47,9 +50,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float32_trunc/src/main.c
+++ b/test/floating_point/float32_trunc/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f32_trunc_LUT.h"
 
@@ -29,12 +30,14 @@ size_t run_test(void) {
         F32_pun result;
         result.flt = truncf(input[i].flt);
         if (result.bin != output[i].bin && !(isnan(result.flt) || isnan(output[i].flt))) {
-            printf(
-                "I: %08lX T: %zu\nG: %08lX\nT: %08lX\n",
-                input[i].bin, i,
-                result.bin,
-                output[i].bin
-            );
+            #if 0
+                printf(
+                    "I: %08lX T: %zu\nG: %08lX\nT: %08lX\n",
+                    input[i].bin, i,
+                    result.bin,
+                    output[i].bin
+                );
+            #endif
             return i;
         }
     }
@@ -47,9 +50,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_arithmetic/src/main.cpp
+++ b/test/floating_point/float64_arithmetic/src/main.cpp
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include <bit>
 #include <cmath>
@@ -124,14 +125,22 @@ int main(void) {
     os_ClrHome();
     int comparison_result = comparison_test();
     if (comparison_result != 0) {
-        printf("Failed test L%d\n", comparison_result);
+        char buf[sizeof("Failed test L-8388608\n")];
+        boot_sprintf(buf, "Failed test L%d\n", comparison_result);
+        fputs(buf, stdout);
     } else {
         int64_t fail_ulp = 0;
         size_t fail_index = run_test(&fail_ulp);
         if (fail_index == SIZE_MAX) {
-            printf("All tests passed");
+            fputs("All tests passed", stdout);
         } else {
-            printf("Failed test: %zu\nULP: %lld", fail_index, fail_ulp);
+            char buf[sizeof("Failed test: 16777215\n")];
+            boot_sprintf(buf, "Failed test: %u\n", fail_index);
+            fputs(buf, stdout);
+            #if 0
+                /* debugging */
+                printf("ULP: %lld\n", fail_ulp);
+            #endif
         }
     }
     while (!os_GetCSC());

--- a/test/floating_point/float64_classification/src/main.c
+++ b/test/floating_point/float64_classification/src/main.c
@@ -136,17 +136,15 @@ static test_result fpclassify_test(void) {
 
 int main(void) {
     os_ClrHome();
-    printf("Testing 2^" NUM_TO_STR(test_count) " inputs");
+    fputs("Testing 2^" NUM_TO_STR(test_count) " inputs", stdout);
     test_result ret = fpclassify_test();
     os_ClrHome();
     if (ret.passed) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        // just in-case printf does not support long long or uint64_t
-        const uint32_t* failed_index_split = (const uint32_t*)((const void*)&(ret.failed_index));
         printf(
-            "Failed test:\n0x%08lX%08lX\nTruth: %06o_%d\nGuess: %06o_%d",
-            failed_index_split[1], failed_index_split[0], ret.truth, ret.truth_fp, ret.guess, ret.guess_fp
+            "Failed test:\n0x%016llX\nTruth: %06o_%d\nGuess: %06o_%d",
+            ret.failed_index, ret.truth, ret.truth_fp, ret.guess, ret.guess_fp
         );
     }
 

--- a/test/floating_point/float64_frexp/src/main.c
+++ b/test/floating_point/float64_frexp/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f64_frexp_LUT.h"
 
@@ -44,9 +45,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_from_integer/src/main.c
+++ b/test/floating_point/float64_from_integer/src/main.c
@@ -8,6 +8,7 @@
 #include <ti/getcsc.h>
 #include <sys/util.h>
 #include <stdlib.h>
+#include <ti/sprintf.h>
 
 #include "f64_from_integer_LUT.h"
 
@@ -18,13 +19,22 @@ typedef union F64_pun {
     uint64_t bin;
 } F64_pun;
 
+#define AUTOTEST_DEBUG 0
+
+#ifndef AUTOTEST_DEBUG
+#define AUTOTEST_DEBUG 0
+#endif
+
+#if AUTOTEST_DEBUG
 void print_failed(uint64_t input, uint64_t guess, uint64_t truth) {
     printf(
         "I: %016llX -->\nG: %016llX !=\nT: %016llX\n",
         input, guess, truth
     );
 }
-
+#else
+#define print_failed(...)
+#endif
 
 long double CRT_utod(unsigned int);
 long double CRT_itod(signed int);
@@ -97,9 +107,12 @@ int main(void) {
     const char* failed_func;
     size_t fail_index = run_test(&failed_func);
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu %s", fail_index, failed_func);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
+        fputs(failed_func, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_ilogb/src/main.c
+++ b/test/floating_point/float64_ilogb/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f64_ilogb_LUT.h"
 
@@ -23,7 +24,9 @@ size_t run_test(void) {
     for (size_t i = 0; i < length; i++) {
         int result = ilogbl(input[i]);
         if (result != output[i]) {
-            // printf("%4zu: %016llX\n %d != %d\n", i, input[i], result, output[i]);
+            #if 0
+                printf("%4zu: %016llX\n %d != %d\n", i, input[i], result, output[i]);
+            #endif
             return i;
         }
     }
@@ -36,9 +39,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_ldexp/src/main.c
+++ b/test/floating_point/float64_ldexp/src/main.c
@@ -46,7 +46,7 @@ int main(void) {
     if (fail_index == SIZE_MAX) {
         fputs("All tests passed", stdout);
     } else {
-        char buf[sizeof("Failed test: -8388608\n")];
+        char buf[sizeof("Failed test: 16777215\n")];
         boot_sprintf(buf, "Failed test: %u\n", fail_index);
         fputs(buf, stdout);
     }

--- a/test/floating_point/float64_math/src/main.cpp
+++ b/test/floating_point/float64_math/src/main.cpp
@@ -6,6 +6,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include <bit>
 #include <cmath>
@@ -38,7 +39,7 @@ static bool test_result(long double guess, long double truth) {
 
 #define TEST(guess, truth) if (test_result(guess, truth)) { return __LINE__; }
 
-static size_t run_test(void) {
+static int run_test(void) {
     
     TEST(std::exp   (    6.3L),  544.5719101259290330593886677332L);
     TEST(std::exp   (   -4.2L),  0.014995576820477706211984360229L);
@@ -91,16 +92,22 @@ static size_t run_test(void) {
     TEST(std::hypot(1.23L, 4.56L, 7.89L), 9.195575022803087326242198470012610630662L);
 
     /* passed all */
-    return SIZE_MAX;
+    return 0;
 }
 
 int main(void) {
     os_ClrHome();
-    size_t fail_index = run_test();
-    if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+    int failed_test = run_test();
+    if (failed_test != 0) {
+        char buf[sizeof("Failed test L-8388608\n")];
+        boot_sprintf(buf, "Failed test L%d\n", failed_test);
+        fputs(buf, stdout);
+        #if 0
+            /* debugging */
+            printf("ULP: %lld\n", fail_ulp);
+        #endif
     } else {
-        printf("Failed test: L%zu\nULP: %lld", fail_index, fail_ulp);
+        fputs("All tests passed", stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_rounding/src/main.c
+++ b/test/floating_point/float64_rounding/src/main.c
@@ -8,6 +8,7 @@
 #include <ti/getcsc.h>
 #include <sys/util.h>
 #include <stdlib.h>
+#include <ti/sprintf.h>
 
 #include "f64_rounding_LUT.h"
 
@@ -17,6 +18,12 @@ typedef union F64_pun {
     long double flt;
     uint64_t bin;
 } F64_pun;
+
+#define AUTOTEST_DEBUG 0
+
+#ifndef AUTOTEST_DEBUG
+#define AUTOTEST_DEBUG 0
+#endif
 
 size_t run_test(const char** failed_func) {
     typedef long double input_t;
@@ -65,9 +72,12 @@ int main(void) {
     const char* failed_func;
     size_t fail_index = run_test(&failed_func);
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu %s", fail_index, failed_func);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
+        fputs(failed_func, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_to_float32/src/main.c
+++ b/test/floating_point/float64_to_float32/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f64_to_f32_LUT.h"
 
@@ -43,9 +44,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/float64_to_integer/src/main.c
+++ b/test/floating_point/float64_to_integer/src/main.c
@@ -18,6 +18,13 @@ typedef union F64_pun {
     uint64_t bin;
 } F64_pun;
 
+#define AUTOTEST_DEBUG 0
+
+#ifndef AUTOTEST_DEBUG
+#define AUTOTEST_DEBUG 0
+#endif
+
+#if AUTOTEST_DEBUG
 void print_failed(long double input, uint64_t guess, uint64_t truth) {
     F64_pun value;
     value.flt = input;
@@ -26,6 +33,9 @@ void print_failed(long double input, uint64_t guess, uint64_t truth) {
         value.bin, guess, truth
     );
 }
+#else
+#define print_failed(...)
+#endif
 
 size_t run_test(const char** failed_func) {
     typedef long double input_t;

--- a/test/floating_point/float64_trunc/src/main.c
+++ b/test/floating_point/float64_trunc/src/main.c
@@ -7,6 +7,7 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "f64_trunc_LUT.h"
 
@@ -47,9 +48,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());

--- a/test/floating_point/ultof/src/main.c
+++ b/test/floating_point/ultof/src/main.c
@@ -6,22 +6,33 @@
 #include <ti/screen.h>
 #include <ti/getcsc.h>
 #include <sys/util.h>
+#include <ti/sprintf.h>
 
 #include "ultof_lut.h"
+
+#define ARRAY_LENGTH(x) (sizeof(x) / sizeof(x[0]))
 
 typedef union F32_pun {
     float flt;
     uint32_t bin;
 } F32_pun;
 
-#define ARRAY_LENGTH(x) (sizeof(x) / sizeof(x[0]))
+#define AUTOTEST_DEBUG 0
 
+#ifndef AUTOTEST_DEBUG
+#define AUTOTEST_DEBUG 0
+#endif
+
+#if AUTOTEST_DEBUG
 void print_failed(uint32_t input, uint32_t guess, uint32_t truth) {
     printf(
         "I: %lu\nU: %08lX -->\nG: %08lX !=\nT: %08lX\n",
         input, input, guess, truth
     );
 }
+#else
+#define print_failed(...)
+#endif
 
 size_t run_test(void) {
     typedef uint32_t input_t;
@@ -65,9 +76,11 @@ int main(void) {
     os_ClrHome();
     size_t fail_index = run_test();
     if (fail_index == SIZE_MAX) {
-        printf("All tests passed");
+        fputs("All tests passed", stdout);
     } else {
-        printf("Failed test: %zu", fail_index);
+        char buf[sizeof("Failed test: 16777215\n")];
+        boot_sprintf(buf, "Failed test: %u\n", fail_index);
+        fputs(buf, stdout);
     }
 
     while (!os_GetCSC());


### PR DESCRIPTION
ldexpf had a small bug where it did (expon < 0) instead of (expon <= 0). So I fixed that

I also replaced `printf` with `boot_sprintf` in some autotests to reduce the chances of GDB1 errors. Since using `boot_sprintf` makes `DEMO.8xp` smaller by ~8kb