### PR TITLE
Update nanoprintf

### DIFF
--- a/src/libc/printf/nanoprintf.c
+++ b/src/libc/printf/nanoprintf.c
@@ -14,7 +14,7 @@
  * @remarks don't set this above 40, or there is a chance that
  * frameset will exceed 127 (generating slower code).
  */
-#define NANOPRINTF_CONVERSION_BUFFER_SIZE 36
+#define NANOPRINTF_CONVERSION_BUFFER_SIZE 24
 
 static void npf_putc_std(int c, void *ctx) {
   (void)ctx;
@@ -26,19 +26,26 @@ static void npf_fputc_std(int c, void *ctx) {
 }
 
 // This is a custom nanoprintf flag
-#define NANOPRINTF_PROMOTE_TO_LONG_DOUBLE 1
+#define NANOPRINTF_USE_LONG_DOUBLE_PRECISION 1
 
-#if NANOPRINTF_PROMOTE_TO_LONG_DOUBLE == 1
+#if NANOPRINTF_USE_LONG_DOUBLE_PRECISION == 1
 #define NANOPRINTF_CONVERSION_FLOAT_TYPE unsigned long long
+#else
+#define NANOPRINTF_CONVERSION_FLOAT_TYPE unsigned long
 #endif
 
 #define NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS 1
+#define NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_ALT_FORM_FLAG 1
+#define NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER 0
+
+// Not applicable since sizeof(float) == sizeof(double) on the ez80
+#define NANOPRINTF_USE_FLOAT_SINGLE_PRECISION 0
 
 #include "nanoprintf.h"
 
@@ -50,13 +57,14 @@ int vsnprintf(char *__restrict buffer, size_t bufsz, char const *__restrict form
 
   npf_putc const pc = buffer ? npf_bufputc : npf_bufputc_nop;
   int const n = npf_vpprintf(pc, &bufputc_ctx, format, vlist);
-  pc('\0', &bufputc_ctx);
 
+  if (buffer && bufsz) {
 #ifdef NANOPRINTF_SNPRINTF_SAFE_EMPTY_STRING_ON_OVERFLOW
-  if (bufsz && (n >= (int)bufsz)) { buffer[0] = '\0'; }
+    buffer[(n < 0 || (unsigned)n >= bufsz) ? 0 : n] = '\0';
 #else
-  if (bufsz && (n >= (int)bufsz)) { buffer[bufsz - 1] = '\0'; }
+    buffer[n < 0 ? 0 : NPF_MIN((unsigned)n, bufsz - 1)] = '\0';
 #endif
+  }
 
   return n;
 }

--- a/src/libc/printf/nanoprintf.h
+++ b/src/libc/printf/nanoprintf.h
@@ -54,6 +54,8 @@ extern "C" {
 #endif
 #endif
 
+#ifndef _EZ80
+
 NPF_VISIBILITY int npf_snprintf_(char * NPF_RESTRICT buffer,
                                  size_t bufsz,
                                  const char * NPF_RESTRICT format, ...)
@@ -83,6 +85,8 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc,
                                 void * NPF_RESTRICT pc_ctx,
                                 char const * NPF_RESTRICT format,
                                 va_list vlist) NPF_PRINTF_ATTR(3, 0);
+
+#endif /* _EZ80 */
 
 #ifdef __cplusplus
 }
@@ -488,7 +492,9 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 #endif
       break;
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+#if !defined(_EZ80) || NANOPRINTF_USE_LONG_DOUBLE_PRECISION
     case 'L': out_spec->length_modifier = NPF_FMT_SPEC_LEN_MOD_LONG_DOUBLE; break;
+#endif /* _EZ80 */
 #endif
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
     case 'j': out_spec->length_modifier = NPF_FMT_SPEC_LEN_MOD_LARGE_INTMAX; break;
