### PR TITLE
correct `.L_` labels

### DIFF
--- a/src/ce/eval.src
+++ b/src/ce/eval.src
@@ -13,16 +13,16 @@ _os_EvalVar:
 	call	$20304		; mov8b
 	ld	hl, ($D02596)	; tmpcnt
 	push	hl
-	ld	hl, .L_os_EvalVar.error
+	ld	hl, _os_EvalVar.error
 	call	$20798		; push error handler
 	call	$20510		; findsym
 	ld	a, 141		; undefined
-	jr	c, .L_os_EvalVar.error
+	jr	c, _os_EvalVar.error
 	call	$20F00		; parseinp
 	call	$20F30		; stoans
 	call	$2079C		; pop error handler
 	xor	a, a
-.L_os_EvalVar.error:
+_os_EvalVar.error:
 	pop	de
 	push	af
 	call	$20E80		; fixtempcnt
@@ -42,7 +42,7 @@ _os_Eval:
 	add	iy, sp
 	ld	hl, ($D02596)	; tmpcnt
 	push	hl
-	ld	hl, .L_os_Eval.error
+	ld	hl, _os_Eval.error
 	call	$20798		; push error handler
 	ld	hl, (iy + 3)
 	push	hl
@@ -67,7 +67,7 @@ _os_Eval:
 	call	$20F30		; stoans
 	call	$2079C		; pop error handler
 	xor	a, a
-.L_os_Eval.error:
+_os_Eval.error:
 	pop	de
 	push	af
 	call	$20E80		; fixtempcnt

--- a/src/libc/ez80_builtin.src
+++ b/src/libc/ez80_builtin.src
@@ -179,10 +179,10 @@ ___ez80_parityi48:
 	add	hl, sp
 	ld	a, (hl)
 	ld	b, 5
-.L___ez80_parityi48.loop:
+___ez80_parityi48.loop:
 	inc	hl
 	xor	a, (hl)
-	djnz	.L___ez80_parityi48.loop
+	djnz	___ez80_parityi48.loop
 	ld	a, b
 	ret	pe
 	dec	a
@@ -291,16 +291,16 @@ ___ez80_rotateleft24:
 	ld	hl, (iy + 3)
 	ld	a, (iy + 6)
 	ld	c, 24
-.L___ez80_rotateleft24.mod24:
+___ez80_rotateleft24.mod24:
 	sub	a, c
-	jr	nc, .L___ez80_rotateleft24.mod24
+	jr	nc, ___ez80_rotateleft24.mod24
 	add	a, c
 	ret	z
 	ld	b, a
-.L___ez80_rotateleft24.loop:
+___ez80_rotateleft24.loop:
 	add	hl, hl
 	adc	hl, de
-	djnz	.L___ez80_rotateleft24.loop
+	djnz	___ez80_rotateleft24.loop
 	ret
 
 ;-------------------------------------------------------------------------------
@@ -318,20 +318,20 @@ ___ez80_rotateleft48:
 	ld	de, (iy + 6)
 	ld	a, (iy + 9)
 	ld	c, 48
-.L___ez80_rotateleft48.mod48:
+___ez80_rotateleft48.mod48:
 	sub	a, c
-	jr	nc, .L___ez80_rotateleft48.mod48
+	jr	nc, ___ez80_rotateleft48.mod48
 	add	a, c
 	ret	z
 	ld	c, 0
-.L___ez80_rotateleft48.loop:
+___ez80_rotateleft48.loop:
 	add	hl, hl
 	ex	de, hl
 	adc	hl, hl
 	ex	de, hl
 	adc	hl, bc
 	dec	a
-	jr	nz, .L___ez80_rotateleft48.loop
+	jr	nz, ___ez80_rotateleft48.loop
 	ret
 
 ;-------------------------------------------------------------------------------
@@ -348,17 +348,17 @@ ___ez80_rotateright24:
 	ld	hl, (iy + 3)
 	ld	a, (iy + 6)
 	ld	c, 24
-.L___ez80_rotateright24.mod24:
+___ez80_rotateright24.mod24:
 	sub	a, c
-	jr	nc, .L___ez80_rotateright24.mod24
+	jr	nc, ___ez80_rotateright24.mod24
 	neg
 	cp	a, c
 	ret	z
 	ld	b, a
-.L___ez80_rotateright24.loop:
+___ez80_rotateright24.loop:
 	add	hl, hl
 	adc	hl, de
-	djnz	.L___ez80_rotateright24.loop
+	djnz	___ez80_rotateright24.loop
 	ret
 
 ;-------------------------------------------------------------------------------
@@ -376,21 +376,21 @@ ___ez80_rotateright48:
 	ld	de, (iy + 6)
 	ld	a, (iy + 9)
 	ld	c, 48
