### PR TITLE
fixed ignore line spacing flag

### DIFF
--- a/src/fontlibc/fontlibc.asm
+++ b/src/fontlibc/fontlibc.asm
@@ -458,8 +458,8 @@ fontlib_SetFont:
 	add	hl,de
 	add	hl,bc
 	ld	(iy + strucFont.bitmapsTablePtr),hl
-; Check for the ignore ling spacing flag
-	ld	hl,arg0
+; Check for the ignore line spacing flag
+	ld	hl,arg1
 	add	hl,sp
 	ld	a,(hl)
 	or	a,a
@@ -2100,4 +2100,3 @@ currentFontRoot := _CurrentFontRoot - DataBaseAddr
 DataBaseAddr:
 ; Embed the current font's properties as library variables
 _CurrentFontProperties strucFont
-


### PR DESCRIPTION
`bool fontlib_SetFont(const fontlib_font_t *font_data, fontlib_load_options_t flags);`
It looks like this code reads from `font_data` instead of `flags`. since the low byte of `font_data` will be non-zero 255/256 times, then I would assume that line spacing will almost always be treated as ignored