### PR TITLE
ldexpf now correctly handles/rounds subnormal inputs

### DIFF
--- a/src/libc/ldexpf.src
+++ b/src/libc/ldexpf.src
@@ -16,183 +16,31 @@ _scalbn := _ldexpf
 
 else
 
-if 1
+; (set to 0 or 1) avoid returning negative zero on underflow with Ti's floats
+__ldexpf_avoid_negative_zero := 1
 
-; NOTE: since Ti floats are used, negative zero will not be returned unless the
-; input was negative zero.
-;
-; normal inputs are handled correctly, unless the output is subnormal
-; subnormal inputs/outputs return zero and set ERANGE and FE_INEXACT
-; zero/infinite/NaN inputs are handled correctly
-_ldexpf:
-_ldexp:
-_scalbnf:
-_scalbn:
-	ld	iy, 0
-	lea	bc, iy + 0
-	add	iy, sp
-	ld	hl, (iy + 3)	; mant
-	add	hl, hl
-	ld	a, (iy + 6)	; expon
-	adc	a, a
-	jr	z, .maybe_subnormal
-	inc	a
-	jr	z, .ret_self	; inf NaN
-	dec	a
-	ex	de, hl
-	ld	hl, (iy + 9)	; scale
-	ld	c, a
-	add	hl, bc	; add expon
-	ld	a, l
-	bit	7, (iy + 11)	; scale sign
-	jr	z, .scale_up
-.scale_down:
-	; HL is not INT_MIN here
-	dec	hl
-	add	hl, hl
-	jr	nc, .finish	; expon > 0
-	; expon <= 0 or subnormal
-.underflow_to_zero:
-	ld	hl, ___fe_cur_env
-	set	5, (hl)	; FE_INEXACT
-if 0
-	ld	a, (iy + 6)
-	and	a, $80	; copysign
-else
-	xor	a, a	; avoid returning negative zero with Ti's floats
-end if
-	sbc	hl, hl
-.common_erange:
-	ld	bc, 5	; ERANGE
-	ld	(_errno), bc
-	ld	e, a
-	ret
-.overflow_to_inf:
-	ld	hl, $800000
-	ld	a, (iy + 6)
-	or	a, $7F	; copysign
-	jr	.common_erange
+; ldexpf behaviour:
+; - signed zero, infinity, and NaN inputs are returned unmodified
+; - ERRNO and FE_INEXACT are set if a finite value becomes zero or infinite
+; - FE_INEXACT is set if rounding occured
+;-------------------------------------------------------------------------------
 
-.scale_up:
-	ld	bc, -255
-	add	hl, bc
-	jr	c, .overflow_to_inf
-.finish:
-	ld	l, a
-	ex	de, hl
-	; signbit(A) E:UHL >>= 1
-	ld	a, (iy + 6)	; expon
-	push	hl
-	rla
-	rr	e
-	rr	(iy - 1)
-	pop	hl
-	rr	h
-	rr	l
-	ret
-
+	private	__ldexpf_helper
+__ldexpf_helper:
 .maybe_subnormal:
-	dec	bc	; BC is now -1
-	add	hl, bc
-	jr	c, .underflow_to_zero
-	; return zero
+	or	a, a
+	adc	hl, bc	; BC is zero
 .ret_self:
-	ld	hl, (iy + 3)
-	ld	e, (iy + 6)
-	ret
-
-else
-
-; normal inputs are handled correctly, unless the output is subnormal
-; subnormal inputs are handled correctly for positive scaling values
-; subnormal outputs return zero and set ERANGE and FE_INEXACT for negative scaling values
-; zero/infinite/NaN inputs are handled correctly
-_ldexpf:
-_ldexp:
-_scalbnf:
-_scalbn:
-	ld	iy, 0
-	lea	bc, iy + 0
-	add	iy, sp
 	ld	hl, (iy + 3)	; mant
