### PR TITLE
Format i48 crt

### DIFF
--- a/src/crt/i48add.src
+++ b/src/crt/i48add.src
@@ -8,11 +8,11 @@
 	section	.text
 	public	__i48add
 __i48add:
-	add hl, bc
-	ex de, hl
-	push bc
-	lea bc, iy
-	adc hl, bc
-	pop bc
-	ex de, hl
+	add	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy
+	adc	hl, bc
+	pop	bc
+	ex	de, hl
 	ret

--- a/src/crt/i48add.src
+++ b/src/crt/i48add.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48add
 __i48add:
+; CC: 11 bytes | 12F + 6R + 3W + 1
 	add	hl, bc
 	ex	de, hl
 	push	bc

--- a/src/crt/i48add_1.src
+++ b/src/crt/i48add_1.src
@@ -9,6 +9,9 @@
 
 	public	__i48add_1
 __i48add_1:
+; CC: 8 bytes
+; HL != -1: 7F + 3R + 2
+; HL == -1: 9F + 3R + 2
 	inc	hl
 	add	hl, de
 	or	a, a

--- a/src/crt/i48add_1.src
+++ b/src/crt/i48add_1.src
@@ -1,4 +1,4 @@
-; Performs 48-bit addition
+; Performs 48-bit increment
 ;
 ; Returns:
 ; ude:uhl = ude:uhl + 1

--- a/src/crt/i48and.src
+++ b/src/crt/i48and.src
@@ -8,51 +8,51 @@
 	section	.text
 	public	__i48and
 __i48and:
-	push af
+	push	af
 
 	; Deal with Upper Byte
-	push hl
-	push bc
-	push de
+	push	hl
+	push	bc
+	push	de
 	scf
-	sbc hl, hl
-	add hl, sp ; uhl = &iyu
-	push iy
+	sbc	hl, hl
+	add	hl, sp	; uhl = &iyu
+	push	iy
 
-	ld de, 3
-	ld a, (hl) ; a = iyu
-	add hl, de
-	and a, (hl) ; a &= deu
-	ld (hl), a ; deu = a
+	ld	de, 3
+	ld	a, (hl)	; a = iyu
+	add	hl, de
+	and	a, (hl)	; a &= deu
+	ld	(hl), a	; deu = a
 
-	add hl, de
-	ld a, (hl) ; a = bcu
-	add hl, de
-	and a, (hl) ; a &= hlu
-	ld (hl), a ; hlu = a
+	add	hl, de
+	ld	a, (hl)	; a = bcu
+	add	hl, de
+	and	a, (hl)	; a &= hlu
+	ld	(hl), a	; hlu = a
 
 	; Load values back into registers and process low and high bytes
-	pop bc
-	pop de
+	pop	bc
+	pop	de
 
-	ld a, d
-	and a, b ; = iyh
-	ld d, a
+	ld	a, d
+	and	a, b	; = iyh
+	ld	d, a
 
-	ld a, e
-	and a, c ; = iyl
-	ld e, a
+	ld	a, e
+	and	a, c	; = iyl
+	ld	e, a
 
-	pop bc
-	pop hl
+	pop	bc
+	pop	hl
 
-	ld a, h
-	and a, b
-	ld h, a
+	ld	a, h
+	and	a, b
+	ld	h, a
 
-	ld a, l
-	and a, c
-	ld l, a
+	ld	a, l
+	and	a, c
+	ld	l, a
 
-	pop af
+	pop	af
 	ret

--- a/src/crt/i48and.src
+++ b/src/crt/i48and.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48and
 __i48and:
+; CC: 41 bytes | 42F + 22R + 17W + 1
 	push	af
 
 	; Deal with Upper Byte

--- a/src/crt/i48bswap.src
+++ b/src/crt/i48bswap.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48bswap
 __i48bswap:
+; CC: 14 bytes | 15F + 12R + 12W + 1
 	; Line up the reversed data on the stack
 	push	hl
 	ld	h, e

--- a/src/crt/i48bswap.src
+++ b/src/crt/i48bswap.src
@@ -9,14 +9,14 @@
 	public	__i48bswap
 __i48bswap:
 	; Line up the reversed data on the stack
-	push hl
-	ld h, e
-	ld l, d
-	ex (sp), hl
-	ld d, l
-	ld e, h
-	push de
-	push hl
+	push	hl
+	ld	h, e
+	ld	l, d
+	ex	(sp), hl
+	ld	d, l
+	ld	e, h
+	push	de
+	push	hl
 	; -1: hlu
 	; -2: e
 	; -3: d
@@ -28,9 +28,9 @@ __i48bswap:
 	; -9: l
 
 	; Misalign the stack and pop into the correct registers
-	inc sp
-	inc sp
-	pop de
-	pop hl
-	inc sp
+	inc	sp
+	inc	sp
+	pop	de
+	pop	hl
+	inc	sp
 	ret

--- a/src/crt/i48cmps.src
+++ b/src/crt/i48cmps.src
@@ -12,14 +12,13 @@
 	section	.text
 	public	__i48cmps
 __i48cmps:
-	push hl
-	push de
-	or a, a
-	sbc hl, bc ; compare hl to bc
-	ex de, hl ; hl = de
-	lea de, iy ; de = iy
-	sbc hl, de ; compare de to iy
-	pop de
-	pop hl
+	push	hl
+	push	de
+	or	a, a
+	sbc	hl, bc	; compare hl to bc
+	ex	de, hl	; hl = de
+	lea	de, iy	; de = iy
+	sbc	hl, de	; compare de to iy
+	pop	de
+	pop	hl
 	ret
-

--- a/src/crt/i48cmps.src
+++ b/src/crt/i48cmps.src
@@ -12,6 +12,7 @@
 	section	.text
 	public	__i48cmps
 __i48cmps:
