### PR TITLE
fixed indentation in autotest.json

### DIFF
--- a/test/floating_point/compiletime_classification/autotest.json
+++ b/test/floating_point/compiletime_classification/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|4000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|400",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 6000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|4000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 6000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/complex/autotest.json
+++ b/test/floating_point/complex/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|200",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|200",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_classification/autotest.json
+++ b/test/floating_point/float32_classification/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_fminmax/autotest.json
+++ b/test/floating_point/float32_fminmax/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|4000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|400",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 6000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|4000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 6000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_frexp/autotest.json
+++ b/test/floating_point/float32_frexp/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_ilogb/autotest.json
+++ b/test/floating_point/float32_ilogb/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_ldexp/autotest.json
+++ b/test/floating_point/float32_ldexp/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_math/autotest.json
+++ b/test/floating_point/float32_math/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|4000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|400",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 6000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|4000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 6000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_modf/autotest.json
+++ b/test/floating_point/float32_modf/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_to_float64/autotest.json
+++ b/test/floating_point/float32_to_float64/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float32_trunc/autotest.json
+++ b/test/floating_point/float32_trunc/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_arithmetic/autotest.json
+++ b/test/floating_point/float64_arithmetic/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|4000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|400",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 6000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|4000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 6000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_classification/autotest.json
+++ b/test/floating_point/float64_classification/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|6000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 8000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|6000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 8000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_frexp/autotest.json
+++ b/test/floating_point/float64_frexp/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_from_integer/autotest.json
+++ b/test/floating_point/float64_from_integer/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_ilogb/autotest.json
+++ b/test/floating_point/float64_ilogb/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_ldexp/autotest.json
+++ b/test/floating_point/float64_ldexp/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_math/autotest.json
+++ b/test/floating_point/float64_math/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|4000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|400",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 6000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|4000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 6000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_rounding/autotest.json
+++ b/test/floating_point/float64_rounding/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_to_float32/autotest.json
+++ b/test/floating_point/float64_to_float32/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "Passed both test types or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "C2EF60CF",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "Passed both test types or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "C2EF60CF",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_to_integer/autotest.json
+++ b/test/floating_point/float64_to_integer/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|3000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|3000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/float64_trunc/autotest.json
+++ b/test/floating_point/float64_trunc/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/floating_point/ultof/autotest.json
+++ b/test/floating_point/ultof/autotest.json
@@ -1,43 +1,43 @@
 {
-	"transfer_files": [
-	  "bin/DEMO.8xp"
-	],
-	"target": {
-	  "name": "DEMO",
-	  "isASM": true
-	},
-	"sequence": [
-	  "action|launch",
-	  "delay|1000",
-	  "hashWait|1",
-	  "key|enter",
-	  "delay|300",
-	  "hashWait|2"
-	],
-	"hashes": {
-	  "1": {
-		"description": "All tests passed or GDB1 error",
-		"timeout": 5000,
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "38E2AD5A",
-		  "2C812DC2"
-		]
-	  },
-	  "2": {
-		"description": "Exit or GDB1 error",
-		"start": "vram_start",
-		"size": "vram_16_size",
-		"expected_CRCs": [
-		  "FFAF89BA",
-		  "101734A5",
-		  "9DA19F44",
-		  "A32840C8",
-		  "349F4775",
-		  "271A9FBF",
-		  "82FD0B1E"
-		]
-	  }
-	}
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed or GDB1 error",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A",
+        "2C812DC2"
+      ]
+    },
+    "2": {
+      "description": "Exit or GDB1 error",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775",
+        "271A9FBF",
+        "82FD0B1E"
+      ]
+    }
+  }
 }

--- a/test/fontlibc/glyph_width/autotest.json
+++ b/test/fontlibc/glyph_width/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/graphx/palette/autotest.json
+++ b/test/graphx/palette/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/regression/i48routines/autotest.json
+++ b/test/regression/i48routines/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/asprintf_fprintf/autotest.json
+++ b/test/standalone/asprintf_fprintf/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/concepts/autotest.json
+++ b/test/standalone/concepts/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/ez80_builtin/autotest.json
+++ b/test/standalone/ez80_builtin/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/i48div/autotest.json
+++ b/test/standalone/i48div/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/mulu_b/autotest.json
+++ b/test/standalone/mulu_b/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/scanf/autotest.json
+++ b/test/standalone/scanf/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/stdbit/autotest.json
+++ b/test/standalone/stdbit/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/strlcpy/autotest.json
+++ b/test/standalone/strlcpy/autotest.json
@@ -23,7 +23,7 @@
   "hashes": {
     "1": {
       "description": "First set of tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [
@@ -32,7 +32,7 @@
     },
     "2": {
       "description": "Second set of tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [
@@ -41,7 +41,7 @@
     },
     "3": {
       "description": "Third set of tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/strtol/autotest.json
+++ b/test/standalone/strtol/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [

--- a/test/standalone/wide_char/autotest.json
+++ b/test/standalone/wide_char/autotest.json
@@ -17,7 +17,7 @@
   "hashes": {
     "1": {
       "description": "All tests passed",
-	  "timeout": 5000,
+      "timeout": 5000,
       "start": "vram_start",
       "size": "vram_16_size",
       "expected_CRCs": [


### PR DESCRIPTION
Enforce 2 spaces per indentation in `autotest.json`. This commit only touches whitespace and nothing else. I will add it to `.git-blame-ignore-revs` once this is merged.

This prevents future indentation/formatting errors from spreading:

***

For whatever reason, this i48routines/autotest.json used a tab instead of 2 spaces to indent here.
<img width="492" height="266" alt="image" src="https://github.com/user-attachments/assets/a15b8337-893d-4d45-938e-ec506b6d5a88" />
and because I kept reusing that template, all of these files have that same indentation error
<img width="877" height="1084" alt="image" src="https://github.com/user-attachments/assets/66f3b333-5df5-4b49-9b6e-0aa298525442" />
