### PR TITLE
fixed gfx_AllocSprite return value bug

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -388,10 +388,12 @@ gfx_AllocSprite:
 	inc	de			; de = width * height + 2
 	push	de
 	call	_indcallHL		; hl = malloc(width * height + 2)
-	pop	de			; de = width * height + 2
-	add	hl, de			; this should never carry
-	sbc	hl, de			; check if malloc failed (hl == 0)
-	pop	de			; e = width, d = height
+	pop	de
+	pop	de			; e = width, d = height, ude = unknown
+	; check if malloc failed (hl == 0)
+	add	hl, de
+	or	a, a
+	sbc	hl, de
 	ret	z			; abort if malloc failed
 	ld	(hl), de		; store width and height
 	ret


### PR DESCRIPTION
MERGE https://github.com/CE-Programming/toolchain/pull/657 BEFORE THIS!!!

fixes https://github.com/CE-Programming/toolchain/issues/658
gfx_AllocSprite made an invalid assumption that the allocation routine would preserve the stack parameters. allocation routines such as `__simple_malloc` destroy the stack parameter, which can cause a returned non-NULL pointer to be off by one. This is especially problematic when this off-by-one pointer has to be freed.

The bug with the `width * height == 0` case is assumed to be undefined behavior, since the sprite routines don't handle this case either.