+; CC: 14 bytes | 15F + 9R + 6W + 1
 	push	hl
 	push	de
 	or	a, a

--- a/src/crt/i48cmpu.src
+++ b/src/crt/i48cmpu.src
@@ -12,14 +12,15 @@
 	section	.text
 	public	__i48cmpu
 __i48cmpu:
-	push hl
-	or a, a
-	lea hl, iy
-	sbc hl, de ; subtract IY - DE, which is the other way around
-	ccf ; complement carry
-	pop hl
-	ret nz
-	or a, a
-	sbc hl, bc ; subtract the low parts the normal way
-	add hl, bc ; causes the same carry, preserves Z
-	ret ; don't complement carry
+	push	hl
+	or	a, a
+	lea	hl, iy
+	sbc	hl, de	; subtract IY - DE, which is the other way around
+	ccf		; complement carry
+	pop	hl
+	ret	nz
+	or	a, a
+	sbc	hl, bc	; subtract the low parts the normal way
+	add	hl, bc	; causes the same carry, preserves Z
+	; don't complement carry
+	ret

--- a/src/crt/i48cmpu.src
+++ b/src/crt/i48cmpu.src
@@ -12,6 +12,9 @@
 	section	.text
 	public	__i48cmpu
 __i48cmpu:
+; CC: 15 bytes
+; Minimum: 11F + 6R + 3W + 2
+; Maximum: 16F + 6R + 3W + 2
 	push	hl
 	or	a, a
 	lea	hl, iy

--- a/src/crt/i48cmpzero.src
+++ b/src/crt/i48cmpzero.src
@@ -8,18 +8,18 @@
 	section	.text
 	public	__i48cmpzero
 __i48cmpzero:
-	;check msb's == 0
-	ex de, hl
-	add hl, de
-	or a, a
-	sbc hl, de ; z set if de = 0, s set if de is negative (z also reset)
-	ex de, hl
-	ret nz
-	;check lsb's == 0
-	;in this path, de = 0 and carry is reset
-	sbc hl, de
-	ret p
-	;special case if bit 23 is set
-	inc e ; reset z and s flags
-	dec de
+	; check msb's == 0
+	ex	de, hl
+	add	hl, de
+	or	a, a
+	sbc	hl, de	; z set if de = 0, s set if de is negative (z also reset)
+	ex	de, hl
+	ret	nz
+	; check lsb's == 0
+	; in this path, de = 0 and carry is reset
+	sbc	hl, de
+	ret	p
+	; special case if bit 23 is set
+	inc	e	; reset z and s flags
+	dec	de
 	ret

--- a/src/crt/i48cmpzero.src
+++ b/src/crt/i48cmpzero.src
@@ -8,6 +8,9 @@
 	section	.text
 	public	__i48cmpzero
 __i48cmpzero:
+; CC: 13 bytes
+; Minimum:  8F + 3R + 2
+; Maximum: 14F + 3R + 3
 	; check msb's == 0
 	ex	de, hl
 	add	hl, de

--- a/src/crt/i48divs.src
+++ b/src/crt/i48divs.src
@@ -1,37 +1,41 @@
+; Performs 48-bit signed division
+;
+; Returns:
+; ude:uhl = ude:uhl / uiy:ubc
+
 	assume	adl=1
 
 	section	.text
 	public	__i48divs
-; Result in ude:uhl
 __i48divs:
-	push af
-	push iy
-	push bc
+	push	af
+	push	iy
+	push	bc
 
 	; divisor sign check
-	push hl
-	lea hl, iy
-	add hl, hl
-	sbc a, a
-	call c, __uiyubcNeg
+	push	hl
+	lea	hl, iy
+	add	hl, hl
+	sbc	a, a
+	call	c, __uiyubcNeg
 
 	; dividend sign check
-	ld hl, $800000
-	add hl, de
-	pop hl
+	ld	hl, $800000
+	add	hl, de
+	pop	hl
 	rla
 	rrca
-	call c, __i48neg
+	call	c, __i48neg
 
-	call __i48dvrmu
+	call	__i48dvrmu
 
 	; negate quotient if exactly one of the dividend and divisor is negative
-	add a, a
-	call pe, __i48neg
+	add	a, a
+	call	pe, __i48neg
 
-	pop bc
-	pop iy
-	pop af
+	pop	bc
+	pop	iy
+	pop	af
 	ret
 
 	extern	__i48dvrmu

--- a/src/crt/i48divu.src
+++ b/src/crt/i48divu.src
@@ -1,17 +1,20 @@
+; Performs 48-bit unsigned division
+;
+; Returns:
+; ude:uhl = ude:uhl / uiy:ubc
+
 	assume	adl=1
 
 	section	.text
 	public	__i48divu
-
-; Result in ude:uhl
 __i48divu:
-	push iy
-	push bc
+	push	iy
+	push	bc
 
-	call __i48dvrmu
+	call	__i48dvrmu
 
-	pop bc
-	pop iy
+	pop	bc
+	pop	iy
 	ret
 
 	extern	__i48dvrmu

--- a/src/crt/i48dvrmu.src
+++ b/src/crt/i48dvrmu.src
@@ -7,83 +7,81 @@
 ; Returns (loaded into other registers by i48divu/s and i48remu/s):
 ; ude:uhl quotient, uiy:ubc remainder
 
-	assume adl=1
+	assume	adl=1
 
-	section .data
-
-	section .text
-	public __i48dvrmu
+	section	.text
+	public	__i48dvrmu
 
 __i48dvrmu:
-	;backup af
-	push af
+	; backup af
+	push	af
 
-	;backup interrupt
-	ld a, i ; P = IEF2
+	; backup interrupt
+	ld	a, i		; P = IEF2
 	di
-	push af
+	push	af
 
 	; save dividend to stack