-.L___ez80_rotateright48.mod48:
+___ez80_rotateright48.mod48:
 	sub	a, c
-	jr	nc, .L___ez80_rotateright48.mod48
+	jr	nc, ___ez80_rotateright48.mod48
 	neg
 	cp	a, c
 	ret	z
 	ld	c, 0
-.L___ez80_rotateright48.loop:
+___ez80_rotateright48.loop:
 	add	hl, hl
 	ex	de, hl
 	adc	hl, hl
 	ex	de, hl
 	adc	hl, bc
 	dec	a
-	jr	nz, .L___ez80_rotateright48.loop
+	jr	nz, ___ez80_rotateright48.loop
 	ret
 
 ;-------------------------------------------------------------------------------

--- a/src/libc/fminmaxf.src
+++ b/src/libc/fminmaxf.src
@@ -16,13 +16,9 @@
 	.type	_fminf, @function
 	.global	_fmin
 	.type	_fmin, @function
-	.global	_fmaxf
-	.type	_fmaxf, @function
-	.global	_fmax
-	.type	_fmax, @function
 
-_fminf:
 _fmin:
+_fminf:
 	ld	iy, 0
 	add	iy, sp
 	ld	bc, $010000
@@ -38,20 +34,20 @@ _fmin:
 	; (X-, Y-): A =  0 NC  Z ; invert compare
 	; (X-, Y+): A = -1  C NZ ; X < Y
 	; (X+, Y-): A = +1 NC NZ ; X > Y
-	jr	nz, .L_fmin.different_sign
-; .L_fmin.same_sign:
+	jr	nz, _fminf.different_sign
+; _fminf.same_sign:
 	sbc	hl, de		; X - Y
 	add	hl, de
-	jr	nz, .L_fmin.x_and_y_diff
+	jr	nz, _fminf.x_and_y_diff
 	ld	a, (iy + 3)
 	cp	a, (iy + 9)
-.L_fmin.x_and_y_diff:
+_fminf.x_and_y_diff:
 	sbc	a, a
 	xor	a, (iy + 6)	; invert the comparison
 	add	a, a
-.L_fmin.different_sign:
+_fminf.different_sign:
 	jr	c, _fminmaxf_common.no_swap
-; .L_fmin.swap:
+; _fminf.swap:
 	ex	de, hl
 	add	hl, bc		; overflows for NaN and Inf
 	jr	c, _fminmaxf_common.y_maybe_NaN
@@ -100,8 +96,8 @@ _fminmaxf_common.x_maybe_NaN:
 	.global	_fmax
 	.type	_fmax, @function
 
-_fmaxf:
 _fmax:
+_fmaxf:
 	ld	iy, 0
 	add	iy, sp
 	ld	bc, $010000
@@ -117,24 +113,24 @@ _fmax:
 	; (X-, Y-): A =  0 NC  Z ; invert compare
 	; (X-, Y+): A = -1  C NZ ; X < Y
 	; (X+, Y-): A = +1 NC NZ ; X > Y
-	jr	nz, .L_fmax.different_sign
-; .L_fmax.same_sign:
+	jr	nz, _fmaxf.different_sign
+; _fmaxf.same_sign:
 	sbc	hl, de		; X - Y
 	add	hl, de
-	jr	nz, .L_fmax.x_and_y_diff
+	jr	nz, _fmaxf.x_and_y_diff
 	ld	a, (iy + 3)
 	cp	a, (iy + 9)
-.L_fmax.x_and_y_diff:
+_fmaxf.x_and_y_diff:
 	sbc	a, a
 	xor	a, (iy + 6)	; invert the comparison
 	add	a, a
-.L_fmax.different_sign:
+_fmaxf.different_sign:
 	jr	nc, _fminmaxf_common.no_swap
-; .L_fmax.swap:
+; _fmaxf.swap:
 	ex	de, hl
 	add	hl, bc		; overflows for NaN and Inf
 	jr	c, _fminmaxf_common.y_maybe_NaN
-.L_fmax.return_y:
+_fmaxf.return_y:
 	ld	hl, (iy + 9)
 	ld	e, (iy + 12)
 	ret

--- a/src/libc/memmem.src
+++ b/src/libc/memmem.src
@@ -70,10 +70,10 @@ _memcmp_fast:
 	; Z = match
 	; NZ = no match
 	ld	bc, (iy + needle_len)
-.L_memcmp_fast.loop:
+.L.cmp_loop:
 	cpi
 	ret	po
 	inc	de
 	ld	a, (de)
-	jr	z, .L_memcmp_fast.loop
+	jr	z, .L.cmp_loop
 	ret

