### PR TITLE
fixed useages of the hardware specific 0xE40000 address

### DIFF
--- a/src/libc/asprintf.src
+++ b/src/libc/asprintf.src
@@ -15,10 +15,14 @@ _vasprintf := __vasprintf_c
 
 else
 
+if 0
+
 _asprintf := _boot_asprintf
 _vasprintf := _boot_vasprintf
 
 	extern	_boot_asprintf
 	extern	_boot_vasprintf
+
+end if
 
 end if

--- a/src/libc/asprintf.src
+++ b/src/libc/asprintf.src
@@ -15,7 +15,7 @@ _vasprintf := __vasprintf_c
 
 else
 
-if 0
+if defined __TICE__
 
 _asprintf := _boot_asprintf
 _vasprintf := _boot_vasprintf

--- a/src/libc/bzero.src
+++ b/src/libc/bzero.src
@@ -4,7 +4,7 @@
 
 	public	_bzero
 
-if 0
+if defined __TICE__
 
 ; uses the hardware specific $E40000 memory location
 

--- a/src/libc/bzero.src
+++ b/src/libc/bzero.src
@@ -4,6 +4,10 @@
 
 	public	_bzero
 
+if 0
+
+; uses the hardware specific $E40000 memory location
+
 ; void bzero(void* buf, size_t n)
 _bzero:
 	ld	hl, 6
@@ -18,3 +22,30 @@ _bzero:
 	ld	hl, $E40000	; large region of all zeros on the Ti84CE
 	ldir
 	ret
+
+else
+
+; makes no hardware assumptions
+
+; void bzero(void* buf, size_t n)
+_bzero:
+	ld	hl, 6
+	add	hl, sp
+	ld	bc, (hl)
+	dec	hl
+	dec	hl
+	dec	hl
+	ld	hl, (hl)
+	cpi
+	add	hl, bc
+	ret	c
+	dec	hl
+	ld	(hl), 0
+	ret	po
+	push	hl
+	pop	de
+	dec	de
+	lddr
+	ret
+
+end if

--- a/src/libc/snprintf.src
+++ b/src/libc/snprintf.src
@@ -15,10 +15,14 @@ _vsnprintf := __vsnprintf_c
 
 else
 
+if 0
+
 _snprintf := _boot_snprintf
 _vsnprintf := _boot_vsnprintf
 
 	extern	_boot_snprintf
 	extern	_boot_vsnprintf
+
+end if
 
 end if

--- a/src/libc/snprintf.src
+++ b/src/libc/snprintf.src
@@ -15,7 +15,7 @@ _vsnprintf := __vsnprintf_c
 
 else
 
-if 0
+if defined __TICE__
 
 _snprintf := _boot_snprintf
 _vsnprintf := _boot_vsnprintf

--- a/src/makefile.mk
+++ b/src/makefile.mk
@@ -267,6 +267,7 @@ FASMGFLAGS = \
 	-i $(call QUOTE_ARG,PREFER_OS_CRT := $(LDPREFER_OS_CRT)) \
 	-i $(call QUOTE_ARG,PREFER_OS_LIBC := $(LDPREFER_OS_LIBC)) \
 	-i $(call QUOTE_ARG,ALLOCATOR_$(ALLOCATOR) := 1) \
+	-i $(call QUOTE_ARG,__TICE__ := 1) \
 	-i $(call QUOTE_ARG,include $(call FASMG_FILES,$(LINKER_SCRIPT))) \
 	-i $(call QUOTE_ARG,range .bss $$$(BSSHEAP_LOW) : $$$(BSSHEAP_HIGH)) \
 	-i $(call QUOTE_ARG,provide __stack = $$$(STACK_HIGH)) \


### PR DESCRIPTION
Removed usage of the `0xE40000` address from standard/common C functions (such as `bzero`). 

`boot_(v)snprintf` and `boot_(v)asprintf` still use the `0xE40000` address in their implementation. Which should be okay, since they are platform specific functions. 

Since `(v)snprintf` and `(v)asprintf` are standard/common C functions, I have removed the option to have them link to `boot_(v)snprintf` and `boot_(v)asprintf`.