-	push de
-	push hl
+	push	de
+	push	hl
 
 	; Set up for ubc' dividend/quotient ptr, uhl':uhl remainder, and ude':ude divisor
-	push bc
-	pop de ; ude = low divisor
-	ld hl, 6
-	ld c, l ; c = byte counter
-	add hl, sp
-	push hl
-	sbc hl, hl  ; uhl = low remainder
+	push	bc
+	pop	de		; ude = low divisor
+	ld	hl, 6
+	ld	c, l		; c = byte counter
+	add	hl, sp
+	push	hl
+	sbc	hl, hl		; uhl = low remainder
 	exx
-	pop bc ; ubc' = dividend/quotient pointer
-	lea de, iy ; ude' = iy = high divisor
-	sbc hl, hl ; uhl' = high remainder
+	pop	bc		; ubc' = dividend/quotient pointer
+	lea	de, iy		; ude' = iy = high divisor
+	sbc	hl, hl		; uhl' = high remainder
 .byteLoop:
-	dec bc
-	ld a, (bc); a = relevant dividend byte
+	dec	bc
+	ld	a, (bc); a = relevant dividend byte
 	exx
-	ld b, 8 ; b = bit counter
+	ld	b, 8		; b = bit counter
 .bitLoop:
 	; r<<1 and r[0] = n[b]
-	rla ; c = n[b], ~q[b-1] = c
-	adc hl, hl ; low r += low r + n[b]
+	rla			; c = n[b], ~q[b-1] = c
+	adc	hl, hl		; low r += low r + n[b]
 	exx
-	adc hl, hl ; high r += high r + c from low r
+	adc	hl, hl		; high r += high r + c from low r
 	exx
 	; r - d
-	sbc hl, de ; low r -= low d
+	sbc	hl, de		; low r -= low d
 	exx
-	sbc hl, de ; high r -= high d
+	sbc	hl, de		; high r -= high d
 	exx
-	jr nc, .greaterEqual
+	jr	nc, .greaterEqual
 	; restore if r<d
-	add hl, de ; restore low
+	add	hl, de		; restore low
 	exx
-	adc hl, de ; restore high
+	adc	hl, de		; restore high
 	exx
 .greaterEqual:
 	; carry contains inverted quotient bit, which is saved in the next iteration
-	djnz .bitLoop
-	rla ; ~q[b] = c
-	cpl ; uninvert quotient
-	dec c ; decrement byte counter
+	djnz	.bitLoop
+	rla			; ~q[b] = c
+	cpl			; uninvert quotient
+	dec	c		; decrement byte counter
 	exx
-	ld (bc), a ; now that dividend byte isn't needed, overwrite with quotient
-	jr nz, .byteLoop
+	ld	(bc), a		; now that dividend byte isn't needed, overwrite with quotient
+	jr	nz, .byteLoop
 
-	;finish and clean up
+	; finish and clean up
 
-	push hl
+	push	hl
 	exx
-	pop iy ; iy = remainder high
-	ex (sp), hl ; hl = lower quotient
-	pop bc ; bc = remainder low
-	pop de ; de = upper quotient
+	pop	iy		; iy = remainder high
+	ex	(sp), hl	; hl = lower quotient
+	pop	bc		; bc = remainder low
+	pop	de		; de = upper quotient
 
-	pop af
-	jp po, .skipEI
+	pop	af
+	jp	po, .skipEI
 	ei
 .skipEI:
-	pop af
+	pop	af
 	ret

--- a/src/crt/i48mulu.src
+++ b/src/crt/i48mulu.src
@@ -12,6 +12,8 @@
 	section	.text
 	public	__i48mulu
 __i48mulu:
+; CC: 202*r(PC)+51*r(SPL)+35*w(SPL)+85
+; CC: 201 bytes | 202F + 51R + 35W + 85
 	; backup af
 	push	af
 	push	ix

--- a/src/crt/i48mulu.src
+++ b/src/crt/i48mulu.src
@@ -12,204 +12,210 @@
 	section	.text
 	public	__i48mulu
 __i48mulu:
-	;backup af
-	push af
-	push ix
-	ld ix, 0
-	add ix, sp
+	; backup af
+	push	af
+	push	ix
+	ld	ix, 0
+	add	ix, sp
 
 	; On stack to get upper byte when needed
-	push de ; de will also be used to perform the actual multiplication
-	push hl
-	push iy
-	push bc
+	push	de		; de will also be used to perform the actual multiplication
+	push	hl
+	push	iy
+	push	bc
 
 	; bc = a[0], a[1]
-	ld a, l ; a = b[0]
-	ld iy, (ix-5) ; iy = b[1], b[2]
+	ld	a, l		; a = b[0]
+	ld	iy, (ix - 5)	; iy = b[1], b[2]
 
-	or a, a
-	sbc hl, hl
-	push hl ; upper bytes of sum at -15
-	;Stack Use:
-	; ix-1 : deu b[5]
-	; ix-2 : d   b[4]
-	; ix-3 : e   b[3]
-	; ix-4 : hlu b[2]
-	; ix-5 : h   b[1]
-	; ix-6 : l   b[0]
-	; ix-7 : iyu a[5]
-	; ix-8 : iyh a[4]
-	; ix-9 : iyl a[3]
-	; ix-10: bcu a[2]
-	; ix-11: b   a[1]
-	; ix-12: c   a[0]
-	; ix-13:   sum[5]
-	; ix-14:   sum[4]
-	; ix-15:   sum[3]
-	; ix-16:   sum[2]
-	; ix-17:   sum[1]
-	; ix-18:   sum[0]
+	or	a, a
+	sbc	hl, hl
+	push	hl		; upper bytes of sum at -15
+	; Stack Use:
+	; ix-1  : deu b[5]
+	; ix-2  : d   b[4]
+	; ix-3  : e   b[3]
+	; ix-4  : hlu b[2]
+	; ix-5  : h   b[1]
+	; ix-6  : l   b[0]
+	; ix-7  : iyu a[5]
+	; ix-8  : iyh a[4]
+	; ix-9  : iyl a[3]
+	; ix-10 : bcu a[2]
+	; ix-11 : b   a[1]
+	; ix-12 : c   a[0]
+	; ix-13 :   sum[5]
+	; ix-14 :   sum[4]
+	; ix-15 :   sum[3]
+	; ix-16 :   sum[2]
+	; ix-17 :   sum[1]
+	; ix-18 :   sum[0]
 
