### PR TITLE
added __frameset_b

### DIFF
--- a/src/crt/frameset_b.src
+++ b/src/crt/frameset_b.src
@@ -1,0 +1,22 @@
+	.assume	adl=1
+
+	.section	.text
+	.global	__frameset_b
+	.type	__frameset_b, @function
+
+	; TODO: merge into __frameset.src once compiler starts emitting __frameset_b
+__frameset_b:
+	; framesets -A bytes (1 to 256 bytes)
+	; framesets 256 bytes if A is zero
+	scf
+	sbc	hl, hl
+	ld	l, a
+; __frameset:
+	pop	de
+	push	ix
+	ld	ix, 0
+	add	ix, sp
+	add	hl, sp
+	ld	sp, hl
+	ex	de, hl
+	jp	(hl)


### PR DESCRIPTION
See discussion here:
https://discordapp.com/channels/432891584451706892/1477002783616925808

TL:DR adds `__frameset_b` to the CRT to be emitted by the compiler in the future at `-Oz`.

# __frameset_b

Most calls to `__frameset` allocate between 4-256 bytes on the stack (it is faster/smaller to use `__frameset0` to allocate 1-3 bytes on the stack). We can save 2 bytes per call to `__frameset` if we did `ld a, -42` instead of `ld hl, -42`.
```asm
_func:
    ld hl, -42 ; 4 bytes
    call __frameset
    ; code
    ld sp, ix
    ret
    
_func:
    ld a, -42 ; 2 bytes
    call __frameset_b
    ; code
    ld sp, ix
    ret
```

Overall, it saves 2 bytes and is 2F slower, which is a fair tradeoff for `-Oz`. It can also tail call the existing `__frameset` routine (although I have `__frameset_b` in a separate file for now).
```asm
__frameset_b:
	; framesets -A bytes (1 to 256 bytes)
	; framesets 256 bytes if A is zero
	scf
	sbc	hl, hl
	ld	l, a
__frameset:
	; framesets -HL bytes
	pop	de
	push	ix
	ld	ix, 0
	add	ix, sp
	add	hl, sp
	ld	sp, hl
	ex	de, hl
	jp	(hl)
```

frameset sizes used in khicas:
```
>512    : 22
257-512 : 71
4-256   : 3376
3-256   : 3791
3       : 415
2       : 6
1       : 57
0       : 1440
```

# optimal frameset code

Here are some snippets of the smallest frameset code for a given size
```asm
; frameset 1 byte
; 18F + 3R + 6W
call __frameset0
dec sp

; frameset 2 bytes
; 19F + 3R + 6W
call __frameset0
dec sp
dec sp

; frameset 3 bytes
; 18F + 3R + 9W
call __frameset0
push reg

; frameset 4 bytes
; 19F + 3R + 9W
call __frameset0
dec sp
push reg

; frameset 5 bytes
; 26F + 3R + 6W
ld a, -5
call __frameset_b

; frameset 6 bytes
; 19F + 3R + 12W (assuming that 6W is faster than 7F)
call __frameset0
push reg
push reg
```