-	add	hl, hl
-	ld	e, (iy + 6)	; expon
-	ld	a, e
-	rl	e
-	jr	z, .maybe_subnormal
-	inc	e
-	jr	z, .ret_self	; inf NaN
-	dec	e
-	ld	c, e
-	ex	de, hl
-	ld	hl, (iy + 9)	; scale
-	add	hl, bc	; add expon
-	ld	a, l
-	bit	7, (iy + 11)	; scale sign
-	jr	z, .scale_up
-.scale_down:
-	; test signbit
-	push	hl
-	; HL is not INT_MIN here
-	dec	hl
-	add	hl, hl
-	pop	hl
-	jr	nc, .finish	; expon > 0
-	; expon <= 0 or subnormal
-;	jr	.underflow_to_zero
-.underflow_to_zero:
-	ld	hl, ___fe_cur_env
-	set	5, (hl)	; FE_INEXACT
-	ld	a, (iy + 6)
-	and	a, $80	; copysign
-	sbc	hl, hl
-.common_erange:
-	ld	bc, 5	; ERANGE
-	ld	(_errno), bc
-	ld	e, a
-	ret
-.overflow_to_inf:
-	ld	hl, $800000
-	ld	a, (iy + 6)
-	or	a, $7F	; copysign
-	jr	.common_erange
-
-.scale_up:
-	ld	bc, -255
-	add	hl, bc
-	jr	c, .overflow_to_inf
-.finish:
-	ld	l, a
-	ex	de, hl
-.finish_subnormal:
-	; signbit(A) E:UHL >>= 1
-	ld	a, (iy + 6)	; expon
-	push	hl
-	rla
-	rr	e
-	rr	(iy - 1)
-	pop	hl
-	rr	h
-	rr	l
-	ret
-
-.maybe_subnormal:
+	ret	z	; return zero/inf/NaN
 	dec	bc	; BC is now -1
-	add	hl, bc
-;	jr	c, .underflow_to_zero
-	jr	c, .subnormal
-	; return zero
-.ret_self:
-	ld	hl, (iy + 3)
-	ld	e, (iy + 6)
-	ret
-
-.subnormal:
+; .subnormal_input:
 	; BC is -1 here
 	bit	7, (iy + 11)	; scale sign
-	jr	nz, .underflow_to_zero
+	jr	nz, .move_subnormal_down
+; .move_subnormal_up:
+	ld	a, e		; signbit
 	ld	de, (iy + 9)	; scale
-	ld	hl, (iy + 3)	; mant
 .norm_loop:
 	add	hl, hl
 	jr	c, .normalized
@@ -201,17 +49,154 @@ _scalbn:
 	ex	de, hl
 	jr	c, .norm_loop
 ; .still_subnormal:
-	ld	e, 0
-	jr	.finish_subnormal
+	; DE is -1 here
+	inc	e	; ld e, 0
+	jr	_ldexpf.finish_subnormal
 .normalized:
 	inc	de
 	ex	de, hl
+	jr	_ldexpf.scale_up
+
+.move_subnormal_down:
+	; BC is -1 here
+	; first we need to test that the result won't be zero
+	call	__ictlz
+	; A is [1, 23]
+	; return zero if (scale < clz_result - 24) or (clz_result - 25 >= scale)
+	sub	a, 24	; A is [-23, -1]
+	ld	c, a	; sign extend A
+	ld	hl, (iy + 9)	; scale
 	ld	a, l
-	jr	.scale_up
-
+	or	a, a
+	sbc	hl, bc
+	cpl
+	jr	nc, _ldexpf.shru_common
+.underflow_to_zero:
+	xor	a, a
+	ld	b, a	; ld b, 0
+if __ldexpf_avoid_negative_zero
+	res	7, (iy + 6)
 end if
+.overflow_to_inf:	; <-- Carry is set when inf/NaN
+	ld	hl, 5	; ERANGE
+	ld	(_errno), hl
+	ld	l, h	; ld l, 0
+	ex	de, hl
+	jr	nc, _ldexpf.underflow_hijack
+	ld	de, $800000
+	ld	b, $7F
+	jr	_ldexpf.overflow_hijack
 