-	; sum[0-1] =============================================================================================================================
+	; ======================================================================
+	; sum[0-1]
 
 	; a[0]*b[0]
-	ld d, c ; d = a[0]
-	ld e, a ; e = b[0]
-	mlt de
-	push de ; lower bytes of sum at -18
-	
-	; sum[1-2] =============================================================================================================================
-	ld l, d ; hl will store current partial sum
+	ld	d, c		; d = a[0]
+	ld	e, a		; e = b[0]
+	mlt	de
+	push	de		; lower bytes of sum at -18
+
+	; ======================================================================
+	; sum[1-2]
+	ld	l, d		; hl will store current partial sum
 
 	; a[1]*b[0]
-	ld d, b ; d = a[1]
-	ld e, a ; e = b[0]
-	mlt de
-	add hl, de
+	ld	d, b		; d = a[1]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
 
 	; a[0]*b[1]
-	ld d, c ; d = a[0]
-	ld e, iyl ; e = b[1]
-	mlt de
-	add hl, de
+	ld	d, c		; d = a[0]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
 
-	ld (ix-17), hl
+	ld	(ix - 17), hl
 
-	; sum[2-3] =============================================================================================================================
-	ld hl, (ix-16) ; hl will store current partial sum
+	; ======================================================================
+	; sum[2-3]
+	ld	hl, (ix - 16)	; hl will store current partial sum
 
 	; a[0]*b[2]
-	ld d, c ; d = a[0]
-	ld e, iyh ; e = b[2]
-	mlt de
-	add hl, de
+	ld	d, c		; d = a[0]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
 
 	; a[1]*b[1]
-	ld d, b ; d = a[1]
-	ld e, iyl ; e = b[1]
-	mlt de
-	add hl, de
+	ld	d, b		; d = a[1]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
 
 	; a[2]*b[0]
-	ld d, (ix-10) ; d = a[2]
-	ld e, a ; e = b[0]
-	mlt de
-	add hl, de
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
 
-	ld (ix-16), hl
+	ld	(ix - 16), hl
 
-	; sum[3-4] =============================================================================================================================
-	ld hl, (ix-15) ; hl will store current partial sum
+	; ======================================================================
+	; sum[3-4]
+	ld	hl, (ix - 15)	; hl will store current partial sum
 
 	; a[0]*b[3]
-	ld d, c ; d = a[0]
-	ld e, (ix-3) ; e = b[3]
-	mlt de
-	add hl, de
+	ld	d, c		; d = a[0]
+	ld	e, (ix - 3)	; e = b[3]
+	mlt	de
+	add	hl, de
 
 	; a[1]*b[2]
-	ld d, b ; d = a[1]
-	ld e, iyh ; e = b[2]
-	mlt de
-	add hl, de
+	ld	d, b		; d = a[1]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
 
 	; a[2]*b[1]
-	ld d, (ix-10) ; d = a[2]
-	ld e, iyl ; e = b[1]
-	mlt de
-	add hl, de
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
 
 	; a[3]*b[0]
-	ld d, (ix-9) ; d = a[3]
-	ld e, a ; e = b[0]
-	mlt de
-	add hl, de
+	ld	d, (ix - 9)	; d = a[3]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
 
-	ld (ix-15), hl
+	ld	(ix - 15), hl
 
-	; sum [4-5] =============================================================================================================================
-	ld hl, (ix-14) ; hl will store current partial sum
+	; ======================================================================
+	; sum[4-5]
+	ld	hl, (ix - 14)	; hl will store current partial sum
 
 	; a[0]*b[4]
-	ld d, c ; d = a[0]
-	ld e, (ix-2) ; e = b[4]
-	mlt de
-	add hl, de
+	ld	d, c		; d = a[0]
+	ld	e, (ix - 2)	; e = b[4]
+	mlt	de
+	add	hl, de
 
 	; a[1]*b[3]
-	ld d, b ; d = a[1]
-	ld e, (ix-3) ; e = b[3]
-	mlt de
-	add hl, de
+	ld	d, b		; d = a[1]
+	ld	e, (ix - 3)	; e = b[3]
+	mlt	de
+	add	hl, de
 
 	; a[2]*b[2]
-	ld d, (ix-10) ; d = a[2]
-	ld e, iyh ; e = b[2]
-	mlt de
-	add hl, de
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
 
 	; a[3]*b[1]
-	ld d, (ix-9) ; d = a[3]
-	ld e, iyl ; e = b[1]
-	mlt de
-	add hl, de
+	ld	d, (ix - 9)	; d = a[3]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
 
 	; a[4]*b[0]
-	ld d, (ix-8) ; d = a[4]
-	ld e, a ; e = b[0]
-	mlt de
-	add hl, de
+	ld	d, (ix - 8)	; d = a[4]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
 
-	ld (ix-14), l
+	ld	(ix - 14), l
 
-	; sum [5] (and overflow) ====================================================================================================================
-	ld l, h ; hl will store current partial sum
+	; ======================================================================
+	; sum[5] (and overflow)
+	ld	l, h		; hl will store current partial sum
 
 	; a[0]*b[5]
