### PR TITLE
Fix atexit/on_exit/_Exit

### DIFF
--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -334,6 +334,7 @@ ___exithl:
 #if HAS_ATEXIT || HAS_FINI_ARRAY
 	push	hl				; preserve exit status
 #endif
+#if HAS_EXIT
 	; jr	.L.exit_function_start
 	db	0x3E				; ld a, *
 	.global	_exit
@@ -341,6 +342,7 @@ ___exithl:
 _exit:
 	; exit status is currently at (sp + 3), so we need to fix that
 	pop	bc				; destroy return address
+#endif
 #if HAS_ATEXIT
 	; input: (sp + 0) = exit status
 	jr	.L.exit_function_start
@@ -392,6 +394,7 @@ _exit:
 	.extern	__fini_array_end
 #endif
 
+#if HAS_C99__EXIT
 	; jr	.L.skip.__Exit
 	db	0x3E				; ld a, *
 	.global	__Exit
@@ -400,6 +403,7 @@ __Exit:
 	; exit status is currently at (sp + 3), so we need to fix that
 	pop	bc				; destroy return address
 .L.skip.__Exit:
+#endif
 
 #if HAS_ATEXIT || HAS_FINI_ARRAY
 	pop	hl				; restore exit status

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -405,7 +405,7 @@ __Exit:
 .L.skip.__Exit:
 #endif
 
-#if HAS_ATEXIT || HAS_FINI_ARRAY
+#if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_EXIT || HAS_C99__EXIT
 	pop	hl				; restore exit status
 #endif
 

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -391,6 +391,16 @@ _exit:
 	.extern	__fini_array_start
 	.extern	__fini_array_end
 #endif
+
+	; jr	.L.skip.__Exit
+	db	0x3E				; ld a, *
+	.global	__Exit
+	.type	__Exit, @function
+__Exit:
+	; exit status is currently at (sp + 3), so we need to fix that
+	pop	bc				; destroy return address
+.L.skip.__Exit:
+
 #if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_ABORT
 	pop	hl				; restore exit status
 #endif

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -322,37 +322,50 @@ ___libload_libs_ret:
 	call	_main
 #endif
 	.equ	__start._main, $ - 3
+
+;-------------------------------------------------------------------------------
+; call atexit/on_exit and fini functions
+;-------------------------------------------------------------------------------
+
 	.global	___exithl
 	.type	___exithl, @function
 ___exithl:
+
 #if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_ABORT
-	push	hl
-	push	de
+	push	hl				; preserve exit status
 #endif
+	; jr	.L.exit_function_start
+	db	0x3E				; ld a, *
 	.global	_exit
 	.type	_exit, @function
 _exit:
+	; exit status is currently at (sp + 3), so we need to fix that
+	pop	bc				; destroy return address
 #if HAS_ATEXIT
+	; input: (sp + 0) = exit status
 	jr	.L.exit_function_start
 .L.exit_function_loop:
 	ld	hl, (ix + 1 + 0 * 3)
 	ld	(__atexit_functions), hl
-	pop	hl
-	ld	de, (ix + 1 + 2 * 3)
-	push	hl
-	push	de
-	push	hl
-	ld	hl, (ix + 1 + 1 * 3)
-	push	hl
+	pop	hl				; exit status
+	push	hl				; exit status
+	ld	de, (ix + 1 + 2 * 3)		; arg
+	push	de				; arg
+	push	hl				; exit status
+	ld	hl, (ix + 1 + 1 * 3)		; func
+	push	hl				; func
 	pea	ix + 1
 	call	_free
-	pop	bc
-	pop	hl
+	pop	bc				; reset SP
+	pop	hl				; func
+	; atexit  : void (*func)(void)
+	; on_exit : void (*func)(int status, void *arg)
 	call	__indcallhl
-	pop	bc
-	pop	bc
+	pop	bc				; reset SP
+	pop	bc				; reset SP
 .L.exit_function_start:
 	ld	ix, (__atexit_functions)
+	; NULL indicates no more atexit functions
 	ld	bc, -1
 	add	ix, bc
 	jr	c, .L.exit_function_loop
@@ -379,9 +392,14 @@ _exit:
 	.extern	__fini_array_end
 #endif
 #if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_ABORT
-	pop	de
-	pop	hl
+	pop	hl				; restore exit status
 #endif
