### PR TITLE
added equzero (same as cmpzero but only outputs Zero flag)

### DIFF
--- a/src/crt/dtof.src
+++ b/src/crt/dtof.src
@@ -173,7 +173,7 @@ __dtof:
 	; BC:UDE:UHL = 1 << shift
 	; (SP) = X
 	call	__lland
-	call	__llcmpzero
+	call	__llequzero
 	pop	hl
 	; DE and BC are swapped here
 	pop	bc
@@ -215,6 +215,6 @@ __dtof:
 	jr	.L.ret_copysign
 
 	.extern	__lland
-	.extern	__llcmpzero
+	.extern	__llequzero
 	.extern	__llshru
 	.extern	__lshru

--- a/src/crt/i48cmpzero.src
+++ b/src/crt/i48cmpzero.src
@@ -6,10 +6,18 @@
 	.assume	adl=1
 
 	.section	.text
+
+	.global	__i48equzero
+	.type	__i48equzero, @function
+
 	.global	__i48cmpzero
 	.type	__i48cmpzero, @function
 
+__i48equzero:
+	; Zero flag = (UDE:UHL == 0)
 __i48cmpzero:
+	; Zero flag = (UDE:UHL == 0)
+	; Sign flag = (UDE:UHL < 0)
 ; CC: 13 bytes
 ; Minimum:  8F + 3R + 2
 ; Maximum: 14F + 3R + 3

--- a/src/crt/lcmpzero.src
+++ b/src/crt/lcmpzero.src
@@ -1,10 +1,18 @@
 	.assume	adl=1
 
 	.section	.text
+
+	.global	__lequzero
+	.type	__lequzero, @function
+
 	.global	__lcmpzero
 	.type	__lcmpzero, @function
 
+__lequzero:
+	; Zero flag = (E:UHL == 0)
 __lcmpzero:
+	; Zero flag = (E:UHL == 0)
+	; Sign flag = (E:UHL < 0)
 	inc	e
 	dec	e
 	ret	nz

--- a/src/crt/llcmpzero.src
+++ b/src/crt/llcmpzero.src
@@ -1,10 +1,18 @@
 	.assume	adl=1
 
 	.section	.text
+
+	.global	__llequzero
+	.type	__llequzero, @function
+
 	.global	__llcmpzero
 	.type	__llcmpzero, @function
 
+__llequzero:
+	; Zero flag = (BC:UDE:UHL == 0)
 __llcmpzero:
+	; Zero flag = (BC:UDE:UHL == 0)
+	; Sign flag = (BC:UDE:UHL < 0)
 	inc	b
 	dec	b
 	ret	nz

--- a/src/libc/strtoll.src
+++ b/src/libc/strtoll.src
@@ -26,7 +26,7 @@ _strtoll.maybe_out_of_range:
 	; negative
 	; check that the result is not an exact INT_MIN
 	ld	b, a		; B = (B << 1)
-	call	__llcmpzero
+	call	__llequzero
 	set	7, b
 	ret	z		; exact INT_MIN
 _strtoll.underflow:
@@ -344,4 +344,4 @@ __strtoll_common.set_overflow_bit:
 
 	.extern	_errno
 	.extern	__llneg
-	.extern	__llcmpzero
+	.extern	__llequzero

--- a/src/softfloat/s_shiftRightJam64.src
+++ b/src/softfloat/s_shiftRightJam64.src
@@ -41,7 +41,7 @@ _softfloat_shiftRightJam64:
 	ld	hl, (iy + 4)
 	call	__llshl
 	xor	a, a
-	call	__llcmpzero
+	call	__llequzero
 	jr	z, .L.no_round
 	inc	a	; ld a, 1
 .L.no_round:
@@ -58,7 +58,7 @@ _softfloat_shiftRightJam64:
 .L.overflow_shift:
 	; A is zero here
 	ld	hl, (iy + 4)
-	call	__llcmpzero
+	call	__llequzero
 	ret	z
 	xor	a, a
 	sbc	hl, hl
@@ -69,6 +69,6 @@ _softfloat_shiftRightJam64:
 	inc	hl
 	ret
 
-	.extern	__llcmpzero
+	.extern	__llequzero
 	.extern	__llshl
 	.extern	__llshru


### PR DESCRIPTION
`__*equzero` is identical to `__*cmpzero` except that it only outputs to the Zero flag. Currently it just aliases `__*cmpzero`, but the intent is that it could maybe link to a smaller/faster routine.

```asm
__i48cmpzero:
; CC: 13 bytes
; Minimum  :  8F + 3R + 2
; arg == 0 : 11F + 3R + 3
; Maximum  : 14F + 3R + 3
	ex	de, hl
	add	hl, de
	or	a, a
	sbc	hl, de
	ex	de, hl
	ret	nz
	sbc	hl, de
	ret	p
	inc	e
	dec	de
	ret

; implementation 1
__i48equzero:
; CC: 9 bytes
; Minimum  :  6F + 3R + 2
; arg == 0 : 10F + 3R + 2
; Maximum  : 10F + 3R + 2
	add	hl, de
	or	a, a
	sbc	hl, de
	ret	nz
	sbc	hl, de
	add	hl, de
	ret

; implementation 2
__i48equzero:
; CC: 10 bytes
; Minimum  :  6F + 3R + 2
; arg == 0 : 11F + 3R + 2
; Maximum  : 11F + 3R + 2
	or	a, a
	sbc	hl, de
	add	hl, de
	ret	nz
	sbc	hl, hl
	adc	hl, de
	ret
```
