### PR TITLE
Reduced libload string footprint

### DIFF
--- a/src/libload/libload.asm
+++ b/src/libload/libload.asm
@@ -587,10 +587,12 @@ throw_error:				; draw the error message onscreen
 	call	ti.DrawStatusBar
 	call	ti.ClrScrn		; clean up the screen a bit
 	call	ti.HomeUp		; if we encounter an error
-	pop	hl
 	set	ti.textInverse, (iy + ti.textFlags)
 	ld	a, 2
 	ld	(ti.curCol), a
+	rload	str_error_prefix
+	call	ti.PutS
+	pop	hl
 	call	ti.PutS
 	res	ti.textInverse, (iy + ti.textFlags)
 	call	ti.NewLine
@@ -626,14 +628,16 @@ throw_error:				; draw the error message onscreen
 	xor	a, a			; return with zero in a
 	ret
 
+str_error_prefix:
+	db	"ERROR: Library ", 0
 str_error_version:
-	db	"ERROR: Library Version", 0
+	db	"Version", 0
 str_error_missing:
-	db	"ERROR: Missing Library", 0
+	db	"Missing", 0
 str_error_invalid:
-	db	"ERROR: Invalid Library", 0
+	db	"Invalid", 0
 str_lib_name:
 	db	"Library Name: ", 0
 str_download:
-	db	"Download here: ", 0
+	db	"Download here:", 0
 	db	"https://tiny.cc/clibs", 0


### PR DESCRIPTION
I noticed that `rload`/`ld_relative` are only used with a positive offset less than 256, so I was able to save space by storing the offset in 1 byte instead of 3 bytes.

I also changed the following error messages:
`ERROR: Missing Library` --> `ERROR: Library Missing`
`ERROR: Invalid Library` --> `ERROR: Library Invalid`
This was done so all three error strings start with the same prefix of `ERROR: Library `.