+
+;-------------------------------------------------------------------------------
+; We have now called all atexit/on_exit and fini functions
+; HL = exit status
+;-------------------------------------------------------------------------------
+
 #if HAS_ABORT
 	jr	.L.skip._abort
 	.global	_abort

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -331,7 +331,7 @@ ___libload_libs_ret:
 	.type	___exithl, @function
 ___exithl:
 
-#if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_ABORT
+#if HAS_ATEXIT || HAS_FINI_ARRAY
 	push	hl				; preserve exit status
 #endif
 	; jr	.L.exit_function_start
@@ -401,7 +401,7 @@ __Exit:
 	pop	bc				; destroy return address
 .L.skip.__Exit:
 
-#if HAS_ATEXIT || HAS_FINI_ARRAY || HAS_ABORT
+#if HAS_ATEXIT || HAS_FINI_ARRAY
 	pop	hl				; restore exit status
 #endif
 

--- a/src/libc/atexit.src
+++ b/src/libc/atexit.src
@@ -21,7 +21,7 @@ _on_exit:
 	ex	de, hl
 	ld	(__atexit_functions), hl
 	ld	(hl), de
-	pop	de		; return address
+	pop	iy		; return address
 	inc	hl
 	inc	hl
 	inc	hl
@@ -34,8 +34,10 @@ _on_exit:
 	ld	(hl), bc
 	push	bc
 	push	bc
-	ex	de, hl
-	jp	(hl)
+	; return zero on success
+	or	a, a
+	sbc	hl, hl
+	jp	(iy)
 
 	.section	.bss
 	.global	__atexit_functions

--- a/src/libc/atexit.src
+++ b/src/libc/atexit.src
@@ -8,7 +8,7 @@
 	.type	_on_exit, @function
 _atexit:
 _on_exit:
-	ld	hl, 3*3
+	ld	hl, 3 * 3
 	push	hl
 	call	_malloc
 	pop	bc
@@ -16,19 +16,22 @@ _on_exit:
 	scf
 	sbc	hl, hl
 	add	hl, de
-	ret	nc
+	ret	nc		; malloc returned NULL, return non-zero value
 	ld	hl, (__atexit_functions)
 	ex	de, hl
 	ld	(__atexit_functions), hl
 	ld	(hl), de
-	pop	de
-.rept 2
+	pop	de		; return address
 	inc	hl
 	inc	hl
 	inc	hl
-	pop	bc
+	pop	bc		; func pointer
 	ld	(hl), bc
-.endr
+	inc	hl
+	inc	hl
+	inc	hl
+	pop	bc		; arg pointer (on_exit)
+	ld	(hl), bc
 	push	bc
 	push	bc
 	ex	de, hl

--- a/test/crt/_Exit/autotest.json
+++ b/test/crt/_Exit/autotest.json
@@ -1,0 +1,39 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "test for errors from on_exit/atexit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "A1280E53"
+      ]
+    },
+    "2": {
+      "description": "test _Exit()",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/_Exit/makefile
+++ b/test/crt/_Exit/makefile
@@ -1,0 +1,19 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/_Exit/src/main.c
+++ b/test/crt/_Exit/src/main.c
@@ -1,0 +1,41 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void atexit_func(void) {
+    printf("atexit_func called\n");
+    while (!os_GetCSC());
+}
+
+void on_exit_func(int status, void *arg) {
+    printf("on_exit_func called\n");
+    printf("status: %d\narg: %p\n", status, arg);
+    while (!os_GetCSC());
+}
+
+int main(void) {
+    errno = 0;
+    os_ClrHome();
+    if (on_exit(on_exit_func, NULL) != 0) {
+        perror("Failed on_exit(on_exit_func, NULL)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (atexit(atexit_func) != 0) {
+        perror("Failed on_exit(on_exit_func, NULL)");
+        while (!os_GetCSC());
+        return 0;
+    }
+
+    printf("errno: %d\n", errno);
+
+    while (!os_GetCSC());
+
+    _Exit(EXIT_SUCCESS);
+}

--- a/test/crt/exit/autotest.json
+++ b/test/crt/exit/autotest.json
@@ -1,0 +1,50 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3"
+  ],
+  "hashes": {
+    "1": {
+      "description": "test for errors from on_exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "A1280E53"
+      ]
+    },
+    "2": {
+      "description": "is the correct return status present",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "15EB5BAA"
+      ]
+    },
+    "3": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/exit/makefile
+++ b/test/crt/exit/makefile
@@ -1,0 +1,19 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/exit/src/main.c
+++ b/test/crt/exit/src/main.c
@@ -1,0 +1,34 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void cleanup(int status, void *arg) {
+    if (arg != NULL) {
+        printf("expected NULL: %p\n", arg);
+    }
+    printf("Exit status: %d\n", status);
+
+    while (!os_GetCSC());
+}
+
+int main(void) {
+    errno = 0;
+    os_ClrHome();
+    if (on_exit(cleanup, NULL) != 0) {
+        perror("Failed on_exit(cleanup, NULL)");
+        while (!os_GetCSC());
+        return 0;
+    }
+
+    printf("errno: %d\n", errno);
+
+    while (!os_GetCSC());
+
+    exit(42);
+}

