### PR TITLE
update errno perror strings

### DIFF
--- a/src/libc/errno_str.c
+++ b/src/libc/errno_str.c
@@ -6,11 +6,85 @@
 
 static char const * const errno_strings[] = {
     "no error",
-    "permission error",
-    "invalid argument",
-    "io error",
-    "math domain error",
-    "math range error",
+    "EPERM",
+    "EINVAL",
+    "EIO",
+    "EDOM",
+    "ERANGE",
+    "EILSEQ",
+    /* C++ errno */
+    "E2BIG",
+    "EACCES",
+    "EADDRINUSE",
+    "EADDRNOTAVAIL",
+    "EAFNOSUPPORT",
+    "EAGAIN",
+    "EALREADY",
+    "EBADF",
+    "EBADMSG",
+    "EBUSY",
+    "ECANCELED",
+    "ECHILD",
+    "ECONNABORTED",
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "EDEADLK",
+    "EDESTADDRREQ",
+    "EEXIST",
+    "EFAULT",
+    "EFBIG",
+    "EHOSTUNREACH",
+    "EIDRM",
+    "EINPROGRESS",
+    "EINTR",
+    "EISCONN",
+    "EISDIR",
+    "ELOOP",
+    "EMFILE",
+    "EMLINK",
+    "EMSGSIZE",
+    "ENAMETOOLONG",
+    "ENETDOWN",
+    "ENETRESET",
+    "ENETUNREACH",
+    "ENFILE",
+    "ENOBUFS",
+    "ENODATA",
+    "ENODEV",
+    "ENOENT",
+    "ENOEXEC",
+    "ENOLCK",
+    "ENOLINK",
+    "ENOMEM",
+    "ENOMSG",
+    "ENOPROTOOPT",
+    "ENOSPC",
+    "ENOSR",
+    "ENOSTR",
+    "ENOSYS",
+    "ENOTCONN",
+    "ENOTDIR",
+    "ENOTEMPTY",
+    "ENOTRECOVERABLE",
+    "ENOTSOCK",
+    "ENOTSUP",
+    "ENOTTY",
+    "ENXIO",
+    "EOPNOTSUPP",
+    "EOVERFLOW",
+    "EOWNERDEAD",
+    "EPIPE",
+    "EPROTO",
+    "EPROTONOSUPPORT",
+    "EPROTOTYPE",
+    "EROFS",
+    "ESPIPE",
+    "ESRCH",
+    "ETIME",
+    "ETIMEDOUT",
+    "ETXTBSY",
+    "EWOULDBLOCK",
+    "EXDEV",
 };
 
 static char * const unknown_errno_string = "unknown error -8388608";
@@ -34,13 +108,6 @@ char* strerror(int errnum) {
     }
     return (char*)errno_strings[errnum];
 }
