### PR TITLE
added assembly include files for <errno.h> <fenv.h> and <math.h>

### DIFF
--- a/src/crt/ltod.src
+++ b/src/crt/ltod.src
@@ -1,5 +1,7 @@
 	.assume	adl=1
 
+	.include	"fenv.inc"
+
 ;-------------------------------------------------------------------------------
 
 	.section	.text
@@ -70,16 +72,18 @@ __lltod_common:
 .L.round_up:
 	inc	b		; round up after shifting
 .L.no_round:
+
 .if 0	; FE_INEXACT
 	adc	a, a		; test sticky and round bits
 	jr	z, .L.result_is_exact
 .L.no_round_inexact:
 	ld	hl, ___fe_cur_env
-	set	5, (hl)		; FE_INEXACT
+	set	FE_INEXACT_BIT, (hl)
 .L.result_is_exact:
 .else
 .L.no_round_inexact:
 .endif
+
 	ld	h, b
 	ld	a, c
 	ld	l, c

--- a/src/crt/makefile
+++ b/src/crt/makefile
@@ -26,6 +26,8 @@ OBJECTS_CE += $(patsubst %.c,build/%.c.ce.o,$(wildcard *.c))
 OBJECTS_CE += $(patsubst %.cpp,build/%.cpp.ce.o,$(wildcard *.cpp))
 OBJECTS_CE += $(patsubst %.src,build/%.ce.o,$(wildcard *.src))
 
+EZASFLAGS += -I$(call NATIVEPATH,$(CURDIR)/../libc)
+
 .SECONDARY:
 
 all: build/libcrt.a build/libcrt_os.a

--- a/src/libc/acosf.src
+++ b/src/libc/acosf.src
@@ -1,5 +1,12 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+
+.if	EDOM & 0xFF != EDOM
+	.print	"EDOM is assumed to be between 1 and 255"
+	.err
+.endif
+
 	.section	.text
 	.global	_acos
 	.type	_acos, @function
@@ -36,7 +43,7 @@ _acosf:
 	jp	p, .L2
 
 .L1:
-	ld	hl,4
+	ld	hl, EDOM
 	ld	(_errno),hl
 	ld	l,h
 	ld	e,h