-	ld d, c ; d = a[0]
-	ld e, (ix-1) ; e = b[5]
-	mlt de
-	add hl, de
+	ld	d, c		; d = a[0]
+	ld	e, (ix - 1)	; e = b[5]
+	mlt	de
+	add	hl, de
 
 	; a[1]*b[4]
-	ld c, (ix-2) ; c = b[4]
-	mlt bc
-	add hl, bc
+	ld	c, (ix - 2)	; c = b[4]
+	mlt	bc
+	add	hl, bc
 
 	; a[2]*b[3]
-	ld bc, (ix-10) ; bc = a[2], a[3]
-	ld d, c ; d = a[2]
-	ld e, (ix-3) ; e = b[3]
-	mlt de
-	add hl, de
+	ld	bc, (ix - 10)	; bc = a[2], a[3]
+	ld	d, c		; d = a[2]
+	ld	e, (ix - 3)	; e = b[3]
+	mlt	de
+	add	hl, de
 
 	; a[3]*b[2]
-	ld c, iyh ; c = b[2]
-	mlt bc
-	add hl, bc
+	ld	c, iyh		; c = b[2]
+	mlt	bc
+	add	hl, bc
 
 	; a[4]*b[1]
-	ld bc, (ix-8) ; bc = a[4], a[5]
-	ld d, c ; d = a[4]
-	ld e, iyl ; e = b[1]
-	mlt de
-	add hl, de
+	ld	bc, (ix - 8)	; bc = a[4], a[5]
+	ld	d, c		; d = a[4]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
 
 	; a[5]*b[0]
-	ld c, a ; c = b[0]
-	mlt bc
-	add hl, bc
+	ld	c, a		; c = b[0]
+	mlt	bc
+	add	hl, bc
 
-	ld (ix-13), l
+	ld	(ix - 13), l
 
-	;clean up stack and restore registers
-	pop hl
-	pop de
-	pop bc
-	pop iy
+	; clean up stack and restore registers
+	pop	hl
+	pop	de
+	pop	bc
+	pop	iy
 
-	ld sp, ix
-	pop ix
-	pop af
+	ld	sp, ix
+	pop	ix
+	pop	af
 	ret

--- a/src/crt/i48neg.src
+++ b/src/crt/i48neg.src
@@ -8,6 +8,9 @@
 	section	.text
 	public	__i48neg
 __i48neg:
+; CC: 17 bytes
+; HL != 0: 18F + 3R + 2
+; HL == 0: 16F + 3R + 2
 	or	a, a
 	sbc	hl, de		; hl = HL - DE
 	ex	de, hl		; hl = DE, de = HL - DE
@@ -27,6 +30,7 @@ __i48neg:
 ; Used by i48divs and i48rems, uiy:ubc = -uiy:ubc
 	public	__uiyubcNeg
 __uiyubcNeg:
+; CC: 18 bytes | 19F + 12R + 9W + 1
 	push	hl
 	or	a, a
 	sbc	hl, hl

--- a/src/crt/i48neg.src
+++ b/src/crt/i48neg.src
@@ -8,34 +8,34 @@
 	section	.text
 	public	__i48neg
 __i48neg:
-	or a, a
-	sbc hl, de ; hl = HL - DE
-	ex de, hl ; hl = DE, de = HL - DE
-	add hl, de ; hl = HL
-	add hl, de ; hl = HL * 2 - DE
-	ex de, hl ; hl = HL - DE, de = HL * 2 - DE
-	or a, a
-	sbc hl, de ; hl = -HL, set Z flag
-	ex de, hl ; hl = HL * 2 - DE, de = -HL
-	add hl, de ; hl = HL - DE
-	add hl, de ; hl = -DE
-	ex de, hl ; hl = -HL, de = -DE
-	ret z ; Return if -HL = 0, meaning no carry when negating the low half
-	dec de ; Carry adjustment
+	or	a, a
+	sbc	hl, de		; hl = HL - DE
+	ex	de, hl		; hl = DE, de = HL - DE
+	add	hl, de		; hl = HL
+	add	hl, de		; hl = HL * 2 - DE
+	ex	de, hl		; hl = HL - DE, de = HL * 2 - DE
+	or	a, a
+	sbc	hl, de		; hl = -HL, set Z flag
+	ex	de, hl		; hl = HL * 2 - DE, de = -HL
+	add	hl, de		; hl = HL - DE
+	add	hl, de		; hl = -DE
+	ex	de, hl		; hl = -HL, de = -DE
+	ret	z		; Return if -HL = 0, meaning no carry when negating the low half
+	dec	de		; Carry adjustment
 	ret
 
-;Used by i48divs and i48rems, uiy:ubc = -uiy:ubc
-	public  __uiyubcNeg
+; Used by i48divs and i48rems, uiy:ubc = -uiy:ubc
+	public	__uiyubcNeg
 __uiyubcNeg:
-	push hl
-	or a, a
-	sbc hl, hl
-	sbc hl, bc ; hl = 0 - BC = -BC
-	push hl
-	add hl, bc ; hl = 0, causes the same carry
-	lea bc, iy
-	sbc hl, bc ; hl = 0 - IY - c
-	pop bc ; bc = -BC
-	ex (sp), hl ; hl = HL
-	pop iy ; iy = -IY - c
+	push	hl
+	or	a, a
+	sbc	hl, hl
+	sbc	hl, bc		; hl = 0 - BC = -BC
+	push	hl
+	add	hl, bc		; hl = 0, causes the same carry
+	lea	bc, iy
+	sbc	hl, bc		; hl = 0 - IY - c
+	pop	bc		; bc = -BC
+	ex	(sp), hl	; hl = HL
+	pop	iy		; iy = -IY - c
 	ret

