### PR TITLE
Optimize gfx triangle

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -6541,18 +6541,21 @@ _LZ_ReadVarSize:
 _Maximum:
 ; Calculate the resut of a signed comparison
 ; Inputs:
-;  DE, HL=numbers
+;  HL, DE
 ; Oututs:
-;  HL=max number
+;  HL = signed_maximum(HL, DE)
+;  DE = destroyed
 	or	a, a
 .no_carry:
 	sbc	hl, de
-	add	hl, de
-	jp	p, .skip
+	jr	c, .skip
+	ex	de,hl
+	ret	m
 	ret	pe
-	ex	de, hl
 .skip:
-	ret	po
+	add	hl, de
+	ret	p
+	ret	pe
 	ex	de, hl
 	ret
 
@@ -6560,19 +6563,22 @@ _Maximum:
 _Minimum:
 ; Calculate the resut of a signed comparison
 ; Inputs:
-;  DE, HL=numbers
+;  HL, DE
 ; Oututs:
-;  HL=min number
+;  HL = signed_minimum(HL, DE)
+;  DE = destroyed
 	or	a, a
 .no_carry:
 	sbc	hl, de
+	jr	nc, .skip
 	ex	de, hl
-	jp	p, .skip
+	ret	p
 	ret	pe
-	add	hl, de
 .skip:
-	ret	po
 	add	hl, de
+	ret	m
+	ret	pe
+	ex	de, hl
 	ret
 
 ;-------------------------------------------------------------------------------

--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -4059,60 +4059,77 @@ gfx_FillTriangle:
 ; Returns:
 ;  None
 	ld	hl, gfx_HorizLine
+tri_frame_offset := 30
+tri_x0        := tri_frame_offset + 6
+tri_y0        := tri_frame_offset + 9
+tri_x1        := tri_frame_offset + 12
+tri_y1        := tri_frame_offset + 15
+tri_x2        := tri_frame_offset + 18
+tri_y2        := tri_frame_offset + 21
+tri_y_counter := tri_frame_offset - 3
+tri_sa        := tri_frame_offset - 6
+tri_sb        := tri_frame_offset - 9
+tri_dx02      := tri_frame_offset - 12
+tri_last      := tri_frame_offset - 15
+tri_dy02      := tri_frame_offset - 18
+tri_dx12      := tri_frame_offset - 21
+tri_dy01      := tri_frame_offset - 24
+tri_dx01      := tri_frame_offset - 27
+tri_dy12      := tri_frame_offset - 30
 _FillTriangle:
 	ld	(.line0), hl
 	ld	(.line1), hl
 	ld	(.line2), hl
 	push	ix
-	ld	ix, 0
+	ld	ix, -tri_frame_offset
 	add	ix, sp
-	lea	hl, ix - 39
-	ld	sp, hl
+	ld	sp, ix
+	or	a, a
 	sbc	hl, hl
-	ld	(ix - 15), hl
-	ld	(ix - 18), hl		; int sa = 0, sb = 0;
-	ld	hl, (ix + 9)		; sort coordinates by y order (y2 >= y1 >= y0)
-	ld	de, (ix + 15)		; if (y0 > y1)
+	ld	(ix + tri_sa), hl
+	ld	(ix + tri_sb), hl		; int sa = 0, sb = 0;
+	ld	hl, (ix + tri_y0)		; sort coordinates by y order (y2 >= y1 >= y0)
+	ld	de, (ix + tri_y1)		; if (y0 > y1)
 	call	_SignedCompare
 	jr	c, .cmp0
-	ld	hl, (ix + 9)
-	ld	(ix + 9), de
-	ld	(ix + 15), hl
-	ld	hl, (ix + 6)
-	ld	de, (ix + 12)
-	ld	(ix + 6), de
-	ld	(ix + 12), hl
+	ld	hl, (ix + tri_y0)
+	ld	(ix + tri_y0), de
+	ld	(ix + tri_y1), hl
+	ld	hl, (ix + tri_x0)
+	ld	de, (ix + tri_x1)
+	ld	(ix + tri_x0), de
+	ld	(ix + tri_x1), hl
 .cmp0:
-	ld	hl, (ix + 15)
-	ld	de, (ix + 21)
+	ld	hl, (ix + tri_y1)
+	ld	de, (ix + tri_y2)
 	call	_SignedCompare
 	jr	c, .cmp1
-	ld	hl, (ix + 15)
-	ld	(ix + 15), de
-	ld	(ix + 21), hl
-	ld	hl, (ix + 12)
-	ld	de, (ix + 18)
-	ld	(ix + 12), de
-	ld	(ix + 18), hl
+	ld	hl, (ix + tri_y1)
+	ld	(ix + tri_y1), de
+	ld	(ix + tri_y2), hl
+	ld	hl, (ix + tri_x1)
+	ld	de, (ix + tri_x2)
+	ld	(ix + tri_x1), de
+	ld	(ix + tri_x2), hl
 .cmp1:
-	ld	hl, (ix + 9)
-	ld	de, (ix + 15)
+	ld	hl, (ix + tri_y0)
+	ld	de, (ix + tri_y1)
 	call	_SignedCompare
 	jr	c, .cmp2
-	ld	hl, (ix + 9)
-	ld	(ix + 9), de
-	ld	(ix + 15), hl
-	ld	hl, (ix + 6)
-	ld	de, (ix + 12)
-	ld	(ix + 6), de
-	ld	(ix + 12), hl
+	ld	hl, (ix + tri_y0)
+	ld	(ix + tri_y0), de
+	ld	(ix + tri_y1), hl
+	ld	hl, (ix + tri_x0)
+	ld	de, (ix + tri_x1)
+	ld	(ix + tri_x0), de
+	ld	(ix + tri_x1), hl
 .cmp2:
-	ld	hl, (ix + 21)		; if (y0 == y2) - handle awkward all-on-same-line case as its own thing
-	ld	bc, (ix + 9)
+	ld	hl, (ix + tri_y2)		; if (y0 == y2) - handle awkward all-on-same-line case as its own thing
+	ld	bc, (ix + tri_y0)
 	or	a, a
 	sbc	hl, bc
-	ld	de, (ix + 6)		; x0
-	ld	hl, (ix + 12)		; x1
+	ld	de, (ix + tri_x0)		; x0
+	ld	hl, (ix + tri_x1)		; x1
 	jr	nz, .notflat
 ;-------------------------------------------------------------------------------
 	; draw a flat horizontal triangle
@@ -4121,13 +4138,13 @@ _FillTriangle:
 	; horizline(x_min, y0, x_max - x_min + 1)
 	; DE = x0, HL = x1, BC = y0
 	call	_Minimum.no_carry
-	ld	de, (ix + 18)	; x2
+	ld	de, (ix + tri_x2)	; x2
 	call	_Minimum
 	push	hl		; x_min
-	ld	hl, (ix + 6)	; x0
-	ld	de, (ix + 12)	; x1
+	ld	hl, (ix + tri_x0)	; x0
+	ld	de, (ix + tri_x1)	; x1
 	call	_Maximum
-	ld	de, (ix + 18)	; x2
+	ld	de, (ix + tri_x2)	; x2
 	call	_Maximum
 	pop	de		; x_min
 	or	a, a
@@ -4138,75 +4155,76 @@ _FillTriangle:
 	push	de		; x_min
 	call	0		; horizline(x_min, y0, x_max - x_min + 1)
 .line0 := $-3
-	ld	sp, ix
+	lea	hl, ix + tri_frame_offset
+	ld	sp, hl
 	pop	ix
 	ret
 ;-------------------------------------------------------------------------------
 .notflat:
 	or	a, a
 	sbc	hl, de
-	ld	(ix - 36), hl		; dx01 = x1 - x0;
-	ld	hl, (ix + 18)
+	ld	(ix + tri_dx01), hl		; dx01 = x1 - x0;
+	ld	hl, (ix + tri_x2)
 	or	a, a
 	sbc	hl, de