--- a/src/libc/errno.inc
+++ b/src/libc/errno.inc
@@ -1,0 +1,98 @@
+.ifndef __ERRNO_INC__
+	.set	__ERRNO_INC__, 1
+
+; errno.inc
+; Assembly errno equates for libc <errno.h>
+; Remember to keep this file in sync with <errno.h>
+
+; Note that many routines assume that EDOM and ERANGE are between 1 and 255.
+
+	.equ	EPERM           ,   1 ; permission error
+	.equ	EINVAL          ,   2 ; invalid argument
+	.equ	EIO             ,   3 ; io error
+	.equ	EDOM            ,   4 ; math domain error
+	.equ	ERANGE          ,   5 ; math range error
+	.equ	EILSEQ          ,   6 ; Illegal byte sequence (C95)
+	.equ	E2BIG           ,   7 ; Argument list too long
+	.equ	EACCES          ,   8 ; Permission denied
+	.equ	EADDRINUSE      ,   9 ; Address in use
+	.equ	EADDRNOTAVAIL   ,  10 ; Address not available
+	.equ	EAFNOSUPPORT    ,  11 ; Address family not supported
+	.equ	EAGAIN          ,  12 ; Resource unavailable, try again
+	.equ	EALREADY        ,  13 ; Connection already in progress
+	.equ	EBADF           ,  14 ; Bad file descriptor
+	.equ	EBADMSG         ,  15 ; Bad message
+	.equ	EBUSY           ,  16 ; Device or resource busy
+	.equ	ECANCELED       ,  17 ; Operation canceled
+	.equ	ECHILD          ,  18 ; No child processes
+	.equ	ECONNABORTED    ,  19 ; Connection aborted
+	.equ	ECONNREFUSED    ,  20 ; Connection refused
+	.equ	ECONNRESET      ,  21 ; Connection reset
+	.equ	EDEADLK         ,  22 ; Resource deadlock avoided
+	.equ	EDESTADDRREQ    ,  23 ; Destination address required
+	.equ	EEXIST          ,  24 ; File exists
+	.equ	EFAULT          ,  25 ; Bad address
+	.equ	EFBIG           ,  26 ; File too large
+	.equ	EHOSTUNREACH    ,  27 ; Host is unreachable
+	.equ	EIDRM           ,  28 ; Identifier removed
+	.equ	EINPROGRESS     ,  29 ; Operation in progress
+	.equ	EINTR           ,  30 ; Interrupted function
+	.equ	EISCONN         ,  31 ; Socket is connected
+	.equ	EISDIR          ,  32 ; Is a directory
+	.equ	ELOOP           ,  33 ; Too many levels of symbolic links
+	.equ	EMFILE          ,  34 ; Too many open files
+	.equ	EMLINK          ,  35 ; Too many links
+	.equ	EMSGSIZE        ,  36 ; Message too long
+	.equ	ENAMETOOLONG    ,  37 ; Filename too long
+	.equ	ENETDOWN        ,  38 ; Network is down
+	.equ	ENETRESET       ,  39 ; Connection aborted by network
+	.equ	ENETUNREACH     ,  40 ; Network is unreachable
+	.equ	ENFILE          ,  41 ; Too many open files in system
+	.equ	ENOBUFS         ,  42 ; No buffer space available
+	.equ	ENODATA         ,  43 ; No message is available on the STREAM head read queue
+	.equ	ENODEV          ,  44 ; No such device
+	.equ	ENOENT          ,  45 ; No such file or directory
+	.equ	ENOEXEC         ,  46 ; Executable file format error
+	.equ	ENOLCK          ,  47 ; No locks available
+	.equ	ENOLINK         ,  48 ; Link has been severed
+	.equ	ENOMEM          ,  49 ; Not enough space
+	.equ	ENOMSG          ,  50 ; No message of desired type
+	.equ	ENOPROTOOPT     ,  51 ; Protocol not available
+	.equ	ENOSPC          ,  52 ; No space left on device
+	.equ	ENOSR           ,  53 ; No stream resources
+	.equ	ENOSTR          ,  54 ; Not a stream
+	.equ	ENOSYS          ,  55 ; Function not implemented
+	.equ	ENOTCONN        ,  56 ; The socket is not connected
+	.equ	ENOTDIR         ,  57 ; Not a directory
+	.equ	ENOTEMPTY       ,  58 ; Directory not empty
+	.equ	ENOTRECOVERABLE ,  59 ; State not recoverable
+	.equ	ENOTSOCK        ,  60 ; Not a socket
+	.equ	ENOTSUP         ,  61 ; Not supported
+	.equ	ENOTTY          ,  62 ; Inappropriate I/O control operation
+	.equ	ENXIO           ,  63 ; No such device or address
+	.equ	EOPNOTSUPP      ,  64 ; Operation not supported on socket
+	.equ	EOVERFLOW       ,  65 ; Value too large to be stored in data type
+	.equ	EOWNERDEAD      ,  66 ; Previous owner died
+	.equ	EPIPE           ,  67 ; Broken pipe
+	.equ	EPROTO          ,  68 ; Protocol error
+	.equ	EPROTONOSUPPORT ,  69 ; Protocol not supported
+	.equ	EPROTOTYPE      ,  70 ; Protocol wrong type for socket
+	.equ	EROFS           ,  71 ; Read-only file system
+	.equ	ESPIPE          ,  72 ; Invalid seek
+	.equ	ESRCH           ,  73 ; No such process
+	.equ	ETIME           ,  74 ; Stream ioctl() timeout
+	.equ	ETIMEDOUT       ,  75 ; Connection timed out
+	.equ	ETXTBSY         ,  76 ; Text file busy
+	.equ	EWOULDBLOCK     ,  77 ; Operation would block
+	.equ	EXDEV           ,  78 ; Cross-device link
+
+.if	ERANGE & 0xFF != ERANGE
+	.print	"ERANGE is assumed to be between 1 and 255"
+	.err
+.endif
+.if	EDOM & 0xFF != EDOM
+	.print	"EDOM is assumed to be between 1 and 255"
+	.err
+.endif
+
+.endif

--- a/src/libc/fenv.inc
+++ b/src/libc/fenv.inc
@@ -1,0 +1,27 @@
+.ifndef __FENV_INC__
+	.set	__FENV_INC__, 1
+
+; fenv.inc
+; Assembly fenv equates for libc <fenv.h>
+; Remember to keep this file in sync with <fenv.h>
+
+	.equ	FE_DIVBYZERO_BIT  , 6
+	.equ	FE_INEXACT_BIT    , 5
+	.equ	FE_INVALID_BIT    , 4
+	.equ	FE_OVERFLOW_BIT   , 3
+	.equ	FE_UNDERFLOW_BIT  , 2
+
+	.equ	FE_DIVBYZERO_MASK , 1 << FE_DIVBYZERO_BIT
+	.equ	FE_INEXACT_MASK   , 1 << FE_INEXACT_BIT
+	.equ	FE_INVALID_MASK   , 1 << FE_INVALID_BIT
+	.equ	FE_OVERFLOW_MASK  , 1 << FE_OVERFLOW_BIT
+	.equ	FE_UNDERFLOW_MASK , 1 << FE_UNDERFLOW_BIT
+
+	.equ	FE_ALL_EXCEPT     , FE_DIVBYZERO_MASK | FE_INEXACT_MASK | FE_INVALID_MASK | FE_OVERFLOW_MASK | FE_UNDERFLOW_MASK
+
+	.equ	FE_TONEAREST      , 0
+	.equ	FE_TOWARDZERO     , 1
+	.equ	FE_DOWNWARD       , 2
+	.equ	FE_UPWARD         , 3
+
+.endif

