### PR TITLE
Optimize graphx circle

### DIFF
--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -1645,32 +1645,28 @@ _Circle:
 	inc	bc
 	ld	(iy - 3), bc
 	ld	bc, (iy - 9)
+	ld	hl, $800000
 	or	a, a
-	sbc	hl, hl
 	sbc	hl, bc
-	jp	m, .cmp0
-	jp	pe, .cmp1
-	jr	.cmp2
-.cmp0:
-	jp	po, .cmp1
-.cmp2:
 	ld	hl, (iy - 3)
+	jp	pe, .cmp1	; BC > 0
+	; BC <= 0
+.cmp2:
 	add	hl, hl
 	inc	hl
 	add	hl, bc
-	jr	.next
+	jr	.loop
 .cmp1:
 	ld	bc, (iy - 6)
 	dec	bc
 	ld	(iy - 6), bc
-	ld	hl, (iy - 3)
 	or	a, a
 	sbc	hl, bc
 	add	hl, hl
 	inc	hl
 	ld	de, (iy - 9)
 	add	hl, de
-.next:
+.loop:
 	ld	(iy - 9), hl
 	ld	bc, (iy - 3)
 	ld	hl, (iy - 6)
@@ -1706,7 +1702,7 @@ gfx_Circle:
 	inc	hl
 	sbc	hl, bc	; HL = 1 - BC
 	call	gfx_Wait
-	jr	_Circle.next
+	jr	_Circle.loop
 
 ;-------------------------------------------------------------------------------
 _FillCircle:
@@ -1772,33 +1768,29 @@ _FillCircle:
 	ld	bc, (ix - 3)
 	inc	bc
 	ld	(ix - 3), bc
-	ld	bc, (ix - 9)
+	ld	bc, (hl)	; ld bc, (ix - 9)
+	ld	hl, $800000
 	or	a, a
-	sbc	hl, hl
 	sbc	hl, bc
-	jp	m, .cmp0
-	jp	pe, .cmp2
-	jr	.cmp1
-.cmp0:
-	jp	po, .cmp2
-.cmp1:
 	ld	hl, (ix - 3)
+	jp	pe, .cmp2	; BC > 0
+	; BC <= 0
+.cmp1:
 	add	hl, hl
 	inc	hl
 	add	hl, bc
-	jr	.cmp3
+	jr	.loop
 .cmp2:
 	ld	bc, (ix - 6)
 	dec	bc
 	ld	(ix - 6), bc
-	ld	hl, (ix - 3)
 	ld	de, (ix - 9)
 	or	a, a
 	sbc	hl, bc
 	add	hl, hl
 	inc	hl
 	add	hl, de
-.cmp3:
+.loop:
 	ld	(ix - 9), hl
 	ld	bc, (ix - 3)
 	ld	hl, (ix - 6)
@@ -1837,7 +1829,7 @@ gfx_FillCircle:
 	ld	(ix - 3), hl
 	inc	hl
 	sbc	hl, bc	; HL = 1 - BC
-	jr	_FillCircle.cmp3
+	jr	_FillCircle.loop
 
 ;-------------------------------------------------------------------------------
 _FillCircle_NoClip:
@@ -1898,16 +1890,13 @@ _FillCircle_NoClip:
 	inc	bc
 	ld	(ix - 3), bc
 	ld	bc, (ix - 9)
+	ld	hl, $800000
 	or	a, a
-	sbc	hl, hl
 	sbc	hl, bc
-	jp	m, .cmp0
-	jp	pe, .cmp2
-	jr	.cmp1
-.cmp0:
-	jp	po, .cmp2
-.cmp1:
 	ld	hl, (ix - 3)
+	jp	pe, .cmp2	; BC > 0
+	; BC <= 0
+.cmp1:
 	add	hl, hl
 	inc	hl
 	add	hl, bc
@@ -1916,7 +1905,6 @@ _FillCircle_NoClip:
 	ld	bc, (ix - 6)
 	dec	bc
 	ld	(ix - 6), bc