-	ld	(ix - 21), hl		; dx02 = x2 - x0;
+	ld	(ix + tri_dx02), hl		; dx02 = x2 - x0;
 
-	ld	de, (ix + 9)		; y0
-	ld	hl, (ix + 15)
+	ld	de, (ix + tri_y0)		; y0
+	ld	hl, (ix + tri_y1)
 	or	a, a
 	sbc	hl, de
-	ld	(ix - 33), hl		; dy01 = y1 - y0;
-	ld	hl, (ix + 21)
+	ld	(ix + tri_dy01), hl		; dy01 = y1 - y0;
+	ld	hl, (ix + tri_y2)
 	or	a, a
 	sbc	hl, de
-	ld	(ix - 27), hl		; dy02 = y2 - y0;
+	ld	(ix + tri_dy02), hl		; dy02 = y2 - y0;
 
-	ld	de, (ix + 12)
-	ld	hl, (ix + 18)
+	ld	de, (ix + tri_x1)
+	ld	hl, (ix + tri_x2)
 	or	a, a
 	sbc	hl, de
-	ld	(ix - 30), hl		; dx12 = x2 - x1;
+	ld	(ix + tri_dx12), hl		; dx12 = x2 - x1;
 
-	ld	bc, (ix + 15)
-	ld	hl, (ix + 21)
+	ld	bc, (ix + tri_y1)
+	ld	hl, (ix + tri_y2)
 	or	a, a
 	sbc	hl, bc
-	ld	(ix - 39), hl		; dy12 = y2 - y1;
+	ld	(ix + tri_dy12), hl		; dy12 = y2 - y1;
 	; if (y1 == y2) { last = y1; }
 	jr	z, .sublast
 	; else { last = y1-1; }
 	dec	bc
 .sublast:
-	ld	(ix - 24), bc
-	ld	bc, (ix + 9)
-	ld	(ix - 12), bc		; for (y = y0; y <= last; y++)
+	ld	(ix + tri_last), bc
+	ld	bc, (ix + tri_y0)
+	ld	(ix + tri_y_counter), bc		; for (y = y0; y <= last; y++)
 	jr	.firstloopstart
 ;-------------------------------------------------------------------------------
+.cmp50:
+	jp	pe, .firstloopfinish
 .firstloop:
-	ld	hl, (ix - 15)
-	ld	bc, (ix - 33)
+	ld	hl, (ix + tri_sa)
+	ld	bc, (ix + tri_dy01)
 	call	_DivideHLBC
-	ld	bc, (ix + 6)
+	ld	bc, (ix + tri_x0)
 	add	hl, bc
-	; a = x0 + sa / dy01;
-	push	hl	; ld (ix - 3), hl
-	ld	hl, (ix - 18)
-	ld	bc, (ix - 27)
+	push	hl	; a = x0 + sa / dy01;
+	ld	hl, (ix + tri_sb)
+	ld	bc, (ix + tri_dy02)
 	call	_DivideHLBC
-	ld	bc, (ix + 6)
+	ld	bc, (ix + tri_x0)
 	add	hl, bc
-	; b = x0 + sb / dy02;
-	push	hl	; ld (ix - 6), hl
-	ld	bc, (ix - 36)
-	ld	hl, (ix - 15)
+	push	hl	; b = x0 + sb / dy02;
+	ld	hl, (ix + tri_sa)
+	ld	bc, (ix + tri_dx01)
 	add	hl, bc
-	ld	(ix - 15), hl		; sa += dx01;
-	ld	bc, (ix - 21)
-	ld	hl, (ix - 18)
+	ld	(ix + tri_sa), hl		; sa += dx01;
+	ld	hl, (ix + tri_sb)
+	ld	bc, (ix + tri_dx02)
 	add	hl, bc
