### PR TITLE
added mulhu and mulhs CRT routines

### DIFF
--- a/src/crt/i48mulhs.src
+++ b/src/crt/i48mulhs.src
@@ -1,0 +1,45 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48mulhs
+	.type	__i48mulhs, @function
+
+; UDE:UHL = ((int96_t)UDE:UHL * (int96_t)UIY:UBC) >> 48
+__i48mulhs:
+	push	af
+	push	iy
+	push	bc
+	push	de
+	push	hl
+
+	push	hl
+	lea	hl, iy + 0
+	add	hl, hl
+	sbc	a, a
+
+	ld	hl, $800000
+	add	hl, de
+	pop	hl
+	rla
+
+	call	__i48mulhu
+
+	; if (UDE:UHL < 0) { result -= UIY:UBC; }
+	rrca
+	call	c, __i48sub
+
+	pop	bc
+	pop	iy
+
+	; if (UIY:UBC < 0) { result -= UDE:UHL; }
+	rrca
+	call	c, __i48sub
+
+	pop	bc
+	pop	iy
+	pop	af
+	ret
+
+	.extern	__i48mulhu
+	.extern	__i48sub

--- a/src/crt/i48mulhs.src
+++ b/src/crt/i48mulhs.src
@@ -13,21 +13,22 @@ __i48mulhs:
 	push	de
 	push	hl
 
-	push	hl
-	lea	hl, iy + 0
+	push	de
+	ex	de, hl
 	add	hl, hl
 	sbc	a, a
 
-	ld	hl, $800000
-	add	hl, de
-	pop	hl
+	lea	hl, iy + 0
+	add	hl, hl
 	rla
+	ex	de, hl
+	pop	de
 
 	call	__i48mulhu
 
 	; if (UDE:UHL < 0) { result -= UIY:UBC; }
-	rrca
-	call	c, __i48sub
+	or	a, a
+	call	m, __i48sub
 
 	pop	bc
 	pop	iy

--- a/src/crt/i48mulhu.src
+++ b/src/crt/i48mulhu.src
@@ -7,12 +7,12 @@
 
 ; UDE:UHL = ((uint96_t)UDE:UHL * (uint96_t)UIY:UBC) >> 48
 __i48mulhu:
-; CC: 88 bytes
-;  minimum:  87F +  39R +  39W + 2
-;  maximum:  89F +  39R +  39W + 3
+; CC: 93 bytes
+;  minimum:  92F +  42R +  42W + 2
+;  maximum:  94F +  42R +  42W + 4
 ; including __i48mulu:
-;  minimum: 895F + 243R + 179W + 342
-;  maximum: 897F + 243R + 179W + 343
+;  minimum: 900F + 246R + 182W + 342
+;  maximum: 902F + 246R + 182W + 344
 	push	ix
 	push	iy
 	push	bc
@@ -46,6 +46,7 @@ __i48mulhu:
 	adc	hl, bc
 
 	pop	bc		; UHL * UBC (low carry)
+	push	af		; upper carry
 	ex	de, hl
 	add	hl, bc
 	jr	nc, .L.no_low_carry
@@ -59,6 +60,10 @@ __i48mulhu:
 	ld	hl, (ix - 3)
 	call	__i48mulu
 	pop	bc		; high carry
+	pop	af		; upper carry
+	jr	nc, .L.no_upper_carry
+	inc	de
+.L.no_upper_carry:
 	add	hl, bc
 	ld	sp, ix
 	pop	bc

--- a/src/crt/i48mulhu.src
+++ b/src/crt/i48mulhu.src
@@ -1,0 +1,71 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48mulhu
+	.type	__i48mulhu, @function
+
+; UDE:UHL = ((uint96_t)UDE:UHL * (uint96_t)UIY:UBC) >> 48
+__i48mulhu:
+; CC: 88 bytes
+;  minimum:  87F +  39R +  39W + 2
+;  maximum:  89F +  39R +  39W + 3
+; including __i48mulu:
+;  minimum: 895F + 243R + 179W + 342
+;  maximum: 897F + 243R + 179W + 343
+	push	ix
+	push	iy
+	push	bc
+	ld	ix, 0
+	lea	iy, ix + 0
+	add	ix, sp
+	push	de
+	push	hl
+
+	; x_lo * y_lo
+	lea	de, iy + 0
+	call	__i48mulu
+	push	de		; UHL * UBC (low carry)
+
+	; x_hi * y_lo
+	lea	de, iy + 0
+	ld	hl, (ix - 3)
+	call	__i48mulu
+	push	de		; hi24
+	push	hl		; lo24
+
+	; x_lo * y_hi
+	lea	de, iy + 0
+	ld	bc, (ix + 3)
+	ld	hl, (ix - 6)
+	call	__i48mulu
+	pop	bc		; lo24
+	add	hl, bc
+	ex	de, hl
+	pop	bc		; hi24
+	adc	hl, bc
+
+	pop	bc		; UHL * UBC (low carry)
+	ex	de, hl
+	add	hl, bc
+	jr	nc, .L.no_low_carry
+	inc	de
+.L.no_low_carry:
+	push	de		; high carry
+
+	; x_hi * y_hi
+	lea	de, iy + 0
+	ld	bc, (ix + 3)
+	ld	hl, (ix - 3)
+	call	__i48mulu
+	pop	bc		; high carry
+	add	hl, bc
+	ld	sp, ix
+	pop	bc
+	pop	iy
+	pop	ix
+	ret	nc		; no high carry
+	inc	de
+	ret
+
+	.extern	__i48mulu

--- a/src/crt/imulhs.src
+++ b/src/crt/imulhs.src
@@ -1,0 +1,42 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__imulhs
+	.type	__imulhs, @function
+
+; UHL = ((int48_t)UHL * (int48_t)UBC) >> 24
+__imulhs:
+	push	af
+	push	bc
+	push	hl
+
+	push	hl
+	add	hl, hl
+	rla
+	ld	hl, $800000
+	add	hl, bc
+	rla
+	pop	hl
+
+	call	__imulhu
+
+	; if (UBC < 0) { result -= UHL; }
+	pop	bc
+	cpl
+	rra
+	jr	c, .L.positive_bc
+	sbc	hl, bc
+.L.positive_bc:
+
+	; if (UHL < 0) { result -= UBC; }
+	pop	bc
+	rra
+	jr	c, .L.positive_hl
+	sbc	hl, bc
+.L.positive_hl:
+
+	pop	af
+	ret
+
+	.extern	__imulhu