-
-#if 0
-/** disabled until the prototypes for this function are defined */
-size_t strerrorlen_s(errno_t errnum) {
-    return strlen(strerror(errnum));
-}
-#endif
 
 void perror(const char *str) {
     if (str != NULL && *str != '\0') {

--- a/src/libc/include/errno.h
+++ b/src/libc/include/errno.h
@@ -6,31 +6,31 @@
 #define EIO         3   /* io error */
 #define EDOM        4   /* math domain error */
 #define ERANGE      5   /* math range error */
+#define EILSEQ      6   /* Illegal byte sequence (C95) */
 
-// Not used, but defined for compatibility
-#define E2BIG           6 /* Argument list too long */
-#define EACCES          7 /* Permission denied */
-#define EADDRINUSE      8 /* Address in use */
-#define EADDRNOTAVAIL   9 /* Address not available */
-#define EAFNOSUPPORT    10 /* Address family not supported */
-#define EAGAIN          11 /* Resource unavailable, try again */
-#define EALREADY        12 /* Connection already in progress */
-#define EBADF           13 /* Bad file descriptor */
-#define EBADMSG         14 /* Bad message */
-#define EBUSY           15 /* Device or resource busy */
-#define ECANCELED       16 /* Operation canceled */
-#define ECHILD          17 /* No child processes */
-#define ECONNABORTED    18 /* Connection aborted */
-#define ECONNREFUSED    19 /* Connection refused */
-#define ECONNRESET      20 /* Connection reset */
-#define EDEADLK         21 /* Resource deadlock avoided */
-#define EDESTADDRREQ    22 /* Destination address required */
-#define EEXIST          23 /* File exists */
-#define EFAULT          24 /* Bad address */
-#define EFBIG           25 /* File too large */
-#define EHOSTUNREACH    26 /* Host is unreachable */
-#define EIDRM           27 /* Identifier removed */
-#define EILSEQ          28 /* Illegal byte sequence */
+/* C++ errno */
+#define E2BIG            7 /* Argument list too long */
+#define EACCES           8 /* Permission denied */
+#define EADDRINUSE       9 /* Address in use */
+#define EADDRNOTAVAIL   10 /* Address not available */
+#define EAFNOSUPPORT    11 /* Address family not supported */
+#define EAGAIN          12 /* Resource unavailable, try again */
+#define EALREADY        13 /* Connection already in progress */
+#define EBADF           14 /* Bad file descriptor */
+#define EBADMSG         15 /* Bad message */
+#define EBUSY           16 /* Device or resource busy */
+#define ECANCELED       17 /* Operation canceled */
+#define ECHILD          18 /* No child processes */
+#define ECONNABORTED    19 /* Connection aborted */
+#define ECONNREFUSED    20 /* Connection refused */
+#define ECONNRESET      21 /* Connection reset */
+#define EDEADLK         22 /* Resource deadlock avoided */
+#define EDESTADDRREQ    23 /* Destination address required */
+#define EEXIST          24 /* File exists */
+#define EFAULT          25 /* Bad address */
+#define EFBIG           26 /* File too large */
+#define EHOSTUNREACH    27 /* Host is unreachable */
+#define EIDRM           28 /* Identifier removed */
 #define EINPROGRESS     29 /* Operation in progress */
 #define EINTR           30 /* Interrupted function */
 #define EISCONN         31 /* Socket is connected */

--- a/test/standalone/errno/autotest.json
+++ b/test/standalone/errno/autotest.json
@@ -23,7 +23,7 @@
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [
-        "B0BE2F4E"
+        "9523A08A"
       ]
     },
     "2": {
@@ -31,7 +31,7 @@
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [
-        "29401BEE"
+        "382A9C66"
       ]
     },
     "3": {

--- a/test/standalone/errno/src/main.c
+++ b/test/standalone/errno/src/main.c
@@ -6,19 +6,91 @@
 #include <errno.h>
 #include <limits.h>
 
-/** @note assumes that the following strings are used: */
-#if 0
-static char const * const errno_str[] = {
-    "no error",
-    "permission error",
-    "invalid argument",
-    "io error",
-    "math domain error",
-    "math range error",
-};
+#define ARRAY_LENGTH(x) (sizeof(x) / sizeof((x)[0]))
 
-static char * const unknown_errno_string = "unknown error -8388608";
-#endif
+/** @note assumes that the following strings are used: */
+static char const * const truth[] = {
+    "no error",
+    "EPERM",
+    "EINVAL",
+    "EIO",
+    "EDOM",
+    "ERANGE",
+    "EILSEQ",
+    /* C++ errno */
+    "E2BIG",
+    "EACCES",
+    "EADDRINUSE",
+    "EADDRNOTAVAIL",
+    "EAFNOSUPPORT",
+    "EAGAIN",
+    "EALREADY",
+    "EBADF",
+    "EBADMSG",
+    "EBUSY",
+    "ECANCELED",
+    "ECHILD",
+    "ECONNABORTED",
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "EDEADLK",
+    "EDESTADDRREQ",
+    "EEXIST",
+    "EFAULT",
+    "EFBIG",
+    "EHOSTUNREACH",
+    "EIDRM",
+    "EINPROGRESS",
+    "EINTR",
+    "EISCONN",
+    "EISDIR",
+    "ELOOP",
+    "EMFILE",
+    "EMLINK",
+    "EMSGSIZE",
+    "ENAMETOOLONG",
+    "ENETDOWN",
+    "ENETRESET",
+    "ENETUNREACH",
+    "ENFILE",
+    "ENOBUFS",
+    "ENODATA",
+    "ENODEV",
+    "ENOENT",
+    "ENOEXEC",
+    "ENOLCK",
+    "ENOLINK",
+    "ENOMEM",
+    "ENOMSG",
+    "ENOPROTOOPT",
+    "ENOSPC",
+    "ENOSR",
+    "ENOSTR",
+    "ENOSYS",
+    "ENOTCONN",
+    "ENOTDIR",
+    "ENOTEMPTY",
+    "ENOTRECOVERABLE",
+    "ENOTSOCK",
+    "ENOTSUP",
+    "ENOTTY",
+    "ENXIO",
+    "EOPNOTSUPP",
+    "EOVERFLOW",
+    "EOWNERDEAD",
+    "EPIPE",
+    "EPROTO",
+    "EPROTONOSUPPORT",
+    "EPROTOTYPE",
+    "EROFS",
+    "ESPIPE",
+    "ESRCH",
+    "ETIME",
+    "ETIMEDOUT",
+    "ETXTBSY",
+    "EWOULDBLOCK",
+    "EXDEV",
+};
 
 int main(void)
 {
@@ -28,20 +100,32 @@ int main(void)
     errno = 1; perror("");
     errno = 2; perror("\0");
     errno = 3; perror(" ");
-    errno = 4; perror("%d");
+    errno = 4; perror("%*.*d%n");
     errno = 5; perror("perror");
+    errno = 6; perror(NULL);
 
     while (!os_GetCSC());
 
     os_ClrHome();
 
-    errno = 6; perror(NULL);
+    errno = ARRAY_LENGTH(truth) - 1; perror("\\");
+    errno = ARRAY_LENGTH(truth); perror(NULL);
     errno = -1; perror("");
-    errno = -123456; perror("%d");
+    errno = -123456; perror("%*.*d%n");
     errno = 123456; perror("???");
     errno = INT_MIN; perror(" ");
     errno = INT_MAX; perror("#");
-    
+
+    for (size_t i = 0; i < ARRAY_LENGTH(truth); i++) {
+        const char * str = strerror(i);
+        errno = (int)i;
+        if (strlen(truth[i]) != strlen(str) || strcmp(truth[i], str) != 0) {
+            fputs("strerror failed\n", stdout);
+            break;
+        }
+    }
+    fputs("finished\n", stdout);
+
     while (!os_GetCSC());
 
     return 0;


### PR DESCRIPTION
To save space `perror`/`strerror` will now return `"EDOM"` instead of `"math domain error"` since there are now `78 errno` values.