-	ld	(ix - 18), hl		; sb += dx02;
-	pop	hl	; ld hl, (ix - 6)
-	pop	de	; ld de, (ix - 3)
+	ld	(ix + tri_sb), hl		; sb += dx02;
+	pop	hl	; HL = b
+	pop	de	; DE = a
 	or	a, a
 	sbc	hl, de			; if (b < a) { swap(a, b); }
 	add	hl, de
@@ -4220,69 +4238,64 @@ _FillTriangle:
 	sbc	hl, de
 	inc	hl
 	push	hl
-	ld	bc, (ix - 12)
+	ld	bc, (ix + tri_y_counter)
 	push	bc
 	push	de
 	call	0			; horizline(a, y, b-a+1);
 .line1 := $-3
-	pop	bc
-	pop	bc
-	pop	bc
-	ld	bc, (ix - 12)
+	ld	sp, ix
+	ld	bc, (ix + tri_y_counter)
 	inc	bc
-	ld	(ix - 12), bc
+	ld	(ix + tri_y_counter), bc
 .firstloopstart:
-	ld	hl, (ix - 24)
+	ld	hl, (ix + tri_last)
 	or	a, a
 	sbc	hl, bc
 	jp	p, .cmp50
 	jp	pe, .firstloop
-	jr	.cmp52
-.cmp50:
-	jp	po, .firstloop
-.cmp52:
-	ld	bc, (ix + 15)
-	ld	hl, (ix - 12)
+.firstloopfinish:
+	ld	bc, (ix + tri_y1)
+	ld	hl, (ix + tri_y_counter)
 	or	a, a
 	sbc	hl, bc
-	ld	de, (ix - 30)
+	ld	de, (ix + tri_dx12)
 	call	_MultiplyHLDE		; sa = dx12 * (y - y1);
-	ld	(ix - 15), hl
-	ld	bc, (ix + 9)
-	ld	hl, (ix - 12)
+	ld	(ix + tri_sa), hl
+	ld	bc, (ix + tri_y0)
+	ld	hl, (ix + tri_y_counter)
 	or	a, a
 	sbc	hl, bc
-	ld	de, (ix - 21)
+	ld	de, (ix + tri_dx02)
 	call	_MultiplyHLDE		; sb = dx02 * (y - y0);
-	ld	(ix - 18), hl
-	ld	bc, (ix - 12)
+	ld	(ix + tri_sb), hl
+	ld	bc, (ix + tri_y_counter)
 	jr	.secondloopstart	; for (; y <= y2; y++)
 ;-------------------------------------------------------------------------------
+.cmp70:
+	jp	pe, .secondloopfinish
 .secondloop:
-	ld	hl, (ix - 15)
-	ld	bc, (ix - 39)
+	ld	hl, (ix + tri_sa)
+	ld	bc, (ix + tri_dy12)
 	call	_DivideHLBC
-	ld	bc, (ix + 12)
+	ld	bc, (ix + tri_x1)
 	add	hl, bc
-	; a = x1 + sa / dy12;
-	push	hl	; ld (ix - 3), hl
-	ld	hl, (ix - 18)
-	ld	bc, (ix - 27)
+	push	hl	; a = x1 + sa / dy12;
+	ld	hl, (ix + tri_sb)
+	ld	bc, (ix + tri_dy02)
 	call	_DivideHLBC
-	ld	bc, (ix + 6)
+	ld	bc, (ix + tri_x0)
 	add	hl, bc
-	; b = x0 + sb / dy02;
-	push	hl	; ld (ix - 6), hl
-	ld	bc, (ix - 30)
-	ld	hl, (ix - 15)
+	push	hl	; b = x0 + sb / dy02;
+	ld	hl, (ix + tri_sa)
+	ld	bc, (ix + tri_dx12)
 	add	hl, bc
-	ld	(ix - 15), hl		; sa += dx12;
-	ld	bc, (ix - 21)
-	ld	hl, (ix - 18)
+	ld	(ix + tri_sa), hl		; sa += dx12;
+	ld	hl, (ix + tri_sb)
+	ld	bc, (ix + tri_dx02)
 	add	hl, bc
