### PR TITLE
fix warning in powf and powl

### DIFF
--- a/src/libc/powf.c
+++ b/src/libc/powf.c
@@ -32,8 +32,8 @@ float powf(float arg1, float arg2) {
         return expf( arg2 * logf( arg1 ) );
     }
     if ( arg1 < 0.0 ){
-        temp = arg2;
-        if ( temp == arg2 ){
+        temp = (long)arg2;
+        if ( (float)temp == arg2 ){
             result = expf( arg2 * logf( -arg1 ) );
             return temp & 1 ? -result : result;
         }

--- a/src/libc/powl.c
+++ b/src/libc/powl.c
@@ -18,8 +18,8 @@ long double powl(long double x, long double y) {
         return expl( y * logl( x ) );
     }
     if ( x < 0.0L ){
-        temp = y;
-        if ( temp == y ){
+        temp = (long)y;
+        if ( (long double)temp == y ){
             result = expl( y * logl( -x ) );
             return temp & 1 ? -result : result;
         }


### PR DESCRIPTION
Fixes/suppresses the following warning
```c
powf.c:36:14: warning: implicit conversion from 'long' to 'float' may lose precision [-Wimplicit-int-float-conversion]
   36 |         if ( temp == arg2 ){
      |              ^~~~ ~~
```