### PR TITLE
specified Carry-out for __*shift_1 routines and Sign-out for __llshl_1

### DIFF
--- a/src/crt/i48shrs_1.src
+++ b/src/crt/i48shrs_1.src
@@ -5,6 +5,12 @@
 	.type	__i48shrs_1, @function
 
 __i48shrs_1:
+	; Input:
+	; - UDE:UHL
+	; Output:
+	; - UDE:UHL >>= 1 (signed)
+	; - Carry = shifted-out bit
+	; Cost: 24 bytes | 25F + 11R + 8W + 3
 	push	hl
 	scf
 	sbc	hl, hl

--- a/src/crt/i48shru_1.src
+++ b/src/crt/i48shru_1.src
@@ -5,6 +5,12 @@
 	.type	__i48shru_1, @function
 
 __i48shru_1:
+	; Input:
+	; - UDE:UHL
+	; Output:
+	; - UDE:UHL >>= 1 (unsigned)
+	; - Carry = shifted-out bit
+	; Cost: 24 bytes | 25F + 11R + 8W + 3
 	push	hl
 	scf
 	sbc	hl, hl

--- a/src/crt/ishrs_1.src
+++ b/src/crt/ishrs_1.src
@@ -5,6 +5,12 @@
 	.type	__ishrs_1, @function
 
 __ishrs_1:
+	; Input:
+	; - UHL
+	; Output:
+	; - UHL >>= 1 (signed)
+	; - Carry = shifted-out bit
+	; Cost: 14 bytes | 15F + 7R + 4W + 2
 	push	hl
 	ld	hl, 2
 	add	hl, sp

--- a/src/crt/ishru_1.src
+++ b/src/crt/ishru_1.src
@@ -5,6 +5,12 @@
 	.type	__ishru_1, @function
 
 __ishru_1:
+	; Input:
+	; - UHL
+	; Output:
+	; - UHL >>= 1 (unsigned)
+	; - Carry = shifted-out bit
+	; Cost: 14 bytes | 15F + 7R + 4W + 2
 	push	hl
 	ld	hl, 2
 	add	hl, sp

--- a/src/crt/llshl_1.src
+++ b/src/crt/llshl_1.src
@@ -5,6 +5,12 @@
 	.type	__llshl_1, @function
 
 __llshl_1:
+	; Input:
+	; - BC:UDE:UHL
+	; Output:
+	; - BC:UDE:UHL <<= 1
+	; - Carry = shifted-out bit
+	; Cost: 10 bytes | 11F + 3R + 1
 	add	hl, hl
 	ex	de, hl
 	adc	hl, hl

--- a/src/crt/llshrs_1.src
+++ b/src/crt/llshrs_1.src
@@ -5,6 +5,12 @@
 	.type	__llshrs_1, @function
 
 __llshrs_1:
+	; Input:
+	; - BC:UDE:UHL
+	; Output:
+	; - BC:UDE:UHL >>= 1 (signed)
+	; - Carry = shifted-out bit
+	; Cost: 28 bytes | 29F + 11R + 8W + 3
 	push	hl
 	scf
 	sbc	hl, hl

--- a/src/crt/llshru_1.src
+++ b/src/crt/llshru_1.src
@@ -5,6 +5,12 @@
 	.type	__llshru_1, @function
 
 __llshru_1:
+	; Input:
+	; - BC:UDE:UHL
+	; Output:
+	; - BC:UDE:UHL >>= 1 (unsigned)
+	; - Carry = shifted-out bit
+	; Cost: 28 bytes | 29F + 11R + 8W + 3
 	push	hl
 	scf
 	sbc	hl, hl

--- a/src/crt/lshrs_1.src
+++ b/src/crt/lshrs_1.src
@@ -5,6 +5,12 @@
 	.type	__lshrs_1, @function
 
 __lshrs_1:
+	; Input:
+	; - E:UHL
+	; Output:
+	; - E:UHL >>= 1 (signed)
+	; - Carry = shifted-out bit
+	; Cost: 16 bytes | 17F + 7R + 4W + 2
 	push	hl
 	ld	hl, 2
 	add	hl, sp

--- a/src/crt/lshru_1.src
+++ b/src/crt/lshru_1.src
@@ -5,6 +5,12 @@
 	.type	__lshru_1, @function
 
 __lshru_1:
+	; Input:
+	; - E:UHL
+	; Output:
+	; - E:UHL >>= 1 (unsigned)
+	; - Carry = shifted-out bit
+	; Cost: 16 bytes | 17F + 7R + 4W + 2
 	push	hl
 	ld	hl, 2
 	add	hl, sp


### PR DESCRIPTION
Added documentation to the `__*shift_1` routines:
- size and clock-cycles
- input and output parameters
- Specified that the `__*shift_1` functions set the Carry flag to the shifted out bit.


~~I also specified the sign out for the `__*shl_1` functions, since every reasonable implementation would output the sign and carry flag anyways. Including a hypothetical `__i72shl_1` function:~~
```asm
__i72shl_1:
	add	hl, hl
	ex	de, hl
	adc	hl, hl
	ex	de, hl
	push	bc
	ex	(sp), hl
	adc	hl, hl
	ex	(sp), hl
	pop	bc
	ret
```

or actually, I guess the sign output could come back to bite us for `UIY:UBC << 1`

```asm
__i48shl_1_uiyubc:
	push	bc
	ex	(sp), hl
	add	hl, hl
	ex	(sp), hl
	pop	bc
	jr nc, .no_carry
	add	iy, iy
	inc	iy
	ret
.no_carry:
	add	iy, iy
	ret
```