-	ld	(ix - 18), hl		; sb += dx02;
-	pop	hl	; ld hl, (ix - 6)
-	pop	de	; ld de, (ix - 3)
+	ld	(ix + tri_sb), hl		; sb += dx02;
+	pop	hl	; HL = b
+	pop	de	; DE = a
 	or	a, a
 	sbc	hl, de			; if (b < a) { swap(a, b); }
 	add	hl, de
@@ -4296,29 +4309,24 @@ _FillTriangle:
 	sbc	hl, de
 	inc	hl
 	push	hl
-	ld	bc, (ix - 12)
+	ld	bc, (ix + tri_y_counter)
 	push	bc
 	push	de
 	call	0			; horizline(a, y, b-a+1);
 .line2 := $-3
-	pop	bc
-	pop	bc
-	pop	bc
-	ld	bc, (ix - 12)
+	ld	sp, ix
+	ld	bc, (ix + tri_y_counter)
 	inc	bc
-	ld	(ix - 12), bc
+	ld	(ix + tri_y_counter), bc
 .secondloopstart:
-	ld	hl, (ix + 21)
+	ld	hl, (ix + tri_y2)
 	or	a, a
 	sbc	hl, bc
 	jp	p, .cmp70
 	jp	pe, .secondloop
-	ld	sp, ix
-	pop	ix
-	ret
-.cmp70:
-	jp	po, .secondloop
-	ld	sp, ix
+.secondloopfinish:
+	lea	hl, ix + tri_frame_offset
+	ld	sp, hl
 	pop	ix
 	ret
 

--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -4107,134 +4107,96 @@ _FillTriangle:
 	ld	(ix + 6), de
 	ld	(ix + 12), hl
 .cmp2:
-	ld	de, (ix + 21)		; if (y0 == y2) - handle awkward all-on-same-line case as its own thing
-	ld	hl, (ix + 9)
+	ld	hl, (ix + 21)		; if (y0 == y2) - handle awkward all-on-same-line case as its own thing
+	ld	bc, (ix + 9)
+	or	a, a
+	sbc	hl, bc
+	ld	de, (ix + 6)		; x0
+	ld	hl, (ix + 12)		; x1
+	jr	nz, .notflat
+;-------------------------------------------------------------------------------
+	; draw a flat horizontal triangle
+	; x_min = min(x0, x1, x2)
+	; x_max = max(x0, x1, x2)
+	; horizline(x_min, y0, x_max - x_min + 1)
+	; DE = x0, HL = x1, BC = y0
+	call	_Minimum.no_carry
+	ld	de, (ix + 18)	; x2
+	call	_Minimum
+	push	hl		; x_min
+	ld	hl, (ix + 6)	; x0
+	ld	de, (ix + 12)	; x1
+	call	_Maximum
+	ld	de, (ix + 18)	; x2
+	call	_Maximum
+	pop	de		; x_min
 	or	a, a
 	sbc	hl, de
-	jr	nz, .notflat
-	ld	bc, (ix + 6)		; x0
-	ld	(ix - 6), bc		; a = x0
-	ld	(ix - 3), bc		; b = x0;
-	ld	hl, (ix + 12)		; if (x1 < a) { a = x1; }
-	or	a, a
-	sbc	hl, bc
-	jp	p, .cmp00
-	jp	pe, .cmp01
-	jr	.cmp02
-.cmp00:
-	jp	po, .cmp01
-.cmp02:
-	ld	bc, (ix + 12)
-	ld	(ix - 3), bc
-	jr	.cmp11
-.cmp01:
-	ld	bc, (ix + 12)
-	ld	hl, (ix - 6)
-	or	a, a
-	sbc	hl, bc			; else if (x1 > b) { b = x1; }
-	jp	p, .cmp10
-	jp	pe, .cmp11
-	jr	.cmp12
-.cmp10:
-	jp	po, .cmp11
-.cmp12:
-	ld	bc, (ix + 12)
-	ld	(ix - 6), bc
-.cmp11:
-	ld	bc, (ix - 3)
-	ld	hl, (ix + 18)
-	or	a, a
-	sbc	hl, bc			; if (x2 < a) { a = x2; }
-	jp	p, .cmp20
-	jp	pe, .cmp21
-	jr	.cmp22
-.cmp20:
-	jp	po, .cmp21
-.cmp22:
-	ld	bc, (ix + 18)
-	ld	(ix - 3), bc
-	jr	.cmp31
-.cmp21:
-	ld	bc, (ix + 18)
-	ld	hl, (ix - 6)
-	or	a, a
-	sbc	hl, bc			; else if (x2 > b) { b = x2; }
-	jp	p, .cmp30
-	jp	pe, .cmp31
-	jr	.cmp32
+	inc	hl
+	push	hl		; x_max - x_min + 1
+	push	bc		; y0
+	push	de		; x_min
+	call	0		; horizline(x_min, y0, x_max - x_min + 1)
+.line0 := $-3
+	ld	sp, ix
+	pop	ix
+	ret
+;-------------------------------------------------------------------------------
 .notflat:
-	ld	bc, (ix + 6)		; x0
-	ld	hl, (ix + 12)
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 	ld	(ix - 36), hl		; dx01 = x1 - x0;
 	ld	hl, (ix + 18)
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 	ld	(ix - 21), hl		; dx02 = x2 - x0;
-	ld	bc, (ix + 9)		; y0
+
+	ld	de, (ix + 9)		; y0
 	ld	hl, (ix + 15)
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 	ld	(ix - 33), hl		; dy01 = y1 - y0;
 	ld	hl, (ix + 21)
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 	ld	(ix - 27), hl		; dy02 = y2 - y0;
-	ld	bc, (ix + 12)
+
+	ld	de, (ix + 12)
 	ld	hl, (ix + 18)
 	or	a, a
-	sbc	hl, bc
+	sbc	hl, de
 	ld	(ix - 30), hl		; dx12 = x2 - x1;
+
 	ld	bc, (ix + 15)
 	ld	hl, (ix + 21)
 	or	a, a
 	sbc	hl, bc
 	ld	(ix - 39), hl		; dy12 = y2 - y1;
-	jr	nz, .elselast		; if (y1 == y2) { last = y1; }
-	ld	(ix - 24), bc
-	jr	.sublast
-.cmp30:
-	jp	po, .cmp31
-.cmp32:
-	ld	bc, (ix + 18)
-	ld	(ix - 6), bc
-.cmp31:
-	ld	de, (ix - 3)
-	ld	hl, (ix - 6)
-	or	a, a
-	sbc	hl, de
-	inc	hl
-	push	hl
-	ld	bc, (ix + 9)
-	push	bc
-	push	de
-	call	0			; horizline(a, y0, b-a+1);
-.line0 := $-3
-	ld	sp, ix
-	pop	ix
-	ret				; return;
-.elselast:
-	ld	bc, (ix + 15)		; else { last = y1-1; }
+	; if (y1 == y2) { last = y1; }
+	jr	z, .sublast
+	; else { last = y1-1; }
 	dec	bc
-	ld	(ix - 24), bc
 .sublast:
+	ld	(ix - 24), bc
 	ld	bc, (ix + 9)
 	ld	(ix - 12), bc		; for (y = y0; y <= last; y++)
 	jr	.firstloopstart
+;-------------------------------------------------------------------------------
 .firstloop:
 	ld	hl, (ix - 15)
 	ld	bc, (ix - 33)
 	call	_DivideHLBC
 	ld	bc, (ix + 6)
 	add	hl, bc
-	ld	(ix - 3), hl		; a = x0 + sa / dy01;
+	; a = x0 + sa / dy01;
+	push	hl	; ld (ix - 3), hl
 	ld	hl, (ix - 18)
 	ld	bc, (ix - 27)
 	call	_DivideHLBC
 	ld	bc, (ix + 6)
 	add	hl, bc