-	ld	hl, (ix - 3)
 	or	a, a
 	sbc	hl, bc
 	add	hl, hl

--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -1645,18 +1645,19 @@ _Circle:
 	inc	bc
 	ld	(iy - 3), bc
 	ld	bc, (iy - 9)
-	ld	hl, $800000
-	or	a, a
-	sbc	hl, bc
+
+	sbc	hl, hl
+	adc	hl, bc		; set Z/NZ
+	add	hl, hl		; C = sign
 	ld	hl, (iy - 3)
-	jp	pe, .cmp1	; BC > 0
-	; BC <= 0
-.cmp2:
+	jr	z, .cmp2	; BC == 0
+	jr	nc, .cmp1	; BC > 0
+.cmp2:	; BC <= 0
 	add	hl, hl
 	inc	hl
 	add	hl, bc
 	jr	.loop
-.cmp1:
+.cmp1:	; BC > 0
 	ld	bc, (iy - 6)
 	dec	bc
 	ld	(iy - 6), bc
@@ -1769,18 +1770,19 @@ _FillCircle:
 	inc	bc
 	ld	(ix - 3), bc
 	ld	bc, (hl)	; ld bc, (ix - 9)
-	ld	hl, $800000
-	or	a, a
-	sbc	hl, bc
+
+	sbc	hl, hl
+	adc	hl, bc		; set Z/NZ
+	add	hl, hl		; C = sign
 	ld	hl, (ix - 3)
-	jp	pe, .cmp2	; BC > 0
-	; BC <= 0
-.cmp1:
+	jr	z, .cmp2	; BC == 0
+	jr	nc, .cmp1	; BC > 0
+.cmp2:	; BC <= 0
 	add	hl, hl
 	inc	hl
 	add	hl, bc
 	jr	.loop
-.cmp2:
+.cmp1:	; BC > 0
 	ld	bc, (ix - 6)
 	dec	bc
 	ld	(ix - 6), bc
@@ -1890,18 +1892,19 @@ _FillCircle_NoClip:
 	inc	bc
 	ld	(ix - 3), bc
 	ld	bc, (ix - 9)
-	ld	hl, $800000
-	or	a, a
-	sbc	hl, bc
+
+	sbc	hl, hl
+	adc	hl, bc		; set Z/NZ
+	add	hl, hl		; C = sign
 	ld	hl, (ix - 3)
-	jp	pe, .cmp2	; BC > 0
-	; BC <= 0
-.cmp1:
+	jr	z, .cmp2	; BC == 0
+	jr	nc, .cmp1	; BC > 0
+.cmp2:	; BC <= 0
 	add	hl, hl
 	inc	hl
 	add	hl, bc
 	jr	.loop
-.cmp2:
+.cmp1:	; BC > 0
 	ld	bc, (ix - 6)
 	dec	bc
 	ld	(ix - 6), bc

--- a/src/graphx/graphx.asm
+++ b/src/graphx/graphx.asm
@@ -1673,9 +1673,11 @@ _Circle:
 	ld	hl, (iy - 6)
 	or	a, a
 	sbc	hl, bc
-	jp	p, .check
+	add	hl, hl		; C = sign
+	jr	nc, .check	; positive
 	jp	pe, .sectors
-	jr	.exit
+	; jr	.exit
+	xor	a, a		; sets PE
 .check:
 	jp	po, .sectors
 .exit:
@@ -1798,11 +1800,11 @@ _FillCircle:
 	ld	hl, (ix - 6)
 	or	a, a
 	sbc	hl, bc
-	jp	p, .check
+	add	hl, hl		; C = sign
+	jr	nc, .check	; positive
 	jp	pe, .fillsectors
-	ld	sp, ix
-	pop	ix
-	ret
+	; jr	.ResetStack
+	xor	a, a		; sets PE
 .check:
 	jp	po, .fillsectors
 .ResetStack:


### PR DESCRIPTION
optimized comparisons in the circle routines (saves 69 bytes).
See also: https://discordapp.com/channels/466808269789200384/470381273312002079/1416151961333534930