--- a/src/crt/i48not.src
+++ b/src/crt/i48not.src
@@ -8,16 +8,16 @@
 	section	.text
 	public	__i48not
 __i48not:
-	add hl, de ; hl = HL + DE
-	ex de, hl ; hl = DE, de = HL + DE
-	or a, a
-	sbc hl, de ; hl = -HL
-	ex de, hl ; hl = HL + DE, de = -HL
-	add hl, de ; hl = DE
-	add hl, de ; hl = DE - HL
-	ex de, hl ; hl = -HL, de = DE - HL
+	add	hl, de		; hl = HL + DE
+	ex	de, hl		; hl = DE, de = HL + DE
+	or	a, a
+	sbc	hl, de		; hl = -HL
+	ex	de, hl		; hl = HL + DE, de = -HL
+	add	hl, de		; hl = DE
+	add	hl, de		; hl = DE - HL
+	ex	de, hl		; hl = -HL, de = DE - HL
 	scf
-	sbc hl, de ; hl = -DE - 1
-	ex de, hl ; hl = DE - HL, de = -DE - 1 = ~DE
-	add hl, de ; hl = -HL - 1 = ~HL
+	sbc	hl, de		; hl = -DE - 1
+	ex	de, hl		; hl = DE - HL, de = -DE - 1 = ~DE
+	add	hl, de		; hl = -HL - 1 = ~HL
 	ret

--- a/src/crt/i48not.src
+++ b/src/crt/i48not.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48not
 __i48not:
+; CC: 15 bytes | 16F + 3R + 1
 	add	hl, de		; hl = HL + DE
 	ex	de, hl		; hl = DE, de = HL + DE
 	or	a, a

--- a/src/crt/i48or.src
+++ b/src/crt/i48or.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48or
 __i48or:
+; CC: 41 bytes | 42F + 22R + 17W + 1
 	push	af
 
 	; Deal with Upper Byte

--- a/src/crt/i48or.src
+++ b/src/crt/i48or.src
@@ -8,51 +8,51 @@
 	section	.text
 	public	__i48or
 __i48or:
-	push af
+	push	af
 
 	; Deal with Upper Byte
-	push hl
-	push bc
-	push de
+	push	hl
+	push	bc
+	push	de
 	scf
-	sbc hl, hl
-	add hl, sp ; uhl = &iyu
-	push iy
+	sbc	hl, hl
+	add	hl, sp	; uhl = &iyu
+	push	iy
 
-	ld de, 3
-	ld a, (hl) ; a = iyu
-	add hl, de
-	or a, (hl) ; a |= deu
-	ld (hl), a ; deu = a
+	ld	de, 3
+	ld	a, (hl)	; a = iyu
+	add	hl, de
+	or	a, (hl)	; a |= deu
+	ld	(hl), a	; deu = a
 
-	add hl, de
-	ld a, (hl) ; a = bcu
-	add hl, de
-	or a, (hl) ; a |= hlu
-	ld (hl), a ; hlu = a
+	add	hl, de
+	ld	a, (hl)	; a = bcu
+	add	hl, de
+	or	a, (hl)	; a |= hlu
+	ld	(hl), a	; hlu = a
 
 	; Load values back into registers and process low and high bytes
-	pop bc
-	pop de
+	pop	bc
+	pop	de
 
-	ld a, d
-	or a, b ; = iyh
-	ld d, a
+	ld	a, d
+	or	a, b	; = iyh
+	ld	d, a
 
-	ld a, e
-	or a, c ; = iyl
-	ld e, a
+	ld	a, e
+	or	a, c	; = iyl
+	ld	e, a
 
-	pop bc
-	pop hl
+	pop	bc
+	pop	hl
 
-	ld a, h
-	or a, b
-	ld h, a
+	ld	a, h
+	or	a, b
+	ld	h, a
 
-	ld a, l
-	or a, c
-	ld l, a
+	ld	a, l
+	or	a, c
+	ld	l, a
 
-	pop af
+	pop	af
 	ret

--- a/src/crt/i48popcnt.src
+++ b/src/crt/i48popcnt.src
@@ -8,32 +8,32 @@
 	section	.text
 	public	__i48popcnt
 __i48popcnt:
-	push hl
-	push de
+	push	hl
+	push	de
 	; Calculate 8-popcount(L)-popcount(HLU), and set HLU=H
-	call __popcnt_common_init_full
+	call	__popcnt_common_init_full
 	; Save the current count in H
-	ld h, a
+	ld	h, a
 	; Prepare to accumulate 8-popcount(D)-popcount(HLU)
-	ld a, d
+	ld	a, d
 	cpl
-	ld l, a
+	ld	l, a
 	; Subtract output carry and an additional H, the adjusted call adds H*2-L
-	sbc a, h
-	call __popcnt_common_iter_adjusted
+	sbc	a, h
+	call	__popcnt_common_iter_adjusted
 	; Subtract value from 25, and accumulate output carry
 	cpl
-	adc a, 26
+	adc	a, 26
 	; Set L=9-popcount(UHL)-popcount(D)
-	ld l, a
+	ld	l, a
 	; Calculate 8-popcount(DEU)-popcount(E)
-	ex de, hl
-	call __popcnt_common_init_full
+	ex	de, hl
+	call	__popcnt_common_init_full
 	; Subtract from saved value in L minus 1 and accumulate output carry
 	cpl
-	adc a, e
-	pop de
-	pop hl
+	adc	a, e
+	pop	de
+	pop	hl
 	ret
 
 	extern	__popcnt_common_init_full, __popcnt_common_iter_adjusted

--- a/src/crt/i48rems.src
+++ b/src/crt/i48rems.src
@@ -1,35 +1,39 @@
+; Performs 48-bit signed remainder
+;
+; Returns:
+; ude:uhl = ude:uhl % uiy:ubc
+
 	assume	adl=1
 
 	section	.text
 	public	__i48rems