--- a/src/libc/ilogbf.src
+++ b/src/libc/ilogbf.src
@@ -1,5 +1,18 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+	.include	"fenv.inc"
+	.include	"math.inc"
+
+.if	!(FP_ILOGBNAN == 0x7FFFFF)
+	.print	"ilogbf/ilogb assumes that FP_ILOGBNAN == 0x7FFFFF (INT_MAX)"
+	.err
+.endif
+.if	!(FP_ILOGB0 - 1 == FP_ILOGBNAN)
+	.print	"ilogbf/ilogb assumes FP_ILOGB0 - 1 == FP_ILOGBNAN"
+	.err
+.endif
+
 	.section	.text
 
 	.global	_ilogbf
@@ -42,10 +55,10 @@ _ilogb:
 .L.inf_nan:
 	scf
 .L.ret_zero:
-	ld	hl, 4	; EDOM
+	ld	hl, EDOM
 	ld	(_errno), hl
 	ld	hl, ___fe_cur_env
-	set	4, (hl)	; FE_INVALID
+	set	FE_INVALID_BIT, (hl)
 	ld	hl, $800000	; FP_ILOGB0
 	ret	nc
 	; FP_ILOGBNAN or INT_MAX when carry is set

--- a/src/libc/ilogbl.src
+++ b/src/libc/ilogbl.src
@@ -1,5 +1,23 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+	.include	"fenv.inc"
+	.include	"math.inc"
+
+.if	EDOM & 0xFF != EDOM
+	.print	"EDOM is assumed to be between 1 and 255"
+	.err
+.endif
+
+.if	!(FP_ILOGBNAN == 0x7FFFFF)
+	.print	"ilogbl assumes that FP_ILOGBNAN == 0x7FFFFF (INT_MAX)"
+	.err
+.endif
+.if	!(FP_ILOGB0 - 1 == FP_ILOGBNAN)
+	.print	"ilogbl assumes FP_ILOGB0 - 1 == FP_ILOGBNAN"
+	.err
+.endif
+
 	.section	.text
 
 	.global	_ilogbl
@@ -58,10 +76,10 @@ _ilogbl:
 	add	hl, de	; FP_ILOGB0 when DE is one
 	ex	de, hl
 	;	DE was zero or one, so HL is now zero or one
-	ld	l, 4	; EDOM
+	ld	l, EDOM
 	ld	(_errno), hl
 	ld	hl, ___fe_cur_env
-	set	4, (hl)	; FE_INVALID
+	set	FE_INVALID_BIT, (hl)
 	ex	de, hl
 	ret
 

--- a/src/libc/ldexpf.src
+++ b/src/libc/ldexpf.src
@@ -1,5 +1,8 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+	.include	"fenv.inc"
+
 	.section	.text
 	.global	_ldexpf
 	.type	_ldexpf, @function
@@ -132,12 +135,12 @@ _ldexpf:
 ; .underflow:
 	inc	b	; ld b, 0 ; sets Z
 .L.overflow_to_inf:	; <-- NZ is set when infinite
-	ld	a, $28	; FE_OVERFLOW | FE_INEXACT
+	ld	a, FE_OVERFLOW_MASK | FE_INEXACT_MASK
 .L.underflow_to_zero:	; <-- Z is set when underflowing to zero
 .L.raise_erange:
 	ld	hl, $800000
 	jr	nz, .L.overflow
-	ld	a, $24	; FE_UNDERFLOW | FE_INEXACT
+	ld	a, FE_UNDERFLOW_MASK | FE_INEXACT_MASK
 	add	hl, hl	; ld hl, 0
 .if __ldexpf_avoid_negative_zero
 	; prevents negative zero from being emitted on underflow
@@ -145,7 +148,7 @@ _ldexpf:
 .endif
 .L.overflow:
 	ex	de, hl
-	ld	hl, 5	; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 .L.raise_inexact:
 	ld	hl, ___fe_cur_env
@@ -218,7 +221,7 @@ _ldexpf:
 	ld	a, c	; UDE
 	or	a, d
 	or	a, e
