### PR TITLE
fixed land/lor/lxor fasmg --> gas conversion

### DIFF
--- a/src/crt/and.src
+++ b/src/crt/and.src
@@ -17,7 +17,8 @@ __land:
 	push	af
 	and	a, e
 	ld	e, a
-	jr	.L.hijack_land
+	; jr	.L.hijack_land
+	.db	0x3E			; ld a, *
 __iand:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af

--- a/src/crt/or.src
+++ b/src/crt/or.src
@@ -18,7 +18,8 @@ __lor:
 	push	af
 	or	a, e
 	ld	e, a
-	jr	.L.hijack_lor
+	; jr	.L.hijack_lor
+	.db	0x3E			; ld a, *
 __ior:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af

--- a/src/crt/xor.src
+++ b/src/crt/xor.src
@@ -18,7 +18,8 @@ __lxor:
 	push	af
 	xor	a, e
 	ld	e, a
-	jr	.L.hijack_lxor
+	; jr	.L.hijack_lxor
+	.db	0x3E			; ld a, *
 __ixor:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af


### PR DESCRIPTION
the virtual macros were converted to `jr` (2 bytes) instead of `db` (1 byte) when migrating from FASMG to GAS