### PR TITLE
Fix and optimize clipping behavior for gfx_HorizLine and gfx_VertLine

### DIFF
--- a/test/issues/673/.gitignore
+++ b/test/issues/673/.gitignore
@@ -1,0 +1,7 @@
+obj/
+bin/
+src/gfx/*.c
+src/gfx/*.h
+src/gfx/*.8xv
+.DS_Store
+convimg.yaml.lst

--- a/test/issues/673/autotest.json
+++ b/test/issues/673/autotest.json
@@ -1,0 +1,36 @@
+{
+  "transfer_files":
+  [
+    "bin/DEMO.8xp"
+  ],
+  "target":
+  {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence":
+  [
+    "action|launch",
+    "delay|100",
+    "hashWait|1",
+    "key|enter",
+    "hashWait|2"
+  ],
+  "hashes":
+  {
+    "1":
+    {
+      "description": "Test line clipping",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [ "045155B1" ]
+    },
+    "2":
+    {
+      "description": "Test program exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [ "FFAF89BA", "101734A5", "9DA19F44", "A32840C8", "349F4775" ]
+    }
+  }
+}

--- a/test/issues/673/makefile
+++ b/test/issues/673/makefile
@@ -1,0 +1,15 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+
+CFLAGS = -Wall -Wextra -Oz
+CXXFLAGS = -Wall -Wextra -Oz
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/issues/673/src/main.c
+++ b/test/issues/673/src/main.c
@@ -1,0 +1,55 @@
+#include <ti/getcsc.h>
+#include <graphx.h>
+#include <limits.h>
+
+static const int test_params[][2] =
+{
+    { 0, 200 },
+    { 50, 256 },
+    { 100, 220 },
+    { -1, 201 },
+    { 100, 221 },
+    { 150, INT_MAX },
+    { -20, INT_MAX },
+    { -40, 20 },
+    { -40, 40 },
+    { -40, 41 },
+    { -40, 400 },
+    { 320, 50 },
+    { 319, 51 },
+    { -1, 0 },
+    { 0, 0 },
+    { 319, 0 },
+    { 320, 0 },
+    { 50, -1 },
+    { 100, INT_MIN },
+};
+
+static const int clip_regions[4][2] = {
+    { 0, 320 },
+    { 80, 220 },
+    { 50, 101 },
+    { 149, 319 },
+};
+
+int main(void)
+{
+    gfx_Begin();
+
+    for (int j = 0; j < 4; j++)
+    {
+        gfx_SetClipRegion(clip_regions[j][0], 0, clip_regions[j][1], 240);
+
+        for (int i = 0; i < (int)(sizeof(test_params) / sizeof(test_params[0])); i++)
+        {
+            gfx_SetColor(i);
+            gfx_HorizLine(test_params[i][0], j * 60 + i * 2 + 1, test_params[i][1]);
+        }
+    }
+
+    while (!os_GetCSC());
+
+    gfx_End();
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #673, verified fix against [FishCE](https://github.com/merthsoft/fishce) and using a new test program.

Also, as a behavioral fix compared to before the clipping logic was broken, signed overflow of start + length is handled as if saturated (so negative lengths are never drawn, and positive lengths causing an overflow past INT_MAX will be drawn all the way to the right of the clip region).