### PR TITLE
Optimize frameset0

### DIFF
--- a/src/crt/frameset0.src
+++ b/src/crt/frameset0.src
@@ -5,8 +5,9 @@
 	.type	__frameset0, @function
 
 __frameset0:
-	pop	hl
-	push	ix
-	ld	ix,0
-	add	ix,sp
+	or	a, a
+	sbc	hl, hl
+	add	hl, sp
+	ex	(sp), hl
+	ex	(sp), ix
 	jp	(hl)

--- a/src/crt/frameset0_fast.src
+++ b/src/crt/frameset0_fast.src
@@ -1,0 +1,12 @@
+	.assume	adl=1
+
+	.section	.text
+	.global	__frameset0_fast
+	.type	__frameset0_fast, @function
+
+__frameset0_fast:
+	pop	hl
+	push	ix
+	ld	ix,0
+	add	ix,sp
+	jp	(hl)


### PR DESCRIPTION
frameset0.src is moved to frameset0_fast.src since it is a little faster. If desired, frameset0_fast.src can be removed.

Old: 11 bytes, 13F+3R+3W=70 cycles
New: 8 bytes, 10F+6R+6W=76 cycles