--- a/src/crt/imulhu.src
+++ b/src/crt/imulhu.src
@@ -1,0 +1,146 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__imulhu
+	.type	__imulhu, @function
+
+; UHL = ((uint48_t)UHL * (uint48_t)UBC) >> 24
+__imulhu:
+; TODO: Optimize this routine as this is mostly just a copy paste of __i48mulu with some stuff removed.
+;
+; CC: 118*r(PC)+39*r(SPL)+38*w(SPL)+37
+; CC: 117 bytes | 118F + 39R + 38W + 37
+	push	de
+	; backup af
+	push	af
+	push	ix
+	ld	ix, 0
+	add	ix, sp
+
+	; On stack to get upper byte when needed
+	push	de		; de will also be used to perform the actual multiplication
+	push	hl
+	push	iy
+	push	bc
+
+	; bc = a[0], a[1]
+	ld	a, l		; a = b[0]
+	ld	iy, (ix - 5)	; iy = b[1], b[2]
+
+	; or	a, a		; carry is already cleared
+	sbc	hl, hl
+	push	hl		; upper bytes of sum at -15
+	; Stack Use:
+	; ix-1  : deu b[5]
+	; ix-2  : d   b[4]
+	; ix-3  : e   b[3]
+	; ix-4  : hlu b[2]
+	; ix-5  : h   b[1]
+	; ix-6  : l   b[0]
+	; ix-7  : iyu a[5]
+	; ix-8  : iyh a[4]
+	; ix-9  : iyl a[3]
+	; ix-10 : bcu a[2]
+	; ix-11 : b   a[1]
+	; ix-12 : c   a[0]
+	; ix-13 :   sum[5]
+	; ix-14 :   sum[4]
+	; ix-15 :   sum[3]
+	; ix-16 :   sum[2]
+	; ix-17 :   sum[1]
+	; ix-18 :   sum[0]
+
+	; ======================================================================
+	; sum[0-1]
+
+	; a[0]*b[0]
+	ld	d, c		; d = a[0]
+	ld	e, a		; e = b[0]
+	mlt	de
+	push	de		; lower bytes of sum at -18
+
+	; ======================================================================
+	; sum[1-2]
+	ld	l, d		; hl will store current partial sum
+
+	; a[1]*b[0]
+	ld	d, b		; d = a[1]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
+
+	; a[0]*b[1]
+	ld	d, c		; d = a[0]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
+
+	ld	(ix - 17), hl
+
+	; ======================================================================
+	; sum[2-3]
+	ld	hl, (ix - 16)	; hl will store current partial sum
+
+	; a[0]*b[2]
+	ld	d, c		; d = a[0]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
+
+	; a[1]*b[1]
+	ld	d, b		; d = a[1]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
+
+	; a[2]*b[0]
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, a		; e = b[0]
+	mlt	de
+	add	hl, de
+
+	ld	(ix - 16), hl
+
+	; ======================================================================
+	; sum[3-4]
+	ld	hl, (ix - 15)	; hl will store current partial sum
+
+	; a[1]*b[2]
+	ld	d, b		; d = a[1]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
+
+	; a[2]*b[1]
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, iyl		; e = b[1]
+	mlt	de
+	add	hl, de
+
+	ld	(ix - 15), hl
+
+	; ======================================================================
+	; sum[4-5]
+	ld	hl, (ix - 14)	; hl will store current partial sum
+
+	; a[2]*b[2]
+	ld	d, (ix - 10)	; d = a[2]
+	ld	e, iyh		; e = b[2]
+	mlt	de
+	add	hl, de
+
+	ld	(ix - 14), l
+	ld	(ix - 13), h
+
+	; clean up stack and restore registers
+	pop	de
+	pop	hl
+	pop	bc
+	pop	iy
+
+	ld	sp, ix
+	pop	ix
+	pop	af
+	pop	de
+	ret

--- a/src/crt/llmulhs.src
+++ b/src/crt/llmulhs.src
@@ -1,0 +1,39 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__llmulhs
+	.type	__llmulhs, @function
+
+; BC:UDE:UHL = ((int128_t)BC:UDE:UHL * (int128_t)(SP64)) >> 64
+__llmulhs:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+
+	push	bc
+	push	de
+	push	hl
+
+	ld	hl, (iy + 6)
+	ld	de, (iy + 9)
+	ld	bc, (iy + 12)
+
+	; argument order can be swapped since multiplication is commutative
+	call	__llmulhu
+
+	; if ((SP64) < 0) { result -= BC:UDE:UHL; }
+	bit	7, (iy + 13)
+	call	nz, __llsub
+
+	; if (BC:UDE:UHL < 0) { result -= (SP64); }
+	bit	7, (iy - 2)
+
+	ld	sp, iy
+
+	pop	iy
+	ret	z
+	jp	__llsub
+
+	.extern	__llmulhu
+	.extern	__llsub

--- a/src/crt/llmulhu.src
+++ b/src/crt/llmulhu.src
@@ -1,0 +1,102 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__llmulhu
+	.type	__llmulhu, @function
+
+; BC:UDE:UHL = ((uint128_t)BC:UDE:UHL * (uint128_t)(SP64)) >> 64
+__llmulhu:
+	push	ix
+	push	iy
+	ld	ix, -36
+	add	ix, sp
+	ld	sp, ix
+	lea	ix, ix + 36
+
+	ld	(ix - 3), bc
+	ld	(ix - 6), de
+	ld	(ix - 9), hl
+
+	ld	bc, 0
+	ld	(ix - 13), bc
+	ld	(ix - 30), bc
+	ld	c, (ix + 12)
+	ld	(ix - 33), bc
+	ld	iy, (ix + 9)
+	ld	(ix - 36), iy
+
+	; x_lo * y_lo
+	ld	c, b
+	ld	d, b
+	inc	de
+	dec.s	de
+	call	__llmulu
+	ld	(ix - 16), bc
+	ld	(ix - 19), de
+	ld	bc, 0
+	ld	(ix - 14), b
+
+	; x_hi * y_lo
+	inc.s	de
+	ld	d, b
+	ld	e, (ix - 2)
+	ld	hl, (ix - 5)
+	call	__llmulu
+	ld	(ix - 21), bc
+	ld	(ix - 24), de
+	ld	(ix - 27), hl
+
+	ld	c, (ix + 16)
+	ld	(ix - 33), c
+	ld	iy, (ix + 13)
+	ld	(ix - 36), iy
+
+	; x_lo * y_hi
+	ld	bc, 0
+	inc.s	de
+	ld	d, b
+	ld	e, (ix - 6)
+	ld	hl, (ix - 9)
+	call	__llmulu
+	lea	iy, ix - 27
+	call	.L.__llmulhu_add
+	lea	iy, ix - 18
+	call	.L.__llmulhu_add
+	ld	(ix - 16), bc
+	ld	(ix - 19), de
+	ld	bc, 0
+	ld	(ix - 14), b
+
+	; x_hi * y_hi
+	inc.s	de
+	ld	d, b
+	ld	e, (ix - 2)
+	ld	hl, (ix - 5)
+	call	__llmulu
+	lea	iy, ix - 18
+	call	.L.__llmulhu_add
+	ld	sp, ix
+	pop	iy
+	pop	ix
+	ret
+
+.L.__llmulhu_add:
+	; similar to __lladd, except iy points to the stack and is destroyed
+	push	bc
+	ld	bc, (iy + 0)
+	add	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 3)
+	adc	hl, bc
+	ex	de, hl
+	pop	bc
+	jr	nc, .L.no_carry48
+	inc	bc
+.L.no_carry48:
+	ld	iy, (iy + 6)
+	add	iy, bc
+	lea	bc, iy + 0
+	ret
+
+	.extern	__llmulu

--- a/src/crt/llmulhu.src
+++ b/src/crt/llmulhu.src
@@ -19,6 +19,7 @@ __llmulhu:
 	ld	(ix - 9), hl
 
 	ld	bc, 0
+	ld	(ix - 10), b
 	ld	(ix - 13), bc
 	ld	(ix - 30), bc
 	ld	c, (ix + 12)