-; Result in ude:uhl
 __i48rems:
-	push iy
-	push bc
+	push	iy
+	push	bc
 
 	; divisor sign check
-	push hl
-	lea hl, iy
-	add hl, hl
-	call c, __uiyubcNeg
+	push	hl
+	lea	hl, iy
+	add	hl, hl
+	call	c, __uiyubcNeg
 
 	; dividend sign check
-	sbc hl, hl
-	adc hl, de
-	pop hl
-	push af
-	call m, __i48neg
-	pop af
+	sbc	hl, hl
+	adc	hl, de
+	pop	hl
+	push	af
+	call	m, __i48neg
+	pop	af
 
-	call __i48dvrmu
-	lea de, iy
-	push bc
-	pop hl
+	call	__i48dvrmu
+	lea	de, iy
+	push	bc
+	pop	hl
 	; negate remainder if dividend was negative
-	call m, __i48neg
+	call	m, __i48neg
 
-	pop bc
-	pop iy
+	pop	bc
+	pop	iy
 	ret
 
 	extern	__i48dvrmu

--- a/src/crt/i48remu.src
+++ b/src/crt/i48remu.src
@@ -1,21 +1,24 @@
+; Performs 48-bit unsigned remainder
+;
+; Returns:
+; ude:uhl = ude:uhl % uiy:ubc
+
 	assume	adl=1
 
 	section	.text
 	public	__i48remu
-
-; Result in ude:uhl
 __i48remu:
-	push iy
-	push bc
+	push	iy
+	push	bc
 
-	call __i48dvrmu
-	lea de, iy
-	or a, a
-	sbc hl, hl
-	add hl, bc
+	call	__i48dvrmu
+	lea	de, iy
+	or	a, a
+	sbc	hl, hl
+	add	hl, bc
 
-	pop bc
-	pop iy
+	pop	bc
+	pop	iy
 	ret
 
 	extern	__i48dvrmu

--- a/src/crt/i48shl.src
+++ b/src/crt/i48shl.src
@@ -3,82 +3,82 @@
 ; Returns:
 ; ude:uhl = ude:uhl<<c
 
-assume	adl=1
+	assume	adl=1
 
 	section	.text
 	public	__i48shl
 __i48shl:
-	push bc
-	ld b, a
+	push	bc
+	ld	b, a
 
-	ld a, e ; Accumulate E in A to reduce register exchanges and preserve Z
-	srl c
-	jr nc, .bit0
+	ld	a, e		; Accumulate E in A to reduce register exchanges and preserve Z
+	srl	c
+	jr	nc, .bit0
 	; ude:uhl<<1
-	add hl, hl
+	add	hl, hl
 	rla
-	ex de, hl
-	add hl, hl
-	ex de, hl
+	ex	de, hl
+	add	hl, hl
+	ex	de, hl
 .bit0:
-	srl c
-	jr nc, .bit1
+	srl	c
+	jr	nc, .bit1
 	; ude:uhl<<2
-	add hl, hl
+	add	hl, hl
 	rla
-	add hl, hl
+	add	hl, hl
 	rla
-	ex de, hl
-	add hl, hl
-	add hl, hl
-	ex de, hl
+	ex	de, hl
+	add	hl, hl
+	add	hl, hl
+	ex	de, hl
 .bit1:
-	srl c
-	jr nc, .bit2
+	srl	c
+	jr	nc, .bit2
 	; ude:uhl<<4
-	add hl, hl
+	add	hl, hl
 	rla
-	add hl, hl
+	add	hl, hl
 	rla
-	add hl, hl
+	add	hl, hl
 	rla
-	add hl, hl
+	add	hl, hl
 	rla
-	ex de, hl
-	add hl, hl
-	add hl, hl
-	add hl, hl
-	add hl, hl
-	ex de, hl
+	ex	de, hl
+	add	hl, hl
+	add	hl, hl
+	add	hl, hl
+	add	hl, hl
+	ex	de, hl
 .bit2:
-	ld e, a
+	ld	e, a
 
-	jr z, .done ; Early out when no byte shift is needed
+	jr	z, .done	; Early out when no byte shift is needed
 	; Subtract the byte shift amount from 9
-	ld a, 9
-	sub a, c ; Clears carry for valid shift amounts
+	ld	a, 9
+	sub	a, c		; Clears carry for valid shift amounts
 
 	; Push the result shifted left by 48 as a 96-bit value on the stack
-	push de
-	push hl
-	sbc hl, hl
-	push hl
-	push hl
+	push	de
+	push	hl
+	sbc	hl, hl
+	push	hl
+	push	hl
 
 	; Offset and read the byte-shifted value
-	ld l, a
-	add hl, sp
-	ld de, (hl)
-	dec hl
-	dec hl
-	dec hl
-	ld hl, (hl)
+	ld	l, a
+	add	hl, sp
+	ld	de, (hl)
+	dec	hl
+	dec	hl
+	dec	hl
+	ld	hl, (hl)
 
-	pop af
-	pop af
-	pop af
-	pop af
+	pop	af
+	pop	af
+	pop	af
+	pop	af
 .done:
-	ld a, b
-	pop bc
+	ld	a, b
+	pop	bc
 	ret

--- a/src/crt/i48shr.src
+++ b/src/crt/i48shr.src
@@ -8,55 +8,55 @@
 	section	.text
 	public	__i48shrs
 __i48shrs:
-	inc c
-	dec c
-	ret z
-	cp a, a ; Set Z flag
-	db $C2 ; inc c \ dec c \ ret z -> jp nz,*
+	inc	c
+	dec	c
+	ret	z
+	cp	a, a	; Set Z flag
+	db	$C2	; inc c \ dec c \ ret z -> jp nz, *
 	require	__i48shru
 
 	section	.text
 	public	__i48shru
 __i48shru:
