### PR TITLE
removed unneeded RCF

### DIFF
--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -71,7 +71,6 @@ __start:
 	ld	sp, (ti.onSP)			; reset stacks
 	call	ti.ResetStacks
 	ld	bc, ___data_len
-	or	a, a
 	sbc	hl, hl
 	adc	hl, bc
 	jr	z, .L.skip_data_copy


### PR DESCRIPTION
`or a, a` can be omitted from this test for zero sequence: `or a, a \ sbc hl, hl \ adc hl, reg`