### PR TITLE
fixed bug with memrchr(NULL, c, 0)

### DIFF
--- a/src/libc/memrchr.src
+++ b/src/libc/memrchr.src
@@ -5,20 +5,20 @@
 	public	_memrchr
 
 _memrchr:
-	ld	iy, 0
+	ld	iy, -1
 	add	iy, sp
-	ld	hl, (iy + 3)
-	ld	bc, (iy + 9)
-	dec	bc
+	ld	bc, (iy + 10)
+	sbc	hl, hl
 	add	hl, bc
-	jr	c, .ret_zero
-	inc	bc
-	ld	a, (iy + 6)
+	jr	nc, .ret_zero
+	ld	de, (iy + 4)
+	add	hl, de
+	ld	a, (iy + 7)
 	cpdr
 	inc	hl
 	ret	z	; found match
+	; or	a, a	; carry won't be set unless (ptr + size) wraps-around (which is UB)
 .ret_zero:
 	; return NULL
-	or	a, a
 	sbc	hl, hl
 	ret

--- a/test/standalone/asprintf_fprintf/src/main.c
+++ b/test/standalone/asprintf_fprintf/src/main.c
@@ -24,6 +24,9 @@
 
 #define SINK (char*)0xE40000
 
+/* pass NULL into functions without triggering -Wnonnull */
+extern void* NULL_ptr;
+
 // prevents Clang from replacing function calls with builtins
 #if 1
 
@@ -543,6 +546,9 @@ int strncmp_test(void) {
 }
 
 int memrchr_test(void) {
+    C(T_memrchr(NULL_ptr, 0x00, 0) == NULL_ptr);
+    C(T_memrchr(NULL_ptr, 0xFF, 0) == NULL_ptr);
+
     C(T_memrchr(SINK, 0x00, 0) == NULL);
     C(T_memrchr(SINK, 0x00, 1) == SINK);
     C(T_memrchr(SINK, 0xFF, 1) == NULL);
@@ -565,6 +571,7 @@ int memrchr_test(void) {
     C(T_memrchr(test, 'G', test_strlen) == NULL);
     C(T_memrchr(test, 'G', test_size) == NULL);
     C(T_memrchr(test0, 'G', sizeof(test0)) == test0);
+
     return 0;
 }
 

--- a/test/standalone/asprintf_fprintf/src/rename.asm
+++ b/test/standalone/asprintf_fprintf/src/rename.asm
@@ -20,6 +20,12 @@ _T_stpcpy := _stpcpy
 
 _T_bzero := _bzero
 
+	section	.rodata
+
+	public	_NULL_ptr
+_NULL_ptr:
+	db	$00, $00, $00
+
 	extern	_memset, _memcpy, _memcmp, _memccpy, _mempcpy, _memrchr
 	extern	_strlen, _strcmp, _strncmp, _stpcpy
 	extern	_bzero


### PR DESCRIPTION
Fixed behavior of `memrchr` when `ptr` and `size` are both zero (`memrchr(NULL, ch, 0)`).

It returns the correct result in all cases except when `ptr + size` wraps around (such as `memrchr(0xFFFFFF, ch, 2)`). Since pointer wrap-around is UB (Undefined behavior), I assume this is okay. Fixing the pointer wrap around case costs 1 byte + 1F.