### PR TITLE
fixed make clean for libc/allocator and libc/printf

### DIFF
--- a/src/libc/makefile
+++ b/src/libc/makefile
@@ -84,6 +84,8 @@ build/%.ce.o: %.src
 
 clean:
 	$(Q)$(call RMDIR,build)
+	$(MAKE) -C allocator clean
+	$(MAKE) -C printf clean
 
 install: all
 	$(Q)$(call MKDIR,$(INSTALL_H))


### PR DESCRIPTION
make clean would not clean some sub-directories like libc/allocator and libc/printf