-	extern	___fe_cur_env
+;-------------------------------------------------------------------------------
+; When the input and output are normal:
+; scaling up  : 60F + 12R + 4W + 2
+; scaling down: 60F + 12R + 4W + 4
+_scalbn:
+_scalbnf:
+_ldexp:
+_ldexpf:
+	ld	iy, 0
+	lea	bc, iy + 0
+	add	iy, sp
+	ld	hl, (iy + 3)	; mant
+	add	hl, hl
+	ld	a, (iy + 6)	; expon
+	ld	e, a		; signbit
+	adc	a, a
+	jr	z, __ldexpf_helper.maybe_subnormal
+	ld	c, a
+	inc	a
+	jr	z, __ldexpf_helper.ret_self	; inf NaN
+	ld	a, e		; signbit
+	ex	de, hl
+	ld	hl, (iy + 9)	; scale
+	add	hl, bc	; add expon
+	bit	7, (iy + 11)	; scale sign
+	jr	nz, .scale_down
+.scale_up:
+	ld	bc, -255	; $FFFF01
+	add	hl, bc
+	jr	c, __ldexpf_helper.overflow_to_inf
+	; sbc	hl, bc	; restore hl
+	dec	l	; we only care about the low 8 bits
+	ex	de, hl
+.finish_subnormal:
+	push	hl
+.finish:
+	rla	; extract signbit
+	rr	e
+	rr	(iy - 1)
+	pop	hl
+	rr	h
+	rr	l
+	ret
+
+;-------------------------------------------------------------------------------
+.scale_down:
+	push	de	; mant <<= 1
+	ld	e, l	; shift amount
+	; HL is not INT_MIN here
+	dec	hl
+	add	hl, hl
+	jr	nc, .finish	; expon > 0
+;-------------------------------------------------------------------------------
+.shru_to_subnormal:
+	xor	a, a
+	sub	a, e
+	pop	de
+	ld	c, 48	; ld bc, 24 << 1
+	add	hl, bc
+	jr	nc, __ldexpf_helper.underflow_to_zero
+
+	set	7, (iy + 5)	; set implicit mantissa bit
+.shru_common:
+	; A should be [0, 23]
+	ld	b, a
+	ld	hl, (iy + 3)	; mantissa
+	push	hl	; ld (iy - 3), hl
+	xor	a, a
+	inc	b
+	; shift amount will be [1, 24]
+	ld	c, a	; ld c, 0
+	ld	d, (iy - 1)
+.shru_loop:
+	adc	a, c	; collect sticky bits
+	srl	d
+	rr	h
+	rr	l
+	djnz	.shru_loop
+	ld	(iy - 1), d
+	pop	de
+	ld	d, h
+	ld	e, l
+
+	; round upwards to even if (round && (guard || sticky))
+	jr	nc, .no_round
+	; be careful not to touch the carry flag
+	inc	a
+	dec	a
+	jr	nz, .round_up
+	bit	0, e	; test guard bit
+	jr	z, .no_round
+.round_up:
+	inc	de	; round upwards to even (wont overflow)
+.no_round:
+	adc	a, a
+	jr	z, .result_is_exact
+.underflow_hijack:
+.overflow_hijack:
+	ld	hl, ___fe_cur_env
+	set	5, (hl)	; FE_INEXACT
+.result_is_exact:
+	ld	a, (iy + 6)	; get signbit
+	ex	de, hl
+	and	a, $80	; copysign
+	or	a, b	; used for the overflow to infinite path
+	ld	e, a
+	ret
+
 	extern	_errno
+	extern	___fe_cur_env
+	extern	__ictlz
 
 end if

--- a/test/floating_point/float32_ldexp/src/f32_ldexp_LUT.h
+++ b/test/floating_point/float32_ldexp/src/f32_ldexp_LUT.h
@@ -9,7 +9,7 @@ typedef struct { uint32_t value; int expon; } input_type;
 
 typedef uint32_t output_type;
 
