### PR TITLE
[libcxx] added cxa_guard functions

### DIFF
--- a/src/libcxx/cxa.cpp
+++ b/src/libcxx/cxa.cpp
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include "abort_message.h"
+
+// https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dso-dtor-runtime-api
+
+// __int64_t
+typedef int64_t __guard;
+
+extern "C" {
+[[gnu::cold]] int __cxa_guard_acquire(__guard *);
+[[gnu::cold]] void __cxa_guard_release(__guard *);
+[[noreturn, gnu::cold]] void __cxa_guard_abort(__guard *);
+}
+
+int __cxa_guard_acquire(__guard *guard_object) {
+    unsigned char const *flag = (unsigned char const *)guard_object;
+    if (*flag == 0) {
+        // initialization not yet complete
+        return 1;
+    }
+    // otherwise
+    return 0;
+}
+
+void __cxa_guard_release(__guard *guard_object) {
+    unsigned char *flag = (unsigned char *)guard_object;
+    // set to a non-zero value
+    *flag = 1;
+}
+
+void __cxa_guard_abort([[maybe_unused]] __guard *guard_object) {
+    std::__abort_message("__cxa_guard_abort");
+}


### PR DESCRIPTION
`__cxa_guard_acquire`, `__cxa_guard_release`, and `__cxa_guard_abort` are emitted with `-fthreadsafe-statics`. Most commonly when building the `libcxx_19_locale` branch.

We currently define `-fno-threadsafe-statics` (see also https://github.com/CE-Programming/toolchain/pull/749) so Clang won't normally emit these. But they are harmless to add into the toolchain, and prevent users in the future from receiving linker errors.