-	inc c
-	dec c
-	ret z
+	inc	c
+	dec	c
+	ret	z
 	; NZ for unsigned shift, Z for signed shift
-	push bc
-	ld b, c
-	push af
-	push de
-	push hl
-	ld hl, 5
-	add hl, sp
-	ld c, (hl)
-	dec hl
-	dec hl
-	dec hl
-	ld a, (hl)
-	ex (sp), hl
-	jr z, .loop
-	srl c
-	jr .midloop
+	push	bc
+	ld	b, c
+	push	af
+	push	de
+	push	hl
+	ld	hl, 5
+	add	hl, sp
+	ld	c, (hl)
+	dec	hl
+	dec	hl
+	dec	hl
+	ld	a, (hl)
+	ex	(sp), hl
+	jr	z, .loop
+	srl	c
+	jr	.midloop
 .loop:
-	sra c
+	sra	c
 .midloop:
-	rr d
-	rr e
+	rr	d
+	rr	e
 	rra
-	rr h
-	rr l
-	djnz .loop
-	ex (sp), hl
-	ld (hl), a
-	inc hl
-	ld (hl), e
-	inc hl
-	ld (hl), d
-	inc hl
-	ld (hl), c
-	pop hl
-	pop de
-	pop af
-	pop bc
+	rr	h
+	rr	l
+	djnz	.loop
+	ex	(sp), hl
+	ld	(hl), a
+	inc	hl
+	ld	(hl), e
+	inc	hl
+	ld	(hl), d
+	inc	hl
+	ld	(hl), c
+	pop	hl
+	pop	de
+	pop	af
+	pop	bc
 	ret

--- a/src/crt/i48sub.src
+++ b/src/crt/i48sub.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48sub
 __i48sub:
+; CC: 13 bytes | 14F + 6R + 3W + 1
 	or	a, a
 	sbc	hl, bc
 	ex	de, hl

--- a/src/crt/i48sub.src
+++ b/src/crt/i48sub.src
@@ -8,12 +8,12 @@
 	section	.text
 	public	__i48sub
 __i48sub:
-	or a, a
-	sbc hl, bc
-	ex de, hl
-	push bc
-	lea bc, iy
-	sbc hl, bc
-	pop bc
-	ex de, hl
+	or	a, a
+	sbc	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy
+	sbc	hl, bc
+	pop	bc
+	ex	de, hl
 	ret

--- a/src/crt/i48sub_1.src
+++ b/src/crt/i48sub_1.src
@@ -1,4 +1,4 @@
-; Performs 48-bit subtraction
+; Performs 48-bit decrement
 ;
 ; Returns:
 ; ude:uhl = ude:uhl - 1

--- a/src/crt/i48sub_1.src
+++ b/src/crt/i48sub_1.src
@@ -9,6 +9,9 @@
 
 	public	__i48sub_1
 __i48sub_1:
+; CC: 8 bytes
+; HL != 0: 7F + 3R + 2
+; HL == 0: 9F + 3R + 2
 	add	hl, de
 	or	a, a
 	sbc	hl, de

--- a/src/crt/i48xor.src
+++ b/src/crt/i48xor.src
@@ -8,6 +8,7 @@
 	section	.text
 	public	__i48xor
 __i48xor:
+; CC: 41 bytes | 42F + 22R + 17W + 1
 	push	af
 
 	; Deal with Upper Byte

--- a/src/crt/i48xor.src
+++ b/src/crt/i48xor.src
@@ -8,51 +8,51 @@
 	section	.text
 	public	__i48xor
 __i48xor:
-	push af
+	push	af
 
 	; Deal with Upper Byte
-	push hl
-	push bc
-	push de
+	push	hl
+	push	bc
+	push	de
 	scf
-	sbc hl, hl
-	add hl, sp ; uhl = &iyu
-	push iy
+	sbc	hl, hl
+	add	hl, sp	; uhl = &iyu
+	push	iy
 
-	ld de, 3
-	ld a, (hl) ; a = iyu
-	add hl, de
-	xor a, (hl) ; a ^= deu
-	ld (hl), a ; deu = a
+	ld	de, 3
+	ld	a, (hl)	; a = iyu
+	add	hl, de
+	xor	a, (hl)	; a ^= deu
+	ld	(hl), a	; deu = a
 
-	add hl, de
-	ld a, (hl) ; a = bcu
-	add hl, de
-	xor a, (hl) ; a ^= hlu
-	ld (hl), a ; hlu = a
+	add	hl, de
+	ld	a, (hl)	; a = bcu
+	add	hl, de
+	xor	a, (hl)	; a ^= hlu
+	ld	(hl), a	; hlu = a
 
 	; Load values back into registers and process low and high bytes
-	pop bc
-	pop de
+	pop	bc
+	pop	de
 
-	ld a, d
-	xor a, b ; = iyh
-	ld d, a
+	ld	a, d
+	xor	a, b	; = iyh
+	ld	d, a
 
-	ld a, e
-	xor a, c ; = iyl
-	ld e, a
+	ld	a, e
+	xor	a, c	; = iyl
+	ld	e, a
 
-	pop bc
-	pop hl
+	pop	bc
+	pop	hl
 
-	ld a, h
-	xor a, b
-	ld h, a
+	ld	a, h
+	xor	a, b
+	ld	h, a
 
-	ld a, l
-	xor a, c
-	ld l, a
+	ld	a, l
+	xor	a, c
+	ld	l, a
 
-	pop af
+	pop	af
 	ret


### PR DESCRIPTION
fixes white-space in i48 CRT routines:
- `add hl, de ; foo` --> `add\thl, de\t\t; foo` and etc
- adding new lines to the end of files
- fixing small typos

I also added the cycle counts for some i48 CRT routines.
