### PR TITLE
fixed bsearch prototype

### DIFF
--- a/src/libc/bsearch.c
+++ b/src/libc/bsearch.c
@@ -26,11 +26,11 @@
 *
 *************************************************/
 void *bsearch(
-    void *keyp, void *ptr, size_t num, size_t width,
+    const void *keyp, const void *ptr, size_t num, size_t width,
     int (*comp)(const void *, const void *)
 ) {
-    char *key = keyp;
-    char *base = ptr;
+    const char *key = keyp;
+    const char *base = ptr;
     unsigned int mid;
     unsigned int low;
     unsigned int high;
@@ -66,7 +66,7 @@ void *bsearch(
             continue;           /* than the key.            */
         }
 
-        d = (*comp)(key,addr = base + mid * width);
+        d = (*comp)(key,addr = (char*)(base + mid * width));
         if (d == 0)             /* we found it              */
             return(addr);
         if (d < 0)              /* key is less than mid,    */

--- a/src/libc/include/stdlib.h
+++ b/src/libc/include/stdlib.h
@@ -78,7 +78,7 @@ void srand(unsigned int seed);
 
 int rand(void);
 
-void *bsearch(void *key, void *base, size_t nmemb, size_t size,
+void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
               int (*compar)(const void *, const void *))
               __attribute__((nonnull(1, 2, 5)));
 


### PR DESCRIPTION
Changed `void *bsearch(void *key, void *base,` to `void *bsearch(const void *key, const void *base,` in `<stdlib.h>`

https://en.cppreference.com/w/c/algorithm/bsearch