--- a/test/crt/on_exit/autotest.json
+++ b/test/crt/on_exit/autotest.json
@@ -1,0 +1,61 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3",
+    "key|enter",
+    "delay|300",
+    "hashWait|4"
+  ],
+  "hashes": {
+    "1": {
+      "description": "test for errors from atexit/on_exit",
+      "start": "vram_start",
+      "size": "vram_8_size",
+      "expected_CRCs": [
+        "0A3F477E"
+      ]
+    },
+    "2": {
+      "description": "is the correct return status present",
+      "start": "vram_start",
+      "size": "vram_8_size",
+      "expected_CRCs": [
+        "FEF6F9F4"
+      ]
+    },
+    "3": {
+      "description": "check that gfx_End() was called",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "4BD20C6F"
+      ]
+    },
+    "4": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/on_exit/makefile
+++ b/test/crt/on_exit/makefile
@@ -1,0 +1,19 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/on_exit/src/main.c
+++ b/test/crt/on_exit/src/main.c
@@ -1,0 +1,59 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+#include <ti/sprintf.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <graphx.h>
+
+void cleanup(int status, void *arg) {
+    const char *message = (char*)arg;
+
+    gfx_PrintStringXY(message, 10, 30);
+
+    gfx_PrintStringXY("Exit status: ", 10, 50);
+    gfx_PrintInt(status, 1);
+
+    while (!os_GetCSC());
+}
+
+void final_func(void) {
+    os_ClrHome();
+    puts("Finished tests");
+    while (!os_GetCSC());
+}
+
+int main(void) {
+    errno = 0;
+    os_ClrHome();
+    const char *msg = "cleanup func";
+    if (atexit(final_func) != 0) {
+        perror("Failed atexit(final_func)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (atexit(gfx_End) != 0) {
+        perror("Failed atexit(gfx_End)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (on_exit(cleanup, (void*)msg) != 0) {
+        perror("Failed on_exit(cleanup, msg)");
+        while (!os_GetCSC());
+        return 0;
+    }
+
+    gfx_Begin();
+
+    gfx_PrintStringXY("errno: ", 10, 10);
+    gfx_PrintInt(errno, 1);
+
+    while (!os_GetCSC());
+
+    return 7184;
+}

--- a/test/crt/quick_exit/autotest.json
+++ b/test/crt/quick_exit/autotest.json
@@ -1,0 +1,61 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3",
+    "key|enter",
+    "delay|300",
+    "hashWait|4"
+  ],
+  "hashes": {
+    "1": {
+      "description": "test for errors from at_quick_exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "A1280E53"
+      ]
+    },
+    "2": {
+      "description": "test for most recent at_quick_exit function",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FE361C99"
+      ]
+    },
+    "3": {
+      "description": "test for first at_quick_exit function",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "9E047358"
+      ]
+    },
+    "4": {
+      "description": "quick_exit calls _Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/quick_exit/makefile
+++ b/test/crt/quick_exit/makefile
@@ -1,0 +1,19 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -ffreestanding -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/quick_exit/src/main.c
+++ b/test/crt/quick_exit/src/main.c
@@ -1,0 +1,63 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void atexit_func(void) {
+    printf("atexit_func called\n");
+    while (!os_GetCSC());
+}
+
+void on_exit_func(int status, void *arg) {
+    printf("on_exit_func called\n");
+    printf("status: %d\narg: %p\n", status, arg);
+    while (!os_GetCSC());
+}
+
+void at_quick_exit_func_1(void) {
+    printf("first at_quick_exit\n");
+    while (!os_GetCSC());
+}
+
+void at_quick_exit_func_2(void) {
+    puts("most recent at_quick_exit");
+    while (!os_GetCSC());
+}
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    errno = 0;
+    os_ClrHome();
+    if (on_exit(on_exit_func, NULL) != 0) {
+        perror("Failed on_exit(on_exit_func, NULL)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (at_quick_exit(at_quick_exit_func_1) != 0) {
+        perror("Failed at_quick_exit(at_quick_exit_func_1)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (atexit(atexit_func) != 0) {
+        perror("Failed on_exit(on_exit_func, NULL)");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (at_quick_exit(at_quick_exit_func_2) != 0) {
+        perror("Failed at_quick_exit(at_quick_exit_func_2)");
+        while (!os_GetCSC());
+        return 0;
+    }
+
+    printf("errno: %d\n", errno);
+
+    while (!os_GetCSC());
+
+    quick_exit(EXIT_SUCCESS);
+}

--- a/tools/cedev-obj/src/main.c
+++ b/tools/cedev-obj/src/main.c
@@ -123,6 +123,8 @@ static void write_header_defines(FILE *out, const char *elf_file, struct elf_fil
     fprintf(out, "#define HAS_FINI_ARRAY %d\n", elf_has_section(elf, ".fini_array") ? 1 : 0);
     fprintf(out, "#define HAS_CLOCK %d\n", elf_has_symbol(elf, "_clock") ? 1 : 0);
     fprintf(out, "#define HAS_ABORT %d\n", elf_has_symbol(elf, "_abort") ? 1 : 0);
+    fprintf(out, "#define HAS_EXIT %d\n", elf_has_symbol(elf, "_exit") ? 1 : 0);
+    fprintf(out, "#define HAS_C99__EXIT %d\n", elf_has_symbol(elf, "__Exit") ? 1 : 0);
     fprintf(out, "#define HAS_RUN_PRGM %d\n", elf_has_symbol(elf, "_os_RunPrgm") ? 1 : 0);
     fprintf(out, "#define HAS_MAIN_ARGC_ARGV %d\n", elf_has_defined_symbol(elf, "___main_argc_argv") ? 1 : 0);
     fprintf(out, "#define HAS_ATEXIT %d\n", elf_has_symbol(elf, "__atexit_functions") ? 1 : 0);

--- a/tools/cedev-obj/src/main.c
+++ b/tools/cedev-obj/src/main.c
@@ -122,8 +122,14 @@ static void write_header_defines(FILE *out, const char *elf_file, struct elf_fil
     fprintf(out, "#define HAS_INIT_ARRAY %d\n", elf_has_section(elf, ".init_array") ? 1 : 0);
     fprintf(out, "#define HAS_FINI_ARRAY %d\n", elf_has_section(elf, ".fini_array") ? 1 : 0);
     fprintf(out, "#define HAS_CLOCK %d\n", elf_has_symbol(elf, "_clock") ? 1 : 0);
-    fprintf(out, "#define HAS_ABORT %d\n", elf_has_symbol(elf, "_abort") ? 1 : 0);
-    fprintf(out, "#define HAS_EXIT %d\n", elf_has_symbol(elf, "_exit") ? 1 : 0);
+    #if 0
+        fprintf(out, "#define HAS_ABORT %d\n", elf_has_symbol(elf, "_abort") ? 1 : 0);
+        fprintf(out, "#define HAS_EXIT %d\n", elf_has_symbol(elf, "_exit") ? 1 : 0);
+    #else
+        // elf_has_symbol has some false negatives, so always emit these functions for now.
+        fprintf(out, "#define HAS_ABORT %d\n", /* _abort */ 1);
+        fprintf(out, "#define HAS_EXIT %d\n", /* _exit */ 1);
+    #endif
     fprintf(out, "#define HAS_C99__EXIT %d\n", elf_has_symbol(elf, "__Exit") ? 1 : 0);
     fprintf(out, "#define HAS_RUN_PRGM %d\n", elf_has_symbol(elf, "_os_RunPrgm") ? 1 : 0);
     fprintf(out, "#define HAS_MAIN_ARGC_ARGV %d\n", elf_has_defined_symbol(elf, "___main_argc_argv") ? 1 : 0);


### PR DESCRIPTION
Fixes https://github.com/CE-Programming/toolchain/issues/734 and https://github.com/CE-Programming/toolchain/issues/736

- Fixed return values from `on_exit`/`atexit`
- Fixed the exit-status passed to `on_exit` functions via returning from `main` and via `exit`
- Re-implemented C99 `_Exit`
- Adds `HAS_EXIT` and `HAS_C99__EXIT` which will only include `exit()` and `_Exit()` in `crt0.S` if the functions are needed (similar to `HAS_ABORT`)

