### PR TITLE
replaced call to ti.LoadDEInd_s since A could be clobbered

### DIFF
--- a/src/libload/libload.asm
+++ b/src/libload/libload.asm
@@ -478,7 +478,14 @@ resolve_entry_points_enqueued:
 	add	hl, hl			; (offset/3) * 2
 	ld	de, (vector_tbl_ptr)	; hl->start of vector table
 	add	hl, de			; hl->correct vector entry
-	call	ti.LoadDEInd_s		; de=offest in lib for function
+
+	; ti.LoadDEInd_s
+	inc.s	de
+	ld	e, (hl)
+	inc	hl
+	ld	d, (hl)
+	; de=offset in lib for function
+
 	ld	hl, (ramlocation)
 	add	hl, de			; hl->function in ram
 	ex	de, hl			; de->function in ram


### PR DESCRIPTION
This appears to be the implementation used for `ti.LoadDEInd_s` which preserves `A`:
```asm
ti.LoadDEInd_s:
ld de, 0
ld e, (hl)
inc hl
ld d, (hl)
inc hl
```
However, `ti.LoadHLInd_s` destroys `A` despite being a similar routine, this indicates that a future version of `ti.LoadDEInd_s` may destroy `A`, so I have inlined the call to prevent `A` from being destroyed.