### PR TITLE
Optimized sprite rotation routines

### DIFF
--- a/src/graphx/graphx.h
+++ b/src/graphx/graphx.h
@@ -1362,6 +1362,8 @@ void gfx_ScaledTransparentSprite_NoClip(const gfx_sprite_t *sprite,
  *
  * @note A scale factor of 64 represents 100% scaling.
  * @warning This routine only accepts square input sprites.
+ * @note Sprites larger than 210x210 may have rendering artifacts.
+ * @warning The output size cannot be greater than 255x255.
  * @param[in] sprite Input sprite to rotate/scale.
  * @param[in] x X coordinate position.
  * @param[in] y Y coordinate position.
@@ -1381,6 +1383,8 @@ uint8_t gfx_RotatedScaledTransparentSprite_NoClip(const gfx_sprite_t *sprite,
  *
  * @note A scale factor of 64 represents 100% scaling.
  * @warning This routine only accepts square input sprites.
+ * @note Sprites larger than 210x210 may have rendering artifacts.
+ * @warning The output size cannot be greater than 255x255.
  * @param[in] sprite Input sprite to rotate/scale.
  * @param[in] x X coordinate position.
  * @param[in] y Y coordinate position.
@@ -1480,6 +1484,8 @@ gfx_sprite_t *gfx_ScaleSprite(const gfx_sprite_t *__restrict sprite_in,
  * @param[in] angle 256 position angular integer.
  * @param[in] scale Scaling factor; range is about 1% to 400% scale.
  * @returns A pointer to \p sprite_out.
+ * @note Rendering artifacts may occur if the output is larger than 210x210.
+ * @warning The output size cannot be greater than 255x255.
  * @note sprite_in and sprite_out cannot be the same. Ensure sprite_out is allocated.
  */
 gfx_sprite_t *gfx_RotateScaleSprite(const gfx_sprite_t *__restrict sprite_in,


### PR DESCRIPTION
This is in its own commit due to the complexity of `gfx_RotateScaleSprite` and `gfx_RotatedScaledSprite(Transparent)_NoClip`.

The inner loop of `gfx_RotatedScaledSpriteTransparent_NoClip` is 8F faster when a pixel is drawn. I also believe that creating a clipped variant of this routine is possible with a constant performance penalty.

I have fixed most of the issues outlined in https://github.com/CE-Programming/toolchain/issues/612. There are a few limitations to note:
- The sprite will render incorrectly if the output is larger than 255x255. This is not worth fixing however, since a 256x256 sprite doesn't fit onto a 320x240 screen anyways.
- input sprites larger than 210x210 (`255 * (sqrt(8) - 2)` or ~211.2489) may experience texture wrapping. This should be harmless, as shown below with a 254x254 sprite
![image](https://github.com/user-attachments/assets/c09e0269-cdb1-4b89-8ca4-e74b1e21c6af)