--- a/src/libc/memrmem.src
+++ b/src/libc/memrmem.src
@@ -88,10 +88,10 @@ _memrcmp_fast:
 	; NZ = no match
 	inc	hl
 	ld	bc, (iy + needle_len)
-.L_memrcmp_fast.loop:
+.L.cmp_loop:
 	cpd
 	ret	po
 	dec	de
 	ld	a, (de)
-	jr	z, .L_memrcmp_fast.loop
+	jr	z, .L.cmp_loop
 	ret

--- a/src/libc/strtol.src
+++ b/src/libc/strtol.src
@@ -1,5 +1,8 @@
 	.assume	adl=1
 
+	; until we figure out how to get FASMG require or etc working correctly
+	.equ	HAVE_WE_FIGURED_OUT_BINUTILS_YET, 0
+
 ;-------------------------------------------------------------------------------
 
 	.section	.text.___strtoi
@@ -9,7 +12,7 @@
 
 ___strtoi:
 	; Similar to strtol, except that it will raise ERANGE and return INT_MIN/INT_MAX when out of range
-	call	.L__strtol_common
+	call	__strtol_common
 	; overflow occured if B is non-zero
 	djnz	.L.out_of_range
 	inc	e
@@ -44,30 +47,30 @@ ___strtoi:
 	.type	_strtol, @function
 
 _strtol:
-	call	.L__strtol_common
+	call	__strtol_common
 	; overflow occured if B is non-zero
-	djnz	.L_strtol.out_of_range
+	djnz	_strtol.out_of_range
 	ld	a, e
 	rla
-	jr	c, .L_strtol.maybe_out_of_range
+	jr	c, _strtol.maybe_out_of_range
 	ret	nz
 	jp	__lneg
 
-.L_strtol.maybe_out_of_range:
+_strtol.maybe_out_of_range:
 	; greater than INT_MAX
-	jr	nz, .L_strtol.overflow
+	jr	nz, _strtol.overflow
 	; negative
 	; check that the result is not an exact INT_MIN
 	or	a, a
 	adc	hl, hl
-	jr	nz, .L_strtol.underflow
+	jr	nz, _strtol.underflow
 	ld	a, e
 	adc	a, a
 	ret	z		; exact INT_MIN
-.L_strtol.underflow:
+_strtol.underflow:
 	xor	a, a		; set Z
-.L_strtol.out_of_range:
-.L_strtol.overflow:
+_strtol.out_of_range:
+_strtol.overflow:
 	ld	e, $80
 	ld	hl, 5		; ERANGE
 	ld	(_errno), hl
@@ -87,14 +90,20 @@ _strtol:
 
 ___strtoui:
 	; Similar to strtoul, except that it will raise ERANGE and return UINT_MAX when out of range
-	call	.L__strtol_common
+	call	__strtol_common
 	; overflow occured if B is non-zero
-	djnz	.L_strtoui.out_of_range
+	djnz	_strtoul.out_of_range
 	call	z, __ineg
 	inc	e
 	dec	e
 	ret	z
-.L_strtoui.out_of_range:
+
+.if HAVE_WE_FIGURED_OUT_BINUTILS_YET
+	.section	.text._strtoul.out_of_range
+
+	.local	_strtoul.out_of_range
+_strtoul.out_of_range:
+.endif
 	ld	hl, 5		; ERANGE
 	ld	(_errno), hl
 	ld	l, h		; ld hl, 0
@@ -107,19 +116,30 @@ ___strtoui:
 	.global	_strtoul
 	.type	_strtoul, @function
 _strtoul:
-	call	.L__strtol_common
+	call	__strtol_common
 	; overflow occured if B is non-zero
-	djnz	.L_strtoui.out_of_range
+	djnz	_strtoul.out_of_range
 	ret	nz
 	jp	__lneg
+
+.if HAVE_WE_FIGURED_OUT_BINUTILS_YET
+.else
+_strtoul.out_of_range:
+	ld	hl, 5		; ERANGE
+	ld	(_errno), hl
+	ld	l, h		; ld hl, 0
+	dec	hl
+	ld	e, l
+	ret
+.endif
 
 ;-------------------------------------------------------------------------------
 
 	.section	.text.__strtol_common
 
-	.local	.L__strtol_common
+	.local	__strtol_common
 
-.L__strtol_common:
+__strtol_common:
 	; output: E:UHL
 	; B = 1 if no overflow
 	; Z means that A is zero = negate return value


### PR DESCRIPTION
This PR originally had 5 commits, but I need 1 of those commits to be merged sooner to avoid merge conflicts.

- Fixed `.L_` typos (changing them to `.L._` or something else)
- Patched the sections for `___strtoui` and `__strtoul`