@@ -32,10 +33,12 @@ __llmulhu:
 	inc	de
 	dec.s	de
 	call	__llmulu
+	inc	bc
+	dec.s	bc
 	ld	(ix - 16), bc
 	ld	(ix - 19), de
-	ld	bc, 0
-	ld	(ix - 14), b
+	ld	b, 0
+	ld	c, b
 
 	; x_hi * y_lo
 	inc.s	de
@@ -43,6 +46,8 @@ __llmulhu:
 	ld	e, (ix - 2)
 	ld	hl, (ix - 5)
 	call	__llmulu
+	inc	bc
+	dec.s	bc
 	ld	(ix - 21), bc
 	ld	(ix - 24), de
 	ld	(ix - 27), hl
@@ -53,20 +58,22 @@ __llmulhu:
 	ld	(ix - 36), iy
 
 	; x_lo * y_hi
-	ld	bc, 0
+	ld	b, 0
+	ld	c, b
 	inc.s	de
 	ld	d, b
 	ld	e, (ix - 6)
 	ld	hl, (ix - 9)
 	call	__llmulu
+	inc	bc
+	dec.s	bc
 	lea	iy, ix - 27
-	call	.L.__llmulhu_add
+	call	.L.__llmulhu_i72add
 	lea	iy, ix - 18
-	call	.L.__llmulhu_add
+	call	.L.__llmulhu_i72add
 	ld	(ix - 16), bc
 	ld	(ix - 19), de
 	ld	bc, 0
-	ld	(ix - 14), b
 
 	; x_hi * y_hi
 	inc.s	de
@@ -74,14 +81,16 @@ __llmulhu:
 	ld	e, (ix - 2)
 	ld	hl, (ix - 5)
 	call	__llmulu
+	inc	bc
+	dec.s	bc
 	lea	iy, ix - 18
-	call	.L.__llmulhu_add
+	call	.L.__llmulhu_i72add
 	ld	sp, ix
 	pop	iy
 	pop	ix
 	ret
 
-.L.__llmulhu_add:
+.L.__llmulhu_i72add:
 	; similar to __lladd, except iy points to the stack and is destroyed
 	push	bc
 	ld	bc, (iy + 0)

--- a/src/crt/llmulhu.src
+++ b/src/crt/llmulhu.src
@@ -5,8 +5,131 @@
 	.global	__llmulhu
 	.type	__llmulhu, @function
 
+.if 1
+
 ; BC:UDE:UHL = ((uint128_t)BC:UDE:UHL * (uint128_t)(SP64)) >> 64
 __llmulhu:
+; modified version of __llmulu that uses exx to obtain the upper 64 bits of the result.
+; __llmulhu runs slightly faster than two calls to __llmulu, and is much faster
+; than the naive implementation of __llmulhu that calls __llmulu four times.
+	push	af
+	ld	a, i
+	di
+	push	af
+
+	push	ix
+	push	iy
+
+	ld	ix, 0
+	lea	iy, ix - 6
+	add	iy, sp		; cf=1
+
+	push	de
+	push	hl
+	ld	l, c
+	ld	h, b
+	ld.s	sp, hl
+
+	lea	hl, iy + 21
+	ld	b, 8
+.L.push_loop:
+	push	af
+	ld	a, (hl)
+	inc	hl
+	or	a, a		; cf=0
+	djnz	.L.push_loop
+
+	sbc	hl, hl
+	ld	e, l
+	ld	d, h
+
+	exx
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ld	c, l
+	ld	b, l
+	exx
+
+.L.byte_loop:
+	scf
+	adc	a, a
+
+.L.bit_loop:
+	ex	af, af'
+
+	add	ix, ix
+	adc	hl, hl
+	ex	de, hl
+	adc.s	hl, hl
+	ex	de, hl
+
+	exx
+	adc	hl, hl
+	ex	de, hl
+	adc	hl, hl
+	ex	de, hl
+	rl	c
+	rl	b
+	exx
+
+	ex	af, af'
+
+	jr	nc, .L.add_end
+	ld	bc, (iy)
+	add	ix, bc
+	ld	bc, (iy + 3)
+	adc	hl, bc
+	ex	de, hl
+	adc.s	hl, sp
+	ex	de, hl
+	jr	nc, .L.add_end
+	exx
+	inc	hl
+	add	hl, de
+	or	a, a
+	sbc	hl, de
+	jr	nz, .L.add_end_exx
+	inc	de
+	sbc	hl, de
+	add	hl, de
+	jr	nz, .L.add_end_exx
+	inc	bc
+.L.add_end_exx:
+	exx
+.L.add_end:
+
+	add	a, a
+	jr	nz, .L.bit_loop
+
+	pop	af
+	jr 	nc, .L.byte_loop
+
+	; ld	b, d
+	; ld	c, e
+	; ex	de, hl
+	; lea	hl, ix + 0
+	; BC:UDE:UHL = lower 64 bits
+	; shadow BC:UDE:UHL = upper 64 bits
+	exx
+
+	pop	af		; reset SP
+	pop	af		; reset SP
+	pop	iy
+	pop	ix
+
+	pop	af
+	jp	po, .L.skipEI
+	ei
+.L.skipEI:
+	pop	af
+	ret
+
+.else
+
+; BC:UDE:UHL = ((uint128_t)BC:UDE:UHL * (uint128_t)(SP64)) >> 64
+__llmulhu:
+	; fallback routine that does not disable interrupts or use shadow registers
 	push	ix
 	push	iy
 	ld	ix, -36
@@ -109,3 +232,5 @@ __llmulhu:
 	ret
 
 	.extern	__llmulu
+
+.endif

--- a/src/crt/lmulhs.src
+++ b/src/crt/lmulhs.src
@@ -1,0 +1,33 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lmulhs
+	.type	__lmulhs, @function
+
+; E:UHL = ((int64_t)E:UHL * (int64_t)A:UBC) >> 32
+__lmulhs:
+	push	bc
+	push	af
+	push	hl
+	push	de
+
+	call	__lmulhu
+
+	; if (A:UBC < 0) { result -= E:UHL; }
+	rlca
+	pop	bc
+	ld	a, c	; ld a, E
+	pop	bc
+	call	c, __lsub
+
+	; if (E:UHL < 0) { result -= A:UBC; }
+	rlca
+	pop	bc
+	ld	a, b	; ld a, A
+	pop	bc
+	ret	nc
+	jp	__lsub
+
+	.extern	__lmulhu
+	.extern	__lsub

--- a/src/crt/lmulhu.src
+++ b/src/crt/lmulhu.src
@@ -1,0 +1,43 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lmulhu
+	.type	__lmulhu, @function
+
+; E:UHL = ((uint64_t)E:UHL * (uint64_t)A:UBC) >> 32
+__lmulhu:
+	push	iy
+	push	de
+	ld	iy, 0
+	push	iy
+	ld	iyl, a
+	push	iy
+	push	bc
+	ld	iyl, iyh	; ld iy, 0
+	lea	bc, iy + 0
+	inc	de
+	dec.s	de
+	ld	d, b
+	call	__llmulu
+	; E   = B
+	; UHL = C
+	; H   = UDE
+	; L   = D
+	add	iy, sp
+	push	de
+	ld	e, (iy - 1)	; H = UDE
+	ld	(iy - 1), c	; UHL = C
+	pop	hl		; UHL = C
+	ld	h, e		; H = UDE
+	ld	l, d		; L = D
+	ld	iyl, b		; E = B
+	pop	bc
+	pop	de		; reset SP
+	pop	de		; reset SP
+	pop	de
+	ld	e, iyl		; E = B
+	pop	iy
+	ret
+
+	.extern	__llmulu

