### PR TITLE
optimized LIB_FLAGS init code

### DIFF
--- a/src/libload/libload.asm
+++ b/src/libload/libload.asm
@@ -117,8 +117,10 @@ disable_relocations
 
 	ld	(error_sp), sp
 
-	res	is_dep, (iy + LIB_FLAGS)
-	res	optional, (iy + LIB_FLAGS)
+	ld	(iy + LIB_FLAGS), c	; C is zero here
+	; res	is_dep, (iy + LIB_FLAGS)
+	; res	optional, (iy + LIB_FLAGS)
+
 	ld	a, (hl)
 	cp	a, REQ_LIB_MARKER
 	jr	z, start


### PR DESCRIPTION
Does `(iy + LIB_FLAGS) = 0` instead of `(iy + LIB_FLAGS) &= 0xF3`. I am assuming that `(iy + LIB_FLAGS)` will initially be in an unknown state

saves 5 bytes