### PR TITLE
formatted header include guards

### DIFF
--- a/src/ce/include/intce.h
+++ b/src/ce/include/intce.h
@@ -97,4 +97,4 @@ void int_SetVector(uint8_t ivect, void (*handler)(void));
 }
 #endif
 
-#endif
+#endif /* _INTCE_H */

--- a/src/ce/include/sys/basicusb.h
+++ b/src/ce/include/sys/basicusb.h
@@ -56,4 +56,4 @@ int8_t os_USBGetRequestStatus(void);
 }
 #endif
 
-#endif
+#endif /* SYS_BASIC_USB_H */

--- a/src/ce/include/sys/lcd.h
+++ b/src/ce/include/sys/lcd.h
@@ -213,4 +213,4 @@ do { \
 }
 #endif
 
-#endif
+#endif /* SYS_LCD_H */

--- a/src/ce/include/sys/power.h
+++ b/src/ce/include/sys/power.h
@@ -83,4 +83,4 @@ uint8_t boot_BatteryCharging(void);
 }
 #endif
 
-#endif
+#endif /* SYS_POWER_H */

--- a/src/ce/include/sys/rtc.h
+++ b/src/ce/include/sys/rtc.h
@@ -211,4 +211,4 @@ do { \
 }
 #endif
 
-#endif
+#endif /* SYS_RTC_H */

--- a/src/ce/include/sys/timers.h
+++ b/src/ce/include/sys/timers.h
@@ -255,4 +255,4 @@ void boot_WaitShort(void);
 }
 #endif
 
-#endif
+#endif /* SYS_TIMERS_H */

--- a/src/ce/include/sys/util.h
+++ b/src/ce/include/sys/util.h
@@ -98,4 +98,4 @@ uint32_t atomic_load_decreasing_32(volatile uint32_t *p);
 }
 #endif
 
-#endif
+#endif /* SYS_UTIL_H */

--- a/src/ce/include/ti/error.h
+++ b/src/ce/include/ti/error.h
@@ -125,4 +125,4 @@ void os_PopErrorHandler(void);
 }
 #endif
 
-#endif
+#endif /* TI_ERROR_H */

--- a/src/ce/include/ti/flags.h
+++ b/src/ce/include/ti/flags.h
@@ -351,4 +351,4 @@ bool os_TestFlagBitsFast(uint16_t offset_pattern);
 }
 #endif
 
-#endif
+#endif /* TI_FLAGS_H */

--- a/src/ce/include/ti/getcsc.h
+++ b/src/ce/include/ti/getcsc.h
@@ -146,4 +146,4 @@ typedef uint8_t sk_key_t;
 }
 #endif
 
-#endif
+#endif /* TI_GETCSC_H */

--- a/src/ce/include/ti/getkey.h
+++ b/src/ce/include/ti/getkey.h
@@ -889,4 +889,4 @@ uint16_t os_GetKey(void);
 }
 #endif
 
-#endif
+#endif /* TI_GETKEY_H */

--- a/src/ce/include/ti/graph.h
+++ b/src/ce/include/ti/graph.h
@@ -137,4 +137,4 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* TI_GRAPH_H */

--- a/src/ce/include/ti/info.h
+++ b/src/ce/include/ti/info.h
@@ -70,4 +70,4 @@ const system_info_t *os_GetSystemInfo(void);
 }
 #endif
 
-#endif
+#endif /* TI_INFO_H */

--- a/src/ce/include/ti/python.h
+++ b/src/ce/include/ti/python.h
@@ -76,4 +76,4 @@ int8_t os_MSDWrite(uint8_t lun, uint8_t blockCount, uint32_t lba, uint24_t block
 }
 #endif
 
-#endif
+#endif /* TI_PYTHON_H */

--- a/src/ce/include/ti/real.h
+++ b/src/ce/include/ti/real.h
@@ -244,4 +244,4 @@ real_t os_StrToReal(const char *string, char **end);
 }
 #endif
 
-#endif
+#endif /* TI_REAL_H */

--- a/src/ce/include/ti/screen.h
+++ b/src/ce/include/ti/screen.h
@@ -321,4 +321,4 @@ uint24_t os_GetDrawBGColor(void);
 }
 #endif
 
-#endif
+#endif /* TI_SCREEN_H */

--- a/src/ce/include/ti/tokens.h
+++ b/src/ce/include/ti/tokens.h
@@ -1787,4 +1787,4 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* TI_TOKENS_H */

--- a/src/ce/include/ti/ui.h
+++ b/src/ce/include/ti/ui.h
@@ -89,4 +89,4 @@ typedef enum {
 }
 #endif
 
-#endif
+#endif /* TI_UI_H */

--- a/src/ce/include/ti/vars.h
+++ b/src/ce/include/ti/vars.h
@@ -555,4 +555,4 @@ int os_EvalVar(const char *name);
 }
 #endif
 
-#endif
+#endif /* TI_VARS_H */

--- a/src/ce/include/tice.h
+++ b/src/ce/include/tice.h
@@ -51,4 +51,4 @@
 #define asm_ClrTxtShd os_ClrTxtShd
 /* @endcond */
 
-#endif
+#endif /* TICE_H */

--- a/src/fatdrvce/fatdrvce.h
+++ b/src/fatdrvce/fatdrvce.h
@@ -296,4 +296,4 @@ fat_error_t fat_CloseFile(fat_file_t *file);
 }
 #endif
 
-#endif
+#endif /* FATDRVCE_H */

--- a/src/fileioc/fileioc.h
+++ b/src/fileioc/fileioc.h
@@ -672,4 +672,4 @@ void ti_CloseAll(void) __attribute__((deprecated ("Use ti_Close(handle) for each
 }
 #endif
 
-#endif
+#endif /* _FILEIOC_H */

--- a/src/fontlibc/fontlibc.h
+++ b/src/fontlibc/fontlibc.h
@@ -826,4 +826,4 @@ fontlib_font_t *fontlib_GetFontByStyle(const char *font_pack_name, uint8_t size_
 }
 #endif
 
-#endif
+#endif /* _FONTLIBC_H */

--- a/src/keypadc/keypadc.h
+++ b/src/keypadc/keypadc.h
@@ -401,4 +401,4 @@ typedef enum {
 }
 #endif
 
-#endif
+#endif /* _KEYPADC_H */

--- a/src/lcddrvce/lcddrvce.h
+++ b/src/lcddrvce/lcddrvce.h
@@ -1083,4 +1083,4 @@ typedef struct lcd_eqctrl_params {
 }
 #endif
 
-#endif
+#endif /* LCDDRVCE_H */

--- a/src/libload/libload.h
+++ b/src/libload/libload.h
@@ -18,4 +18,4 @@
         _libload_library_##name;                                \
     })
 
-#endif
+#endif /* LIBLOAD_H */

--- a/src/msddrvce/msddrvce.h
+++ b/src/msddrvce/msddrvce.h
@@ -150,4 +150,4 @@ uint8_t msd_FindPartitions(msd_t *msd, msd_partition_t *partitions, uint8_t max)
 }
 #endif
 
-#endif
+#endif /* MSDDRVCE_H */


### PR DESCRIPTION
Changes `#endif` to `#endif /* HEADER_H */` in headers