-	ld	(ix - 6), hl		; b = x0 + sb / dy02;
+	; b = x0 + sb / dy02;
+	push	hl	; ld (ix - 6), hl
 	ld	bc, (ix - 36)
 	ld	hl, (ix - 15)
 	add	hl, bc
@@ -4243,22 +4205,17 @@ _FillTriangle:
 	ld	hl, (ix - 18)
 	add	hl, bc
 	ld	(ix - 18), hl		; sb += dx02;
-	ld	de, (ix - 3)
-	ld	hl, (ix - 6)
+	pop	hl	; ld hl, (ix - 6)
+	pop	de	; ld de, (ix - 3)
 	or	a, a
 	sbc	hl, de			; if (b < a) { swap(a, b); }
-	jp	p, .cmp40
-	jp	pe, .cmp41
-	jr	.cmp42
-.cmp40:
-	jp	po, .cmp41
-.cmp42:
-	ld	hl, (ix - 3)
-	ld	de, (ix - 6)
-	ld	(ix - 3), de
-	ld	(ix - 6), hl
-.cmp41:
-	ld	hl, (ix - 6)
+	add	hl, de
+	jp	p, .cmp43
+	ex	de, hl
+.cmp43:
+	jp	po, .cmp44
+	ex	de, hl
+.cmp44:
 	or	a, a
 	sbc	hl, de
 	inc	hl
@@ -4298,20 +4255,24 @@ _FillTriangle:
 	ld	de, (ix - 21)
 	call	_MultiplyHLDE		; sb = dx02 * (y - y0);
 	ld	(ix - 18), hl
+	ld	bc, (ix - 12)
 	jr	.secondloopstart	; for (; y <= y2; y++)
+;-------------------------------------------------------------------------------
 .secondloop:
 	ld	hl, (ix - 15)
 	ld	bc, (ix - 39)
 	call	_DivideHLBC
 	ld	bc, (ix + 12)
 	add	hl, bc
-	ld	(ix - 3), hl		; a = x1 + sa / dy12;
+	; a = x1 + sa / dy12;
+	push	hl	; ld (ix - 3), hl
 	ld	hl, (ix - 18)
 	ld	bc, (ix - 27)
 	call	_DivideHLBC
 	ld	bc, (ix + 6)
 	add	hl, bc
-	ld	(ix - 6), hl		; b = x0 + sb / dy02;
+	; b = x0 + sb / dy02;
+	push	hl	; ld (ix - 6), hl
 	ld	bc, (ix - 30)
 	ld	hl, (ix - 15)
 	add	hl, bc
@@ -4320,22 +4281,17 @@ _FillTriangle:
 	ld	hl, (ix - 18)
 	add	hl, bc
 	ld	(ix - 18), hl		; sb += dx02;
-	ld	de, (ix - 3)
-	ld	hl, (ix - 6)
+	pop	hl	; ld hl, (ix - 6)
+	pop	de	; ld de, (ix - 3)
 	or	a, a
 	sbc	hl, de			; if (b < a) { swap(a, b); }
-	jp	p, .cmp60
-	jp	pe, .cmp61
-	jr	.cmp62
-.cmp60:
-	jp	po, .cmp61
-.cmp62:
-	ld	hl, (ix - 3)
-	ld	de, (ix - 6)
-	ld	(ix - 3), de
-	ld	(ix - 6), hl
-.cmp61:
-	ld	hl, (ix - 6)
+	add	hl, de
+	jp	p, .cmp63
+	ex	de, hl
+.cmp63:
+	jp	po, .cmp64
+	ex	de, hl
+.cmp64:
 	or	a, a
 	sbc	hl, de
 	inc	hl
@@ -4352,7 +4308,6 @@ _FillTriangle:
 	inc	bc
 	ld	(ix - 12), bc
 .secondloopstart:
-	ld	bc, (ix - 12)
 	ld	hl, (ix + 21)
 	or	a, a
 	sbc	hl, bc


### PR DESCRIPTION
Optimizes `gfx_Triangle` while still keeping the same algorithm.

Saves 195 bytes. A lot of savings came from removing all the signed comparisons for the flat line case.