@@ -587,6 +593,10 @@ static NPF_NOINLINE int npf_utoa_rev(
   typedef float npf_real_t;
   #define NPF_REAL_MANT_DIG FLT_MANT_DIG
   #define NPF_REAL_MAX_EXP  FLT_MAX_EXP
+#elif NANOPRINTF_USE_LONG_DOUBLE_PRECISION
+  typedef long double npf_real_t;
+  #define NPF_REAL_MANT_DIG LDBL_MANT_DIG
+  #define NPF_REAL_MAX_EXP  LDBL_MAX_EXP
 #else
   typedef double npf_real_t;
   #define NPF_REAL_MANT_DIG DBL_MANT_DIG
@@ -643,7 +653,11 @@ static NPF_FORCE_INLINE npf_real_bin_t npf_real_to_int_rep(npf_real_t f) {
   npf_real_bin_t bin = 0;
   char const *src = (char const *)&f;
   char *dst = (char *)&bin;
+#ifndef _EZ80
   for (uint_fast8_t i = 0; i < sizeof(f); ++i) { dst[i] = src[i]; }
+#else /* _EZ80 */
+  __builtin_memcpy(dst, src, sizeof(f));
+#endif /* _EZ80 */
   return bin;
 }
 
@@ -813,7 +827,11 @@ static NPF_FORCE_INLINE npf_double_bin_t npf_double_to_int_rep(double f) {
   npf_double_bin_t bin = 0;
   char const *src = (char const *)&f;
   char *dst = (char *)&bin;
+#ifndef _EZ80
   for (uint_fast8_t i = 0; i < sizeof(f); ++i) { dst[i] = src[i]; }
+#else /* _EZ80 */
+  __builtin_memcpy(dst, src, sizeof(f));
+#endif /* _EZ80 */
   return bin;
 }
 #else
@@ -932,13 +950,22 @@ typedef struct npf_cnt_putc_ctx {
   int n;
 } npf_cnt_putc_ctx_t;
 
+#ifdef NANOPRINTF_STATIC_GLOBALS
+static npf_cnt_putc_ctx_t pc_cnt;
+#endif
+
 static void npf_putc_cnt(int c, void *ctx) {
-  npf_cnt_putc_ctx_t *pc_cnt = (npf_cnt_putc_ctx_t *)ctx;
-  ++pc_cnt->n;
-  pc_cnt->pc(c, pc_cnt->ctx); // sibling-call optimization
+  npf_cnt_putc_ctx_t *pc_putc_cnt = (npf_cnt_putc_ctx_t *)ctx;
+  ++pc_putc_cnt->n;
+  pc_putc_cnt->pc(c, pc_putc_cnt->ctx); // sibling-call optimization
 }
 
+#ifdef NANOPRINTF_STATIC_GLOBALS
+static void NPF_PUTC_IMPL(char VAL) { npf_putc_cnt((int)(VAL), &pc_cnt); }
+#define NPF_PUTC(VAL) NPF_PUTC_IMPL(VAL)
+#else
 #define NPF_PUTC(VAL) do { npf_putc_cnt((int)(VAL), &pc_cnt); } while (0)
+#endif
 
 #define NPF_EXTRACT(MOD, CAST_TO, EXTRACT_AS) \
   case NPF_FMT_SPEC_LEN_MOD_##MOD: val = (CAST_TO)va_arg(args, EXTRACT_AS); break
@@ -949,7 +976,9 @@ static void npf_putc_cnt(int c, void *ctx) {
 int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   npf_format_spec_t fs;
   char const *cur = format;
+#ifndef NANOPRINTF_STATIC_GLOBALS
   npf_cnt_putc_ctx_t pc_cnt;
+#endif
   pc_cnt.pc = pc;
   pc_cnt.ctx = pc_ctx;
   pc_cnt.n = 0;
@@ -1319,6 +1348,8 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #undef NPF_EXTRACT
 #undef NPF_WRITEBACK
 
+#ifndef _EZ80
+
 int npf_vsnprintf(char * NPF_RESTRICT buffer,
                   size_t bufsz,
                   char const * NPF_RESTRICT format,
@@ -1363,6 +1394,8 @@ int npf_snprintf_(char * NPF_RESTRICT buffer,
   va_end(val);
   return rv;
 }
+
+#endif /* _EZ80 */
 
 #if NPF_HAVE_GCC_WARNING_PRAGMAS
   #pragma GCC diagnostic pop


### PR DESCRIPTION
Updates nanoprintf to this commit (the latest commit at the time of writing) https://github.com/charlesnicholson/nanoprintf/tree/e3a1e65c7ae0699d26d25d68f6c3e21babfe31ca

nanoprintf recently added support for hexadecimal floats (`%a` and `%A`), but I have chosen to leave them disabled since hexadecimal floats are rarely used.