-	ld	a, $20	; FE_INEXACT
+	ld	a, FE_INEXACT_MASK
 	jr	nz, .L.raise_inexact
 	; NZ needs to be set here
 	jr	.L.raise_erange

--- a/src/libc/logbf.src
+++ b/src/libc/logbf.src
@@ -1,5 +1,13 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+	.include	"fenv.inc"
+
+.if	EDOM & 0xFF != EDOM
+	.print	"EDOM is assumed to be between 1 and 255"
+	.err
+.endif
+
 	.section	.text
 
 	.global	_logbf
@@ -46,11 +54,10 @@ _logbf:
 
 .L.ret_zero:
 	; HL is zero here
-	ld	l, 4	; EDOM
+	ld	l, EDOM
 	ld	(_errno), hl
-	; FE_DIVBYZERO
 	ld	hl, ___fe_cur_env
-	set	6, (hl)
+	set	FE_DIVBYZERO_BIT, (hl)
 	; -HUGE_VALF
 	ld	hl, $800000
 	ld	e, b	; ld e, $FF

--- a/src/libc/math.inc
+++ b/src/libc/math.inc
@@ -1,0 +1,18 @@
+.ifndef __MATH_INC__
+	.set	__MATH_INC__, 1
+
+; math.inc
+; Assembly equates for libc <math.h>
+; Remember to keep this file in sync with <math.h>
+
+	; note that FP_ILOGBINF is INT_MAX
+	.equ	FP_ILOGB0    , 0x800000
+	.equ	FP_ILOGBNAN  , 0x7FFFFF
+
+	.equ	FP_ZERO      , 0x0
+	.equ	FP_INFINITE  , 0x1
+	.equ	FP_SUBNORMAL , 0x2
+	.equ	FP_NAN       , 0x3
+	.equ	FP_NORMAL    , 0x4
+
+.endif

--- a/src/libc/strtol.src
+++ b/src/libc/strtol.src
@@ -1,5 +1,12 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+
+.if	ERANGE & 0xFF != ERANGE
+	.print	"ERANGE is assumed to be between 1 and 255"
+	.err
+.endif
+
 	; until we figure out how to get FASMG require or etc working correctly
 	.equ	HAVE_WE_FIGURED_OUT_BINUTILS_YET, 0
 
@@ -32,7 +39,7 @@ ___strtoi:
 	ret	p		; 0 <= x <= INT_MAX
 .L.out_of_range:
 	or	a, a		; test sign (Z = negative)
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 	ld	hl, $7FFFFF	; overflow
 	ret	nz
@@ -72,7 +79,7 @@ _strtol.underflow:
 _strtol.out_of_range:
 _strtol.overflow:
 	ld	e, $80
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
 	ret	z		; underflow
@@ -108,7 +115,7 @@ ___strtoui:
 	.local	_strtoul.out_of_range
 _strtoul.out_of_range:
 .endif
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
 	dec	hl
@@ -129,7 +136,7 @@ _strtoul:
 .if HAVE_WE_FIGURED_OUT_BINUTILS_YET
 .else
 _strtoul.out_of_range:
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
 	dec	hl

--- a/src/libc/strtoll.src
+++ b/src/libc/strtoll.src
@@ -1,5 +1,12 @@
 	.assume	adl=1
 
+	.include	"errno.inc"
+
+.if	ERANGE & 0xFF != ERANGE
+	.print	"ERANGE is assumed to be between 1 and 255"
+	.err
+.endif
+
 ;-------------------------------------------------------------------------------
 
 	.section	.text
@@ -34,7 +41,7 @@ _strtoll.underflow:
 _strtoll.out_of_range:
 _strtoll.overflow:
 	ld	b, $80
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	c, h
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
@@ -67,7 +74,7 @@ _strtoull:
 	jp	__llneg
 
 _strtoull.out_of_range:
-	ld	hl, 5		; ERANGE
+	ld	hl, ERANGE
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
 	dec	hl


### PR DESCRIPTION
I need to fix some things after reading Mateos comment
https://github.com/CE-Programming/toolchain/issues/672

This should allow better portability in case some `<errno.h>` or `<fenv.h>` values differ on other platforms/toolchains.

One issue I did encounter is that a lot of assembly routines assume that `EDOM` and `ERANGE` are between 1 and 255 (meaning bits 8-23 are zero). The C standard only states that `EDOM` and `ERANGE` must be unique and positive, so some assembly routines will need to be modified if a platform defines `EDOM` or `ERANGE` to be greater than 255. For now I have just placed an assert which will error if `EDOM`/`ERANGE` is greater than 255.