### PR TITLE
enabled __TICE__ define when building the toolchain

### DIFF
--- a/src/common.mk
+++ b/src/common.mk
@@ -84,11 +84,13 @@ ROOT_DIR := $(dir $(realpath $(call NATIVEPATH,$(lastword $(MAKEFILE_LIST)))))
 
 EZCFLAGS := -S -fno-autolink -fno-addrsig -fno-math-errno -ffunction-sections -fdata-sections -ffreestanding
 EZCFLAGS += -Wall -Wextra -Wimplicit-float-conversion -Wimplicit-int-float-conversion -Oz
-EZCFLAGS += -D_EZ80 -isystem $(call NATIVEPATH,$(ROOT_DIR)libc/include) -I$(call NATIVEPATH,$(ROOT_DIR)ce/include) -I$(call NATIVEPATH,$(ROOT_DIR)fileioc)
+EZCFLAGS += -D_EZ80 -D__TICE__
+EZCFLAGS += -isystem $(call NATIVEPATH,$(ROOT_DIR)libc/include) -I$(call NATIVEPATH,$(ROOT_DIR)ce/include) -I$(call NATIVEPATH,$(ROOT_DIR)fileioc)
 EZCFLAGS += -mllvm -profile-guided-section-prefix=false -mllvm -z80-gas-style
 EZCXXFLAGS := $(EZCFLAGS) -fno-exceptions -fno-rtti
 EZCXXFLAGS += -isystem $(call NATIVEPATH,$(ROOT_DIR)libcxx/include)
 EZASFLAGS := -march=ez80+full
+EZASFLAGS += --defsym __TICE__=1
 
 INSTALL_DIR := $(patsubst %/,%,$(subst \,/,$(DESTDIR)))/$(PREFIX)
 INSTALL_PATH := $(call QUOTE_NATIVE,$(INSTALL_DIR))

--- a/src/libc/bzero.src
+++ b/src/libc/bzero.src
@@ -5,7 +5,7 @@
 	.global	_bzero
 	.type	_bzero, @function
 
-.ifdef PREFER_OS_CRT
+.ifdef __TICE__
 
 ; uses the hardware specific $E40000 memory location
 

--- a/src/libc/calloc.src
+++ b/src/libc/calloc.src
@@ -4,7 +4,7 @@
 	.global	_calloc
 	.type	_calloc, @function
 
-.ifdef PREFER_OS_CRT
+.ifdef __TICE__
 
 ; uses the hardware specific $E40000 memory location
 


### PR DESCRIPTION
`__TICE__` was not defined in C/C++ or the assembler when building the toolchain

fixes
https://github.com/CE-Programming/toolchain/issues/717

And to clarify, `__TICE__` is already defined in `makefile.mk` (users), but it is not defined in `common.mk` (building)