--- a/src/crt/smulhs.src
+++ b/src/crt/smulhs.src
@@ -1,0 +1,30 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__smulhs
+	.type	__smulhs, @function
+
+; HL = ((int32_t)HL * (int32_t)BC) >> 16
+__smulhs:
+	push	bc
+	push	hl
+	call	__smulhu
+
+	; if (BC < 0) { result -= HL; }
+	bit	7, b
+	pop	bc
+	jr	z, .L.positive_hl
+	or	a, a
+	sbc	hl, bc
+.L.positive_hl:
+
+	; if (HL < 0) { result -= BC; }
+	bit	7, b
+	pop	bc
+	ret	z
+	or	a, a
+	sbc	hl, bc
+	ret
+
+	.extern	__smulhu

--- a/src/crt/smulhs.src
+++ b/src/crt/smulhs.src
@@ -7,21 +7,21 @@
 
 ; HL = ((int32_t)HL * (int32_t)BC) >> 16
 __smulhs:
-	push	bc
-	push	hl
+	push	de
+	ld	d, h
+	ld	e, l
 	call	__smulhu
 
 	; if (BC < 0) { result -= HL; }
 	bit	7, b
-	pop	bc
 	jr	z, .L.positive_hl
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 .L.positive_hl:
 
 	; if (HL < 0) { result -= BC; }
-	bit	7, b
-	pop	bc
+	bit	7, d
+	pop	de
 	ret	z
 	or	a, a
 	sbc	hl, bc

--- a/src/crt/smulhu.src
+++ b/src/crt/smulhu.src
@@ -1,0 +1,37 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__smulhu
+	.type	__smulhu, @function
+
+; HL = ((uint32_t)HL * (uint32_t)BC) >> 16
+__smulhu:
+; CC: 32 bytes
+; ADL = 1: 33F + 12R + 9W + 17
+; ADL = 0: 33F +  8R + 6W + 17
+	push	af
+	push	de
+	push	bc
+	ld	d, l
+	ld	e, c
+	mlt	de	; L * C
+	ld	a, d
+	ld	d, l
+	ld	e, b
+	mlt	de	; L * B
+	ld	l, b
+	ld	b, h
+	mlt	bc	; H * C
+	mlt	hl	; H * B
+	add	a, c
+	ld	c, b
+	ld	b, 0
+	adc	hl, bc
+	add	a, e
+	ld	c, d
+	adc	hl, bc	; result is [0, $FFFE]
+	pop	bc
+	pop	de
+	pop	af
+	ret

--- a/test/standalone/mulhu/autotest.json
+++ b/test/standalone/mulhu/autotest.json
@@ -1,0 +1,40 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed",
+	  "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A"
+      ]
+    },
+    "2": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/standalone/mulhu/autotest.json
+++ b/test/standalone/mulhu/autotest.json
@@ -8,7 +8,7 @@
   },
   "sequence": [
     "action|launch",
-    "delay|1000",
+    "delay|2000",
     "hashWait|1",
     "key|enter",
     "delay|300",

--- a/test/standalone/mulhu/autotest.json
+++ b/test/standalone/mulhu/autotest.json
@@ -8,16 +8,16 @@
   },
   "sequence": [
     "action|launch",
-    "delay|2000",
+    "delay|6000",
     "hashWait|1",
     "key|enter",
-    "delay|300",
+    "delay|400",
     "hashWait|2"
   ],
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 8000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/mulhu/makefile
+++ b/test/standalone/mulhu/makefile
@@ -1,0 +1,19 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Wshadow -Wconversion -Wformat=2 -Wno-sign-conversion -Oz
+CXXFLAGS = -Wall -Wextra -Wshadow -Wconversion -Wformat=2 -Wno-sign-conversion -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/standalone/mulhu/src/crt_wrap.s
+++ b/test/standalone/mulhu/src/crt_wrap.s
@@ -50,6 +50,20 @@ _CRT_smulhu:
 	call	__smulhu
 	jp	_set_next_reg
 
+	.global	_CRT_smulhs
+_CRT_smulhs:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	b, (iy + 10)
+	ld	c, (iy + 9)
+	ld	h, (iy + 7)
+	ld	l, (iy + 6)
+	pop	iy
+	call	_set_prev_reg
+	call	__smulhs
+	jp	_set_next_reg
+
 	.global	_CRT_imulhu
 _CRT_imulhu:
 	push	iy
@@ -60,6 +74,18 @@ _CRT_imulhu:
 	pop	iy
 	call	_set_prev_reg
 	call	__imulhu
+	jp	_set_next_reg
+
+	.global	_CRT_imulhs
+_CRT_imulhs:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 6)
+	ld	bc, (iy + 9)
+	pop	iy
+	call	_set_prev_reg
+	call	__imulhs
 	jp	_set_next_reg
 
 	.global	_CRT_lmulhu
@@ -76,6 +102,20 @@ _CRT_lmulhu:
 	call	__lmulhu
 	jp	_set_next_reg
 
+	.global	_CRT_lmulhs
+_CRT_lmulhs:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 6)
+	ld	e, (iy + 9)
+	ld	bc, (iy + 12)
+	ld	a, (iy + 15)
+	pop	iy
+	call	_set_prev_reg
+	call	__lmulhs
+	jp	_set_next_reg
+
 	.global	_CRT_i48mulhu
 _CRT_i48mulhu:
 	ld	iy, 0
@@ -86,6 +126,18 @@ _CRT_i48mulhu:
 	ld	iy, (iy + 12)
 	call	_set_prev_reg
 	call	__i48mulhu
+	jp	_set_next_reg
+
+	.global	_CRT_i48mulhs
+_CRT_i48mulhs:
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 3)
+	ld	de, (iy + 6)
+	ld	bc, (iy + 9)
+	ld	iy, (iy + 12)
+	call	_set_prev_reg
+	call	__i48mulhs
 	jp	_set_next_reg
 
 	.global	_CRT_llmulhu
@@ -106,8 +158,32 @@ _CRT_llmulhu:
 	ld	sp, iy
 	jp	_set_next_reg
 
+	.global	_CRT_llmulhs
+_CRT_llmulhs:
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 18)
+	push	hl
+	ld	hl, (iy + 15)
+	push	hl
+	ld	hl, (iy + 12)
+	push	hl
+	ld	bc, (iy + 9)
+	ld	de, (iy + 6)
+	ld	hl, (iy + 3)
+	call	_set_prev_reg
+	call	__llmulhs
+	ld	sp, iy
+	jp	_set_next_reg
+
 	.extern	__smulhu
 	.extern	__imulhu
 	.extern	__lmulhu
 	.extern	__i48mulhu
 	.extern	__llmulhu
+
+	.extern	__smulhs
+	.extern	__imulhs
+	.extern	__lmulhs
+	.extern	__i48mulhs
+	.extern	__llmulhs

