### PR TITLE
optimize i64 bitwise operations

### DIFF
--- a/src/crt/lland.src
+++ b/src/crt/lland.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__lland
 __lland:
-; CC: 62*r(PC)+25*r(SPL)+14*w(SPL)+1
+; CC: 61*r(PC)+25*r(SPL)+14*w(SPL)+1
 	push	af
 	push	iy
 	ld	iy, 0
@@ -33,9 +33,10 @@ __lland:
 	and	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	and	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	and	a, (iy + 10)

--- a/src/crt/lland_fast.src
+++ b/src/crt/lland_fast.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__lland_fast
 __lland_fast:
-; CC: 56*r(PC)+19*r(SPL)+8*w(SPL)+1
+; CC: 55*r(PC)+19*r(SPL)+8*w(SPL)+1
 	ld	iy, 0
 	add	iy, sp
 	push	hl
@@ -31,9 +31,10 @@ __lland_fast:
 	and	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	and	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	and	a, (iy + 4)

--- a/src/crt/llor.src
+++ b/src/crt/llor.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__llor
 __llor:
-; CC: 62*r(PC)+25*r(SPL)+14*w(SPL)+1
+; CC: 61*r(PC)+25*r(SPL)+14*w(SPL)+1
 	push	af
 	push	iy
 	ld	iy, 0
@@ -33,9 +33,10 @@ __llor:
 	or	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	or	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	or	a, (iy + 10)

--- a/src/crt/llor_fast.src
+++ b/src/crt/llor_fast.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__llor_fast
 __llor_fast:
-; CC: 56*r(PC)+19*r(SPL)+8*w(SPL)+1
+; CC: 55*r(PC)+19*r(SPL)+8*w(SPL)+1
 	ld	iy, 0
 	add	iy, sp
 	push	hl
@@ -31,9 +31,10 @@ __llor_fast:
 	or	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	or	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	or	a, (iy + 4)

--- a/src/crt/llxor.src
+++ b/src/crt/llxor.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__llxor
 __llxor:
-; CC: 62*r(PC)+25*r(SPL)+14*w(SPL)+1
+; CC: 61*r(PC)+25*r(SPL)+14*w(SPL)+1
 	push	af
 	push	iy
 	ld	iy, 0
@@ -33,9 +33,10 @@ __llxor:
 	xor	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	xor	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	xor	a, (iy + 10)

--- a/src/crt/llxor_fast.src
+++ b/src/crt/llxor_fast.src
@@ -3,7 +3,7 @@
 	section	.text
 	public	__llxor_fast
 __llxor_fast:
-; CC: 56*r(PC)+19*r(SPL)+8*w(SPL)+1
+; CC: 55*r(PC)+19*r(SPL)+8*w(SPL)+1
 	ld	iy, 0
 	add	iy, sp
 	push	hl
@@ -31,9 +31,10 @@ __llxor_fast:
 	xor	a, (hl)
 	ld	e, a
 	dec	hl
-	ld	a, (iy - 1)
+	ld	a, (hl)
+	lea	hl, iy - 1
 	xor	a, (hl)
-	ld	(iy - 1), a
+	ld	(hl), a
 	pop	hl
 	ld	a, h
 	xor	a, (iy + 4)


### PR DESCRIPTION
Saved 1 byte and 1F in `lland`, `llor`, `llxor` and their fast variants