-static const input_type f32_ldexp_LUT_input[1080] = {
+static const input_type f32_ldexp_LUT_input[1100] = {
 /*    0 */ {UINT32_C(0x00000000), 0},
 /*    1 */ {UINT32_C(0x00000001), 0},
 /*    2 */ {UINT32_C(0x00800000), 0},
@@ -1090,9 +1090,31 @@ static const input_type f32_ldexp_LUT_input[1080] = {
 /* 1077 */ {UINT32_C(0x7A9CE72A), 125},
 /* 1078 */ {UINT32_C(0x3479E345), 129},
 /* 1079 */ {UINT32_C(0xF96A3263), 19},
+/* 1080 */ {UINT32_C(0x1E8739EC), 109},
+/* extra tests */
+/* 1081 */ {UINT32_C(0x0001D191), -17},
+/* 1082 */ {UINT32_C(0x0003EF18), -18},
+/* 1083 */ {UINT32_C(0x000426F3), -19},
+/* 1084 */ {UINT32_C(0x000C70E3), -20},
+/* 1085 */ {UINT32_C(0x800FA056), -20},
+/* 1086 */ {UINT32_C(0x001BB2FA), -21},
+/* 1087 */ {UINT32_C(0x8016A81D), -21},
+/* 1088 */ {UINT32_C(0x002ECA33), -22},
+/* 1089 */ {UINT32_C(0x803655E0), -22},
+/* 1090 */ {UINT32_C(0x004A3993), -23},
+/* 1091 */ {UINT32_C(0x804024DC), -23},
+/* other tests */
+/* 1092 */ {UINT32_C(0x367B228A), -131},
+/* 1093 */ {UINT32_C(0xE1AFE9E3), -218},
+/* 1094 */ {UINT32_C(0x2B683524), -108},
+/* 1095 */ {UINT32_C(0xBF55E15C), -148},
+/* 1096 */ {UINT32_C(0x728C6D7F), -252},
+/* 1097 */ {UINT32_C(0xD9E79CEB), -202},
+/* 1098 */ {UINT32_C(0x19F6F465), -74},
+/* 1099 */ {UINT32_C(0xD014C299), -183},
 };
 
-static const output_type f32_ldexp_LUT_output[1080] = {
+static const output_type f32_ldexp_LUT_output[1100] = {
 /*    0 */ UINT32_C(0x00000000),
 /*    1 */ UINT32_C(0x00000001),
 /*    2 */ UINT32_C(0x00800000),
@@ -2173,6 +2195,28 @@ static const output_type f32_ldexp_LUT_output[1080] = {
 /* 1077 */ UINT32_C(0x7F800000),
 /* 1078 */ UINT32_C(0x74F9E345),
 /* 1079 */ UINT32_C(0xFF800000),
+/* 1080 */ UINT32_C(0x550739EC),
+/* extra tests */
+/* 1081 */ UINT32_C(0x00000001),
+/* 1082 */ UINT32_C(0x00000001),
+/* 1083 */ UINT32_C(0x00000001),
+/* 1084 */ UINT32_C(0x00000001),
+/* 1085 */ UINT32_C(0x80000001),
+/* 1086 */ UINT32_C(0x00000001),
+/* 1087 */ UINT32_C(0x80000001),
+/* 1088 */ UINT32_C(0x00000001),
+/* 1089 */ UINT32_C(0x80000001),
+/* 1090 */ UINT32_C(0x00000001),
+/* 1091 */ UINT32_C(0x80000001),
+/* other tests */
+/* 1092 */ UINT32_C(0x00000001),
+/* 1093 */ UINT32_C(0x80000001),
+/* 1094 */ UINT32_C(0x00000002),
+/* 1095 */ UINT32_C(0x80000002),
+/* 1096 */ UINT32_C(0x00000001),
+/* 1097 */ UINT32_C(0x80000001),
+/* 1098 */ UINT32_C(0x00000001),
+/* 1099 */ UINT32_C(0x80000001),
 };
 
 #endif /* F32_LDEXP_LUT_H */

--- a/test/floating_point/float32_ldexp/src/main.c
+++ b/test/floating_point/float32_ldexp/src/main.c
@@ -11,7 +11,6 @@
 
 #include "f32_ldexp_LUT.h"
 
-
 #define ARRAY_LENGTH(x) (sizeof(x) / sizeof(x[0]))
 
 typedef union F32_pun {
@@ -20,7 +19,7 @@ typedef union F32_pun {
 } F32_pun;
 
 size_t run_test(void) {
-    typedef struct { float value; int expon; } input_t;
+    typedef struct { F32_pun value; int expon; } input_t;
     typedef F32_pun output_t;
 
     const size_t length = ARRAY_LENGTH(f32_ldexp_LUT_input);
@@ -28,25 +27,24 @@ size_t run_test(void) {
     const output_t *output = (const output_t*)((const void*)f32_ldexp_LUT_output);
     for (size_t i = 0; i < length; i++) {
         F32_pun result;
-        result.flt = ldexpf(input[i].value, input[i].expon);
+        result.flt = ldexpf(input[i].value.flt, input[i].expon);
         if (result.bin != output[i].bin) {
-            // ignore NaN's with differing payloads
-            // treat signed zeros as equal for now
             if (
+                /* ignore NaN's with differing payloads */
                 (!(isnan(result.flt) && isnan(output[i].flt))) &&
-                (!(result.bin == 0 && iszero(output[i].flt)))
+                #if 1
+                    /* treat signed zeros as equal for now */
+                    (!(result.bin == 0 && iszero(output[i].flt)))
+                #endif
             ) {
-                /* Float multiplication does not handle subnormals yet */
-                if (!(iszero(result.flt) && (issubnormal(output[i].flt) || issubnormal(input[i].value)))) {
-                    #if 1
-                        printf(
-                            "%zu:\nI: %08lX %+d\nG: %08lX\nT: %08lX\n",
-                            i, *(uint32_t*)(void*)&(input[i].value), input[i].expon,
-                            result.bin, output[i].bin
-                        );
-                    #endif
-                    return i;
-                }
+                #if 0
+                    printf(
+                        "%zu:\nI: %08lX %+d\nG: %08lX\nT: %08lX\n",
+                        i, input[i].value.bin, input[i].expon,
+                        result.bin, output[i].bin
+                    );
+                #endif
+                return i;
             }
         }
     }


### PR DESCRIPTION
ldexpf/scalbnf now correctly handles/rounds subnormal inputs/outputs.

Since Ti's floats don't support negative zero, ldexpf also has a `__ldexpf_avoid_negative_zero` option (set to 1 currently), which guarantees that negative zero is only returned if the input is negative zero.