--- a/test/standalone/mulhu/src/crt_wrap.s
+++ b/test/standalone/mulhu/src/crt_wrap.s
@@ -1,0 +1,113 @@
+	.assume	adl=1
+
+	.section	.data._prev_reg
+
+	.global	_prev_reg
+_prev_reg:
+	;	L H U  E D U  C B U  A  Y I U  X I U
+	db	0,0,0, 0,0,0, 0,0,0, 0, 0,0,0, 0,0,0
+
+	.section	.data._next_reg
+
+	.global	_next_reg
+_next_reg:
+	;	L H U  E D U  C B U  A  Y I U  X I U
+	db	0,0,0, 0,0,0, 0,0,0, 0, 0,0,0, 0,0,0
+
+	.section	.text
+
+	.local	_set_prev_reg
+_set_prev_reg:
+	ld	(_prev_reg +  0), hl
+	ld	(_prev_reg +  3), de
+	ld	(_prev_reg +  6), bc
+	ld	(_prev_reg +  9), a
+	ld	(_prev_reg + 10), iy
+	ld	(_prev_reg + 13), ix
+	ret
+
+	.local	_set_next_reg
+_set_next_reg:
+	ld	(_next_reg +  0), hl
+	ld	(_next_reg +  3), de
+	ld	(_next_reg +  6), bc
+	ld	(_next_reg +  9), a
+	ld	(_next_reg + 10), iy
+	ld	(_next_reg + 13), ix
+	ret
+
+	.global	_CRT_smulhu
+_CRT_smulhu:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	b, (iy + 10)
+	ld	c, (iy + 9)
+	ld	h, (iy + 7)
+	ld	l, (iy + 6)
+	pop	iy
+	call	_set_prev_reg
+	call	__smulhu
+	jp	_set_next_reg
+
+	.global	_CRT_imulhu
+_CRT_imulhu:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 6)
+	ld	bc, (iy + 9)
+	pop	iy
+	call	_set_prev_reg
+	call	__imulhu
+	jp	_set_next_reg
+
+	.global	_CRT_lmulhu
+_CRT_lmulhu:
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 6)
+	ld	e, (iy + 9)
+	ld	bc, (iy + 12)
+	ld	a, (iy + 15)
+	pop	iy
+	call	_set_prev_reg
+	call	__lmulhu
+	jp	_set_next_reg
+
+	.global	_CRT_i48mulhu
+_CRT_i48mulhu:
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 3)
+	ld	de, (iy + 6)
+	ld	bc, (iy + 9)
+	ld	iy, (iy + 12)
+	call	_set_prev_reg
+	call	__i48mulhu
+	jp	_set_next_reg
+
+	.global	_CRT_llmulhu
+_CRT_llmulhu:
+	ld	iy, 0
+	add	iy, sp
+	ld	hl, (iy + 18)
+	push	hl
+	ld	hl, (iy + 15)
+	push	hl
+	ld	hl, (iy + 12)
+	push	hl
+	ld	bc, (iy + 9)
+	ld	de, (iy + 6)
+	ld	hl, (iy + 3)
+	call	_set_prev_reg
+	call	__llmulhu
+	ld	sp, iy
+	jp	_set_next_reg
+
+	.extern	__smulhu
+	.extern	__imulhu
+	.extern	__lmulhu
+	.extern	__i48mulhu
+	.extern	__llmulhu

--- a/test/standalone/mulhu/src/crt_wrap.s
+++ b/test/standalone/mulhu/src/crt_wrap.s
@@ -3,6 +3,7 @@
 	.section	.data._prev_reg
 
 	.global	_prev_reg
+	.type	_prev_reg, @function
 _prev_reg:
 	;	L H U  E D U  C B U  A  Y I U  X I U
 	db	0,0,0, 0,0,0, 0,0,0, 0, 0,0,0, 0,0,0
@@ -10,6 +11,7 @@ _prev_reg:
 	.section	.data._next_reg
 
 	.global	_next_reg
+	.type	_next_reg, @function
 _next_reg:
 	;	L H U  E D U  C B U  A  Y I U  X I U
 	db	0,0,0, 0,0,0, 0,0,0, 0, 0,0,0, 0,0,0
@@ -37,6 +39,7 @@ _set_next_reg:
 	ret
 
 	.global	_CRT_smulhu
+	.type	_CRT_smulhu, @function
 _CRT_smulhu:
 	push	iy
 	ld	iy, 0
@@ -51,6 +54,7 @@ _CRT_smulhu:
 	jp	_set_next_reg
 
 	.global	_CRT_smulhs
+	.type	_CRT_smulhs, @function
 _CRT_smulhs:
 	push	iy
 	ld	iy, 0
@@ -65,6 +69,7 @@ _CRT_smulhs:
 	jp	_set_next_reg
 
 	.global	_CRT_imulhu
+	.type	_CRT_imulhu, @function
 _CRT_imulhu:
 	push	iy
 	ld	iy, 0
@@ -77,6 +82,7 @@ _CRT_imulhu:
 	jp	_set_next_reg
 
 	.global	_CRT_imulhs
+	.type	_CRT_imulhs, @function
 _CRT_imulhs:
 	push	iy
 	ld	iy, 0
@@ -89,6 +95,7 @@ _CRT_imulhs:
 	jp	_set_next_reg
 
 	.global	_CRT_lmulhu
+	.type	_CRT_lmulhu, @function
 _CRT_lmulhu:
 	push	iy
 	ld	iy, 0
@@ -103,6 +110,7 @@ _CRT_lmulhu:
 	jp	_set_next_reg
 
 	.global	_CRT_lmulhs
+	.type	_CRT_lmulhs, @function
 _CRT_lmulhs:
 	push	iy
 	ld	iy, 0
@@ -117,6 +125,7 @@ _CRT_lmulhs:
 	jp	_set_next_reg
 
 	.global	_CRT_i48mulhu
+	.type	_CRT_i48mulhu, @function
 _CRT_i48mulhu:
 	ld	iy, 0
 	add	iy, sp
@@ -129,6 +138,7 @@ _CRT_i48mulhu:
 	jp	_set_next_reg
 
 	.global	_CRT_i48mulhs
+	.type	_CRT_i48mulhs, @function
 _CRT_i48mulhs:
 	ld	iy, 0
 	add	iy, sp
@@ -141,6 +151,7 @@ _CRT_i48mulhs:
 	jp	_set_next_reg
 
 	.global	_CRT_llmulhu
+	.type	_CRT_llmulhu, @function
 _CRT_llmulhu:
 	ld	iy, 0
 	add	iy, sp
@@ -159,6 +170,7 @@ _CRT_llmulhu:
 	jp	_set_next_reg
 
 	.global	_CRT_llmulhs
+	.type	_CRT_llmulhs, @function
 _CRT_llmulhs:
 	ld	iy, 0
 	add	iy, sp

