### PR TITLE
fixed <fenv.h> function-macros and added <cfenv>

### DIFF
--- a/src/libc/fenv.c
+++ b/src/libc/fenv.c
@@ -3,19 +3,24 @@
 const fenv_t __fe_dfl_env = FE_TONEAREST;
 fenv_t __fe_cur_env = __fe_dfl_env;
 
-#define _
-#define DEF(name, params, args) int name _ params { return name args; }
+extern inline int feclearexcept(int __excepts);
 
-DEF(feclearexcept, (int excepts), (excepts))
-DEF(fegetexceptflag, (fexcept_t *flagp, int excepts), (flagp, excepts))
-DEF(feraiseexcept, (int excepts), (excepts))
-DEF(fesetexceptflag, (const fexcept_t *flagp, int excepts), (flagp, excepts))
-DEF(fetestexcept, (int excepts), (excepts))
+extern inline int fegetexceptflag(fexcept_t *__flagp, int __excepts);
 
-DEF(fegetround, (void), ())
-DEF(fesetround, (int rounding_mode), (rounding_mode))
+extern inline int feraiseexcept(int __excepts);
 
-DEF(fegetenv, (fenv_t *envp), (envp))
-DEF(feholdexcept, (fenv_t *envp), (envp))
-DEF(fesetenv, (const fenv_t *envp), (envp))
-DEF(feupdateenv, (const fenv_t *envp), (envp))
+extern inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
+
+extern inline int fetestexcept(int __excepts);
+
+extern inline int fegetround(void);
+
+extern inline int fesetround(int __rounding_mode);
+
+extern inline int fegetenv(fenv_t *__envp);
+
+extern inline int feholdexcept(fenv_t *__envp);
+
+extern inline int fesetenv(const fenv_t *__envp);
+
+extern inline int feupdateenv(const fenv_t *__envp);

--- a/src/libc/include/fenv.h
+++ b/src/libc/include/fenv.h
@@ -11,10 +11,6 @@ extern __fenv_t __fe_cur_env;
 #ifndef _FENV_H
 #define _FENV_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 enum {
     FE_DIVBYZERO  = 1 << 6,
 #define FE_DIVBYZERO  FE_DIVBYZERO
@@ -45,39 +41,53 @@ typedef unsigned char fexcept_t;
 extern const fenv_t __fe_dfl_env;
 #define FE_DFL_ENV (&__fe_dfl_env)
 
-int feclearexcept(int);
-#define feclearexcept(excepts) (__fe_cur_env &= ~((excepts) & FE_ALL_EXCEPT), 0)
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-int fegetexceptflag(fexcept_t *, int);
-#define fegetexceptflag(flagp, excepts) (*(flagp) = __fe_cur_env & (excepts) & FE_ALL_EXCEPT, 0)
+inline int feclearexcept(int __excepts) {
+    return (__fe_cur_env &= ~((__excepts) & FE_ALL_EXCEPT), 0);
+}
 
-int feraiseexcept(int);
-#define feraiseexcept(excepts) (__fe_cur_env |= (excepts) & FE_ALL_EXCEPT, 0)
+inline int fegetexceptflag(fexcept_t *__flagp, int __excepts) {
+    return (*(__flagp) = __fe_cur_env & (__excepts) & FE_ALL_EXCEPT, 0);
+}
 
-int fesetexceptflag(const fexcept_t *, int);
-#define fesetexceptflag(flagp, excepts) (__fe_cur_env = (__fe_cur_env & ~((excepts) & FE_ALL_EXCEPT)) \
-                                         | (*(flagp) & (excepts) & FE_ALL_EXCEPT), 0)
+inline int feraiseexcept(int __excepts) {
+    return (__fe_cur_env |= (__excepts) & FE_ALL_EXCEPT, 0);
+}
 
-int fetestexcept(int);
-#define fetestexcept(excepts) (__fe_cur_env & (excepts) & FE_ALL_EXCEPT)
+inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts) {
+    return (__fe_cur_env = (__fe_cur_env & ~((__excepts) & FE_ALL_EXCEPT)) | (*(__flagp) & (__excepts) & FE_ALL_EXCEPT), 0);
+}
 
-int fegetround(void);
-#define fegetround() (__fe_cur_env & 3)
+inline int fetestexcept(int __excepts) {
+    return (__fe_cur_env & (__excepts) & FE_ALL_EXCEPT);
+}
 
-int fesetround(int);
-#define fesetround(rounding_mode) (__fe_cur_env = (__fe_cur_env & ~3) | ((rounding_mode) & 3), 0)
+inline int fegetround(void) {
+    return (__fe_cur_env & 3);
+}
 
-int fegetenv(fenv_t *);
-#define fegetenv(envp) (*(envp) = __fe_cur_env, 0)
+inline int fesetround(int __rounding_mode) {
+    return (__fe_cur_env = (__fe_cur_env & ~3) | ((__rounding_mode) & 3), 0);
+}
 
-int feholdexcept(fenv_t *);
-#define feholdexcept(envp) (*(envp) = __fe_cur_env, __fe_cur_env &= ~FE_ALL_EXCEPT, 0)
+inline int fegetenv(fenv_t *__envp) {
+    return (*(__envp) = __fe_cur_env, 0);
+}
 
-int fesetenv(const fenv_t *);
-#define fesetenv(envp) (__fe_cur_env = *(envp), 0)
+inline int feholdexcept(fenv_t *__envp) {
+    return (*(__envp) = __fe_cur_env, __fe_cur_env &= ~FE_ALL_EXCEPT, 0);
+}
 
-int feupdateenv(const fenv_t *);
-#define feupdateenv(envp) (__fe_cur_env = (__fe_cur_env & FE_ALL_EXCEPT) | *(envp), 0)
+inline int fesetenv(const fenv_t *__envp) {
+    return (__fe_cur_env = *(__envp), 0);
+}
+
+inline int feupdateenv(const fenv_t *__envp) {
+    return (__fe_cur_env = (__fe_cur_env & FE_ALL_EXCEPT) | *(__envp), 0);
+}
 
 #ifdef __cplusplus
 }

--- a/src/libcxx/header_test.cpp
+++ b/src/libcxx/header_test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cctype>
 #include <cerrno>
+#include <cfenv>
 #include <cfloat>
 #include <cinttypes>
 #include <ciso646>

--- a/src/libcxx/include/cfenv
+++ b/src/libcxx/include/cfenv
@@ -1,0 +1,26 @@
+// -*- C++ -*-
+#ifndef _EZCXX_CFENV
+#define _EZCXX_CFENV
+
+#include <fenv.h>
+
+#pragma clang system_header
+
+namespace std {
+using ::fenv_t;
+using ::fexcept_t;
+
+using ::feclearexcept;
+using ::fegetexceptflag;
+using ::feraiseexcept;
+using ::fesetexceptflag;
+using ::fetestexcept;
+using ::fegetround;
+using ::fesetround;
+using ::fegetenv;
+using ::feholdexcept;
+using ::fesetenv;
+using ::feupdateenv;
+} // namespace std
+
+#endif // _EZCXX_CFENV


### PR DESCRIPTION
Previously, `<fenv.h>` had function-macros (such as `#define feraiseexcept(excepts) (__fe_cur_env |= (excepts) & FE_ALL_EXCEPT, 0)` that prevented `std::feraiseexcept(value)` from working. I have now changed these to `inline` functions, allowing for `<cfenv>` to be implemented. `extern inline` functions in `fenv.c` are linked if the compiler chooses not to inline.
