### PR TITLE
added errchar (similar to outchar)

### DIFF
--- a/src/libc/errchar.src
+++ b/src/libc/errchar.src
@@ -1,0 +1,10 @@
+	.assume	adl=1
+
+	.section	.text
+	.weak	_errchar
+	.type	_errchar, @function
+
+_errchar:
+	jp	_outchar
+
+	.extern	_outchar

--- a/src/libc/errno_str.cpp
+++ b/src/libc/errno_str.cpp
@@ -124,17 +124,23 @@ char *strerror(int errnum)
     return const_cast<char*>(ret);
 }
 
+static void errchar_puts(const char *str)
+{
+    while (*str) {
+        errchar(*str++);
+    }
+}
+
 void perror(const char *str)
 {
     /* Normally this would print to stderr, but since they are handled the same and pulling */
-    /* in fputs would create a dependency on fileioc, just use puts rather than fputs here */
+    /* in fputs would create a dependency on fileioc, just use puts/errchar rather than fputs here */
 
     if (str != nullptr && *str != '\0') {
-        while (*str) {
-            putchar(*str++);
-        }
-        putchar(':');
-        putchar(' ');
+        errchar_puts(str);
+        errchar(':');
+        errchar(' ');
     }
-    puts(strerror(errno));
+    errchar_puts(strerror(errno));
+    errchar('\n');
 }

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -41,6 +41,8 @@ int inchar(void);
 
 void outchar(char character);
 
+void errchar(char character);
+
 FILE *fopen(const char *__restrict filename, const char *__restrict mode);
 
 FILE *freopen(const char *__restrict filename, const char *__restrict mode, FILE *__restrict stream);


### PR DESCRIPTION
Implements https://github.com/CE-Programming/toolchain/issues/721

The user can override `errchar` with their own function. `errchar` aliases `outchar` if no custom `errchar` function has been provided