--- a/test/standalone/mulhu/src/main.c
+++ b/test/standalone/mulhu/src/main.c
@@ -1,0 +1,330 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <ti/sprintf.h>
+#include <ez80_builtin.h>
+
+//------------------------------------------------------------------------------
+// Config
+//------------------------------------------------------------------------------
+
+#define RANDOM_TEST_COUNT 256
+
+// define to 0 or 1
+#define DEBUG_DIAGNOSTICS 0
+
+#define AUTOTEST_SEED 0x7184CE
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+#define C(expr) if (!(expr)) { return __LINE__; }
+
+#define TEST(test) { ret = test; if (ret != 0) { return ret; }}
+
+#ifndef DEBUG_DIAGNOSTICS
+#error "DEBUG_DIAGNOSTICS needs to be defined to 0 or 1"
+#endif
+
+#if RANDOM_TEST_COUNT < 4
+#error "RANDOM_TEST_COUNT is out of range"
+#endif
+
+#if DEBUG_DIAGNOSTICS
+#define test_printf printf
+#else
+#define test_printf(...)
+#endif
+
+#define CMP(format, x, y, truth, guess) do { \
+    if (truth != guess) { \
+        test_printf("I: " format "\n * " format "\nT: " format "\nG: " format "\n", x, y, truth, guess); \
+        return __LINE__; \
+    } \
+} while(0)
+
+#define rand8() ((uint8_t)random())
+
+#define rand16() ((uint16_t)random())
+
+#define rand24() ((uint24_t)random())
+
+#define rand32() ((uint32_t)random())
+
+__attribute__((__unused__)) static uint48_t rand48(void) {
+    union {
+        uint48_t u48;
+        struct {
+            uint32_t lo32;
+            uint16_t hi16;
+        };
+    } split;
+    split.lo32 = (uint32_t)random();
+    split.hi16 = (uint16_t)random();
+    return split.u48;
+}
+
+__attribute__((__unused__)) static uint64_t rand64(void) {
+    union {
+        uint64_t u64;
+        struct {
+            uint32_t lo32;
+            uint32_t hi32;
+        };
+    } split;
+    split.lo32 = (uint32_t)random();
+    split.hi32 = (uint32_t)random();
+    return split.u64;
+}
+
+uint16_t CRT_smulhu(uint16_t, uint16_t);
+uint24_t CRT_imulhu(uint24_t, uint24_t);
+uint32_t CRT_lmulhu(uint32_t, uint32_t);
+uint48_t CRT_i48mulhu(uint48_t, uint48_t);
+uint64_t CRT_llmulhu(uint64_t, uint64_t);
+
+static __attribute__((__unused__))
+uint16_t truth_smulhu(uint16_t x, uint16_t y) {
+    return (uint16_t)(((uint32_t)x * (uint32_t)y) >> 16);
+}
+
+static __attribute__((__unused__))
+uint24_t truth_imulhu(uint24_t x, uint24_t y) {
+    return (uint24_t)(((uint48_t)x * (uint48_t)y) >> 24);
+}
+
+static __attribute__((__unused__))
+uint32_t truth_lmulhu(uint32_t x, uint32_t y) {
+    return (uint32_t)(((uint64_t)x * (uint64_t)y) >> 32);
+}
+
+static __attribute__((__unused__))
+uint48_t truth_i48mulhu(uint48_t x, uint48_t y) {
+    const uint48_t x_hi = (x >> 24);
+    const uint48_t y_hi = (y >> 24);
+    const uint48_t x_lo = (x & UINT24_MAX);
+    const uint48_t y_lo = (y & UINT24_MAX);
+    uint48_t result = x_lo * y_lo;
+    result >>= 24;
+    result += x_hi * y_lo + x_lo * y_hi;
+    result >>= 24;
+    result += x_hi * y_hi;
+    return result;
+}
+
+static __attribute__((__unused__))
+uint64_t truth_llmulhu(uint64_t x, uint64_t y) {
+    const uint64_t x_hi = (x >> 32);
+    const uint64_t y_hi = (y >> 32);
+    const uint64_t x_lo = (x & UINT32_MAX);
+    const uint64_t y_lo = (y & UINT32_MAX);
+    uint64_t result = x_lo * y_lo;
+    result >>= 32;
+    result += x_hi * y_lo + x_lo * y_hi;
+    result >>= 32;
+    result += x_hi * y_hi;
+    return result;
+}
+
+typedef struct reg_group {
+    union {
+        struct {
+            uint24_t HL;
+            uint24_t DE;
+            uint24_t BC;
+        };
+        struct {
+            uint8_t L;
+            uint8_t H;
+            uint8_t UHL;
+            uint8_t E;
+            uint8_t D;
+            uint8_t UDE;
+            uint8_t C;
+            uint8_t B;
+            uint8_t UBC;
+        };
+    };
+    uint8_t A;
+    uint24_t IY;
+    uint24_t IX;
+} reg_group;
+extern reg_group prev_reg;
+extern reg_group next_reg;
+
+void print_reg(void) {
+    test_printf(
+        "A: %02X -> %02X\n"\
+        "HL: %06X -> %06X\n"\
+        "DE: %06X -> %06X\n"\
+        "BC: %06X -> %06X\n"\
+        "IY: %06X -> %06X\n"\
+        "IX: %06X -> %06X\n",
+        prev_reg.A , next_reg.A ,
+        prev_reg.HL, next_reg.HL,
+        prev_reg.DE, next_reg.DE,
+        prev_reg.BC, next_reg.BC,
+        prev_reg.IY, next_reg.IY,
+        prev_reg.IX, next_reg.IX
+    );
+}
+
+__attribute__((__unused__))
+static bool test_A_UBC_UDE_UIY_UIX(void) {
+    if (
+        (prev_reg.A   == next_reg.A  ) &&
+        (prev_reg.BC  == next_reg.BC ) &&
+        (prev_reg.DE  == next_reg.DE ) &&
+        (prev_reg.IY  == next_reg.IY ) &&
+        (prev_reg.IX  == next_reg.IX )
+    ) {
+        return true;
+    }
+    print_reg();
+    return false;
+}
+
+__attribute__((__unused__))
+static bool test_A_UBC_UD_UIY_UIX(void) {
+    if (
+        (prev_reg.A   == next_reg.A  ) &&
+        (prev_reg.BC  == next_reg.BC ) &&
+        (prev_reg.UDE == next_reg.UDE) &&
+        (prev_reg.D   == next_reg.D  ) &&
+        (prev_reg.IY  == next_reg.IY ) &&
+        (prev_reg.IX  == next_reg.IX )
+    ) {
+        return true;
+    }
+    print_reg();
+    return false;
+}
+
+__attribute__((__unused__))
+static bool test_A_UBC_UIY_UIX(void) {
+    if (
+        (prev_reg.A   == next_reg.A  ) &&
+        (prev_reg.BC  == next_reg.BC ) &&
+        (prev_reg.IY  == next_reg.IY ) &&
+        (prev_reg.IX  == next_reg.IX )
+    ) {
+        return true;
+    }
+    print_reg();
+    return false;
+}
+
+__attribute__((__unused__))
+static bool test_A_UIY_UIX(void) {
+    if (
+        (prev_reg.A   == next_reg.A  ) &&
+        (prev_reg.IY  == next_reg.IY ) &&
+        (prev_reg.IX  == next_reg.IX )
+    ) {
+        return true;
+    }
+    print_reg();
+    return false;
+}
+
+int test_smulhu(void) {
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint16_t truth, guess, x, y;
+        x = rand16();
+        y = rand16();
+        truth = truth_smulhu(x, y);
+        guess = CRT_smulhu(x, y);
+        CMP("%04X", x, y, truth, guess);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
+    return 0;
+}
+
+int test_imulhu(void) {
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint24_t truth, guess, x, y;
+        x = rand24();
+        y = rand24();
+        truth = truth_imulhu(x, y);
+        guess = CRT_imulhu(x, y);
+        CMP("%06X", x, y, truth, guess);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
+    return 0;
+}
+
+int test_lmulhu(void) {
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint32_t truth, guess, x, y;
+        x = rand32();
+        y = rand32();
+        truth = truth_lmulhu(x, y);
+        guess = CRT_lmulhu(x, y);
+        CMP("%08lX", x, y, truth, guess);
+        C((test_A_UBC_UD_UIY_UIX()));
+    }
+    return 0;
+}
+
+int test_i48mulhu(void) {
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint48_t truth, guess, x, y;
+        x = rand48();
+        y = rand48();
+        truth = truth_i48mulhu(x, y);
+        guess = CRT_i48mulhu(x, y);
+        CMP("%012llX", (uint64_t)x, (uint64_t)y, (uint64_t)truth, (uint64_t)guess);
+        C((test_A_UBC_UIY_UIX()));
+    }
+    return 0;
+}
+
+int test_llmulhu(void) {
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint64_t truth, guess, x, y;
+        x = rand64();
+        y = rand64();
+        truth = truth_llmulhu(x, y);
+        guess = CRT_llmulhu(x, y);
+        CMP("%016llX", x, y, truth, guess);
+        C((test_A_UIY_UIX()));
+    }
+    return 0;
+}
+
+int run_tests(void) {
+    srandom(AUTOTEST_SEED);
+    int ret = 0;
+    TEST(test_smulhu());
+    TEST(test_imulhu());
+    TEST(test_lmulhu());
+    TEST(test_i48mulhu());
+    TEST(test_llmulhu());
+
+    return ret;
+}
+
+int main(void) {
+    os_ClrHome();
+    int failed_test = run_tests();
+    if (failed_test != 0) {
+        char buf[sizeof("Failed test L-8388608\n")];
+        boot_sprintf(buf, "Failed test L%d\n", failed_test);
+        fputs(buf, stdout);
+    } else {
+        fputs("All tests passed", stdout);
+    }
+
+    while (!os_GetCSC());
+
+    return 0;
+}

