### PR TITLE
optimized constant in dto(u)ll

### DIFF
--- a/src/crt/dtoll.src
+++ b/src/crt/dtoll.src
@@ -41,21 +41,24 @@ __dtoull:
 	ld	a, h	; expon
 	sub	a, 52 + 1 - 1	; float64 mantissa bits + CPL trick - inc HL
 	jr	c, .shift_right
-	; shift_left
-	; expon >= 52 or [52, 63]
-	; A is one less than it should be here to allow for the CPL trick in shift_right
-	; A is [-1, 10]
-	cp	a, 11	; only call __llshl if the shift amount is [0, 63]
-	inc	a	; positioning inc a after cp a allows __llshl to be skipped when the shift amount is zero
+	; .shift_left
+	; A is [0, 203] or [0, 10] in the non-UB case
+	; expon >= 52 or [52, 63] in the non-UB case
+	inc	a	; A is one less than it should be here to allow for the CPL trick in shift_right
+	; C is [16, 31]
+	cp	a, c	; only call __llshl if the shift amount is [0, 63]
 	ld	l, a
 	ex	(sp), hl
+	; shift is non-zero and [1, 11] in the non-UB case
 	call	c, __llshl
 	jr	.finish
 .shift_right:
+	; A is [-1, -52]
 	; expon is [0, 51]
 	cpl
 	ld	l, a
 	ex	(sp), hl
+	; shift is [0, 51]
 	call	__llshru
 .finish:
 	pop	af	; reset SP


### PR DESCRIPTION
`cp a, 11` could be replaced with any constant between 11 and 62, so I was able to replace it with `cp a, c` since C is between 16 and 31. The reason this check exists is just to ensure that the shift amount passed into `__llshl` is between 0 and 63. For `dtoll`, A >= 11 would imply that the result would not fit inside a 64 bit integer anyways (like inf/NaN), so the result is UB (undefined behavior).