### PR TITLE
fix return value for atof(f)

### DIFF
--- a/src/libc/atof.src
+++ b/src/libc/atof.src
@@ -25,10 +25,9 @@ _atoff:
 	push	bc
 	call	_strtod
 	pop	bc
-	pop	hl
+	pop	bc
 	ret
 
-	.extern	__frameset0
 	.extern	_strtod
 
 .endif


### PR DESCRIPTION
`atof(f)` wraps `strtod` returns a `double` in `E:UHL`