--- a/test/standalone/mulhu/src/main.c
+++ b/test/standalone/mulhu/src/main.c
@@ -27,10 +27,6 @@
 // Utility
 //------------------------------------------------------------------------------
 
-#define C(expr) if (!(expr)) { return __LINE__; }
-
-#define TEST(test) { ret = test; if (ret != 0) { return ret; }}
-
 #ifndef DEBUG_DIAGNOSTICS
 #error "DEBUG_DIAGNOSTICS needs to be defined to 0 or 1"
 #endif
@@ -41,9 +37,21 @@
 
 #if DEBUG_DIAGNOSTICS
 #define test_printf printf
+#define test_debug(...) sprintf((char*)0xFB0000, __VA_ARGS__)
 #else
 #define test_printf(...)
+#define test_debug(...)
 #endif
+
+#define C(expr) if (!(expr)) { return __LINE__; }
+
+#define TEST(test) do { \
+    test_debug("calling %s\n", #test); \
+    ret = test; \
+    if (ret != 0) { \
+        return ret; \
+    } \
+} while(0)
 
 #define CMP(format, x, y, truth, guess) do { \
     if (truth != guess) { \
@@ -51,6 +59,9 @@
         return __LINE__; \
     } \
 } while(0)
+
+#define rand4_u() (uint8_t)(((uint8_t)random()) & 0x0F)
+#define rand4_s() (int8_t)((int8_t)random() >> 4)
 
 #define rand8() ((uint8_t)random())
 
@@ -300,6 +311,7 @@ bool test_A_UIY_UIX(void) {
 //------------------------------------------------------------------------------
 
 int test_smulhu(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         uint16_t truth, guess, x, y;
         x = (uint16_t)rand16();
@@ -309,10 +321,24 @@ int test_smulhu(void) {
         CMP("%04hX", x, y, truth, guess);
         C((test_A_UBC_UDE_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint16_t truth, guess_1, guess_2, x, y;
+        x = (uint16_t)rand16();
+        y = rand4_u();
+        truth = truth_smulhu(x, y);
+        guess_1 = CRT_smulhu(x, y);
+        CMP("%04hX", x, y, truth, guess_1);
+        C((test_A_UBC_UDE_UIY_UIX()));
+        guess_2 = CRT_smulhu(y, x);
+        CMP("%04hX", y, x, truth, guess_2);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_imulhu(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         uint24_t truth, guess, x, y;
         x = (uint24_t)rand24();
@@ -322,10 +348,24 @@ int test_imulhu(void) {
         CMP("%06X", x, y, truth, guess);
         C((test_A_UBC_UDE_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint24_t truth, guess_1, guess_2, x, y;
+        x = (uint24_t)rand24();
+        y = rand4_u();
+        truth = truth_imulhu(x, y);
+        guess_1 = CRT_imulhu(x, y);
+        CMP("%06X", x, y, truth, guess_1);
+        C((test_A_UBC_UDE_UIY_UIX()));
+        guess_2 = CRT_imulhu(y, x);
+        CMP("%06X", y, x, truth, guess_2);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_lmulhu(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         uint32_t truth, guess, x, y;
         x = (uint32_t)rand32();
@@ -335,10 +375,24 @@ int test_lmulhu(void) {
         CMP("%08lX", x, y, truth, guess);
         C((test_A_UBC_UD_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint32_t truth, guess_1, guess_2, x, y;
+        x = (uint32_t)rand32();
+        y = rand4_u();
+        truth = truth_lmulhu(x, y);
+        guess_1 = CRT_lmulhu(x, y);
+        CMP("%08lX", x, y, truth, guess_1);
+        C((test_A_UBC_UD_UIY_UIX()));
+        guess_2 = CRT_lmulhu(y, x);
+        CMP("%08lX", y, x, truth, guess_2);
+        C((test_A_UBC_UD_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_i48mulhu(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         uint48_t truth, guess, x, y;
         x = (uint48_t)rand48();
@@ -348,10 +402,24 @@ int test_i48mulhu(void) {
         CMP("%012llX", (uint64_t)x, (uint64_t)y, (uint64_t)truth, (uint64_t)guess);
         C((test_A_UBC_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint48_t truth, guess_1, guess_2, x, y;
+        x = (uint48_t)rand48();
+        y = rand4_u();
+        truth = truth_i48mulhu(x, y);
+        guess_1 = CRT_i48mulhu(x, y);
+        CMP("%012llX", (uint64_t)x, (uint64_t)y, (uint64_t)truth, (uint64_t)guess_1);
+        C((test_A_UBC_UIY_UIX()));
+        guess_2 = CRT_i48mulhu(y, x);
+        CMP("%012llX", (uint64_t)y, (uint64_t)x, (uint64_t)truth, (uint64_t)guess_2);
+        C((test_A_UBC_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_llmulhu(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         uint64_t truth, guess, x, y;
         x = (uint64_t)rand64();
@@ -359,6 +427,19 @@ int test_llmulhu(void) {
         truth = truth_llmulhu(x, y);
         guess = CRT_llmulhu(x, y);
         CMP("%016llX", x, y, truth, guess);
+        C((test_A_UIY_UIX()));
+    }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        uint64_t truth, guess_1, guess_2, x, y;
+        x = (uint64_t)rand64();
+        y = rand4_u();
+        truth = truth_llmulhu(x, y);
+        guess_1 = CRT_llmulhu(x, y);
+        CMP("%016llX", x, y, truth, guess_1);
+        C((test_A_UIY_UIX()));
+        guess_2 = CRT_llmulhu(y, x);
+        CMP("%016llX", y, x, truth, guess_2);
         C((test_A_UIY_UIX()));
     }
     return 0;
@@ -369,6 +450,7 @@ int test_llmulhu(void) {
 //------------------------------------------------------------------------------
 
 int test_smulhs(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         int16_t truth, guess, x, y;
         x = (int16_t)rand16();
@@ -378,10 +460,24 @@ int test_smulhs(void) {
         CMP("%04hX", x, y, truth, guess);
         C((test_A_UBC_UDE_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        int16_t truth, guess_1, guess_2, x, y;
+        x = (int16_t)rand16();
+        y = rand4_s();
+        truth = truth_smulhs(x, y);
+        guess_1 = CRT_smulhs(x, y);
+        CMP("%04hX", x, y, truth, guess_1);
+        C((test_A_UBC_UDE_UIY_UIX()));
+        guess_2 = CRT_smulhs(y, x);
+        CMP("%04hX", y, x, truth, guess_2);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_imulhs(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         int24_t truth, guess, x, y;
         x = (int24_t)rand24();
@@ -391,10 +487,24 @@ int test_imulhs(void) {
         CMP("%06X", x, y, truth, guess);
         C((test_A_UBC_UDE_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        int24_t truth, guess_1, guess_2, x, y;
+        x = (int24_t)rand24();
+        y = rand4_s();
+        truth = truth_imulhs(x, y);
+        guess_1 = CRT_imulhs(x, y);
+        CMP("%06X", x, y, truth, guess_1);
+        C((test_A_UBC_UDE_UIY_UIX()));
+        guess_2 = CRT_imulhs(y, x);
+        CMP("%06X", y, x, truth, guess_2);
+        C((test_A_UBC_UDE_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_lmulhs(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         int32_t truth, guess, x, y;
         x = (int32_t)rand32();
@@ -404,10 +514,24 @@ int test_lmulhs(void) {
         CMP("%08lX", x, y, truth, guess);
         C((test_A_UBC_UD_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        int32_t truth, guess_1, guess_2, x, y;
+        x = (int32_t)rand32();
+        y = rand4_s();
+        truth = truth_lmulhs(x, y);
+        guess_1 = CRT_lmulhs(x, y);
+        CMP("%08lX", x, y, truth, guess_1);
+        C((test_A_UBC_UD_UIY_UIX()));
+        guess_2 = CRT_lmulhs(y, x);
+        CMP("%08lX", y, x, truth, guess_2);
+        C((test_A_UBC_UD_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_i48mulhs(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         int48_t truth, guess, x, y;
         x = (int48_t)rand48();
@@ -417,10 +541,24 @@ int test_i48mulhs(void) {
         CMP("%012llX", (int64_t)x, (int64_t)y, (int64_t)truth, (int64_t)guess);
         C((test_A_UBC_UIY_UIX()));
     }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        int48_t truth, guess_1, guess_2, x, y;
+        x = (int48_t)rand48();
+        y = rand4_s();
+        truth = truth_i48mulhs(x, y);
+        guess_1 = CRT_i48mulhs(x, y);
+        CMP("%012llX", (int64_t)x, (int64_t)y, (int64_t)truth, (int64_t)guess_1);
+        C((test_A_UBC_UIY_UIX()));
+        guess_2 = CRT_i48mulhs(y, x);
+        CMP("%012llX", (int64_t)y, (int64_t)x, (int64_t)truth, (int64_t)guess_2);
+        C((test_A_UBC_UIY_UIX()));
+    }
     return 0;
 }
 
 int test_llmulhs(void) {
+    // test full-width random operands
     for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
         int64_t truth, guess, x, y;
         x = (int64_t)rand64();
@@ -428,6 +566,19 @@ int test_llmulhs(void) {
         truth = truth_llmulhs(x, y);
         guess = CRT_llmulhs(x, y);
         CMP("%016llX", x, y, truth, guess);
+        C((test_A_UIY_UIX()));
+    }
+    // test cases where the upper-half of the result is small
+    for (int i = 0; i < RANDOM_TEST_COUNT; i++) {
+        int64_t truth, guess_1, guess_2, x, y;
+        x = (int64_t)rand64();
+        y = rand4_s();
+        truth = truth_llmulhs(x, y);
+        guess_1 = CRT_llmulhs(x, y);
+        CMP("%016llX", x, y, truth, guess_1);
+        C((test_A_UIY_UIX()));
+        guess_2 = CRT_llmulhs(y, x);
+        CMP("%016llX", y, x, truth, guess_2);
         C((test_A_UIY_UIX()));
     }
     return 0;
@@ -452,6 +603,8 @@ int run_tests(void) {
     TEST(test_lmulhs());
     TEST(test_i48mulhs());
     TEST(test_llmulhs());
+
+    test_debug("Finished\n");
 
     return ret;
 }


### PR DESCRIPTION
Added multiply high signed/unsigned routines. These can be used to optimize division by a constant. `__smulhu` is optimized, but the rest are not well optimized. They use the exact same calling convention as the regular multiplication routines. We can optimize these routines in later PR's.

```
__smulhu   :         HL = ((uint32_t)         HL * (uint32_t)      BC) >> 16
__imulhu   :        UHL = ((uint48_t)        UHL * (uint48_t)     UBC) >> 24
__lmulhu   :      E:UHL = ((uint64_t)      E:UHL * (uint64_t)   A:UBC) >> 32
__i48mulhu :    UDE:UHL = ((uint96_t)    UDE:UHL * (uint96_t) UIY:UBC) >> 48
__llmulhu  : BC:UDE:UHL = ((uint128_t)BC:UDE:UHL * (uint128_t) (SP64)) >> 64

__smulhs   :         HL = ((int32_t)          HL * (int32_t)       BC) >> 16
__imulhs   :        UHL = ((int48_t)         UHL * (int48_t)      UBC) >> 24
__lmulhs   :      E:UHL = ((int64_t)       E:UHL * (int64_t)    A:UBC) >> 32
__i48mulhs :    UDE:UHL = ((int96_t)     UDE:UHL * (int96_t)  UIY:UBC) >> 48
__llmulhs  : BC:UDE:UHL = ((int128_t) BC:UDE:UHL * (int128_t)  (SP64)) >> 64
```
```
__smulhu   :  32 bytes |  33F +  12R +   9W +  17
__imulhu   : 117 bytes | 118F +  39R +  38W +  37
__lmulhu   : 1 call to __llmulu
__i48mulhu :  93 bytes | 902F + 246R + 182W + 344
__llmulhu  : (disables interrupts to use exx) slightly faster than 2 calls to __llmulu
```

`__bmulhu` was not added since it is just `mlt bc \ ld a, b` (and the 8-bit calling convention is not well defined). Although Zilog appears to define it to be `A = H * L` going off of `__frbmuls`
