### PR TITLE
Fallback dvrmu

### DIFF
--- a/src/crt/i48dvrmu.src
+++ b/src/crt/i48dvrmu.src
@@ -13,6 +13,8 @@
 	.global	__i48dvrmu
 	.type	__i48dvrmu, @function
 
+.if 1
+
 __i48dvrmu:
 	; backup af
 	push	af
@@ -86,3 +88,90 @@ __i48dvrmu:
 .skipEI:
 	pop	af
 	ret
+
+.else
+
+__i48dvrmu:
+; fallback routine that does not disable interrupts or use shadow registers
+	push	af
+	push	bc
+	ex	(sp), ix	; IX = divisor[0:23]
+	push	de
+	ex	(sp), iy	; IY = dividend[24:47]
+	pop	bc		; BC = divisor[24:47]
+	push	hl		; (SP) = dividend[0:23]
+
+	; Initialize remainder to 0
+	or	a, a
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+
+	; Handle dividend[24:47] and return quotient[24:47]
+	ld	a, 24
+	call	.L.loop
+
+	ex	(sp), iy	; IY = dividend[0:23], (SP) = quotient[24:47]
+
+	; Handle dividend[0:23] and return quotient[0:23]
+	ld	a, 24
+	call	.L.loop
+
+	push	de
+	ex	(sp), iy	; IY = remainder[24:47]
+	ex	(sp), hl	; HL = quotient[0:23]
+	pop	bc		; BC = remainder[0:23]
+	pop	de		; DE = quotient[24:47]
+	pop	ix
+	pop	af
+	ret
+
+.L.cmp_lower:
+	; Subtract [48:71]
+	sbc	hl, bc
+	jr	nc, .L.subtracted
+
+	; Restore [48:71]
+	add	hl, bc
+	pop	bc
+	ex	de, hl
+.L.restore:
+	; Restore [72:95]
+	add	hl, bc
+	ex	de, hl
+	dec	a
+	ret	z
+
+	; Process 24 quotient bits
+	; DE:HL is the remainder, BC:IX is the divisor, IY is 24 bits of the dividend/quotient
+.L.loop:
+	; [24:47] <<= 1
+	add	iy, iy
+
+	; [48:95] <<= 1
+	adc	hl, hl
+	ex	de, hl
+	adc	hl, hl
+
+	; Subtract [72:95]
+	sbc	hl, bc
+	jr	c, .L.restore
+	ex	de, hl
+	push	bc
+	lea	bc, ix + 0
+	jr	z, .L.cmp_lower
+
+	; Subtract [48:71]
+	sbc	hl, bc
+
+	; Borrow into [72:95]
+	jr	nc, .L.subtracted
+	dec	de
+.L.subtracted:
+	pop	bc
+	inc	iy		; Increment quotient
+	dec	a
+	jr	nz, .L.loop
+	ret
+
+.endif

--- a/src/crt/ldvrmu.src
+++ b/src/crt/ldvrmu.src
@@ -16,6 +16,7 @@
 .else
 
 __ldvrmu:
+; REMEMBER to also modify ldivu.src, lremu.src, and ldiv.src if you change this
 if 1
 ; I: EUHL=dividend, AUBC=divisor
 ; O: a[uhl']=EUHL%AUBC, bcu=0, b=A, c=?, euhl=EUHL/AUBC, eubc'=AUBC, zf=!IEF2

--- a/src/crt/lldvrmu.src
+++ b/src/crt/lldvrmu.src
@@ -6,6 +6,8 @@
 	.global	__lldvrmu.hijack
 	.type	__lldvrmu.hijack, @function
 
+.if 1
+
 __lldvrmu:
 ; Atrociously slow.
 
@@ -109,3 +111,122 @@ __lldvrmu.hijack:
 	ret	po
 	ei
 	ret
+
+.else
+
+__lldvrmu:
+__lldvrmu.hijack:
+; Atrociously slow.
+
+	push	hl
+	ex	(sp), ix
+	ld	iy, 0
+	add	iy, sp
+
+	push	bc
+	push	de
+	; or	a, a
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ld	c, l
+	ld	b, l
+	ld	a, 64
+	jr	.L.start
+
+	; (iy + 21) = denominator [48:63]
+	; (iy + 18) = denominator [24:47]
+	; (iy + 15) = denominator [ 0:23]
+	; (iy + 12) = caller return address
+	; (iy +  9) = preserved IY
+	; (iy +  6) = preserved AF
+	; (iy +  3) = return address
+	; (iy +  0) = preserved IX
+	; IX        = numerator [ 0:23]
+	; (iy -  3) = numerator [48:63]
+	; (iy -  6) = numerator [24:47]
+	; SP        = iy - 6
+
+.L.loop:
+	dec	a
+	jr	z, .L.finish
+.L.start:
+	; [0:63] <<= 1
+	add	ix, ix
+	ex	(sp), hl
+	adc	hl, hl
+	ex	(sp), hl
+	rl	(iy - 3)
+	rl	(iy - 2)
+
+	; [64:127] <<= 1
+	adc	hl, hl
+	ex	de, hl
+	adc	hl, hl
+	ex	de, hl
+	rl	c
+	rl	b
+
+	; test if R >= D
+
+	; inlined __llcmpu
+	or	a, a
+	push	hl
+	ld	hl, (iy + 21)
+	sbc.s	hl, bc
+	jr	nz, .L.cmpu_ne
+	ld	hl, (iy + 18)
+	sbc	hl, de
+	jr	nz, .L.cmpu_ne
+	pop	hl
+	push	bc
+	ld	bc, (iy + 15)
+	sbc	hl, bc
+	add	hl, bc
+	pop	bc
+	jr	.L.finish_cmpu
+
+.L.cmpu_ne:
+	ccf
+	pop	hl
+.L.finish_cmpu:
+	jr	c, .L.loop	; R < D
+	; R >= D
+
+	inc	ix		; increment quotient
+	; inlined __llsub
+	push	bc
+	ld	bc, (iy + 15)
+	sbc	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 18)
+	sbc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 21)
+	sbc	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	jr	.L.loop
+
+.L.finish:
+	; BC:UDE:UHL = remainder
+	; [iy - 6, iy - 2]:IX = quotient
+	ld	(iy + 15), ix
+	pop	ix		; ld ix, (iy - 6)
+	ld	(iy + 18), ix
+.if 0
+	; pop	ix		; ld ix, (iy - 3)
+	; overwrites iy + 23 which is used by __lldivs/__llrems for the quotient sign
+	; ld	(iy + 21), ix
+.else
+	ex	(sp), hl	; ld hl, (iy - 3)
+	ld	(iy + 21), l
+	ld	(iy + 22), h
+	pop	hl
+.endif
+	pop	ix
+	ret
+
+.endif

--- a/src/crt/lldvrmu.src
+++ b/src/crt/lldvrmu.src
@@ -116,6 +116,8 @@ __lldvrmu.hijack:
 
 __lldvrmu:
 __lldvrmu.hijack:
+; Fallback routine that does not disable interrupts or use shadow registers.
+; Uses a special fast path for 8-bit denominators (0 - 255).
 ; Atrociously slow.
 
 	push	hl
@@ -123,16 +125,30 @@ __lldvrmu.hijack:
 	ld	iy, 0
 	add	iy, sp
 
+	; test if the denominator is less than 256 (fast path)
 	push	bc
+	; test bits [8, 55]
+	ld	hl, (iy + 16)
+	ld	bc, (iy + 19)
+	adc	hl, bc
+	jr	nz, .L.not_8_bit
+	; note that bits [8, 55] are non-zero if carry is set
+	ld	a, l		; ld a, 0
+	; test if bits [56, 63] are non-zero or if carry was set from before
+	sbc	a, (iy + 22)
+	jr	nc, .L.denominator_is_8_bit
+.L.not_8_bit:
+	; denominator >= 256
+
 	push	de
-	; or	a, a
+	or	a, a
 	sbc	hl, hl
 	ex	de, hl
 	sbc	hl, hl
 	ld	c, l
 	ld	b, l
-	ld	a, 64
-	jr	.L.start
+	ld	a, 64 + 1
+	; jr	.L.start
 
 	; (iy + 21) = denominator [48:63]
 	; (iy + 18) = denominator [24:47]
@@ -148,6 +164,7 @@ __lldvrmu.hijack:
 	; SP        = iy - 6
 
 .L.loop:
+	; worst-case CC per iter: 85F + 38R + 20W + 2
 	dec	a
 	jr	z, .L.finish
 .L.start:
@@ -226,6 +243,46 @@ __lldvrmu.hijack:
 	ld	(iy + 22), h
 	pop	hl
 .endif
+	pop	ix
+	ret
+
+.L.denominator_is_8_bit:
+	; A is zero and carry is cleared
+	ex	de, hl
+	pop	de
+	ld	c, (iy + 15)	; denominator
+	ld	b, 64
+.L.loop_8_bit:
+	; worst-case CC per iter: 20F + 1
+	add	ix, ix		; UHL
+	adc	hl, hl		; UDE
+	rl	e		; C
+	rl	d		; B
+	rla			; remainder
+	jr	c, .L.bit_1
+	cp	a, c
+	jr	c, .L.bit_0
+.L.bit_1:
+	sub	a, c
+	inc	ixl
+.L.bit_0:
+	djnz	.L.loop_8_bit
+	; B is zero here
+
+	; store the 64-bit quotient
+	ld	(iy + 15), ix
+	ld	(iy + 18), hl
+	ld	(iy + 21), e
+	ld	(iy + 22), d
+
+	; store the 8-bit remainder
+	ex.s	de, hl		; zero UHL and UDE
+	ld	c, b
+	ld	e, b
+	ld	d, b
+	ld	h, b
+	ld	l, a		; remainder
+
 	pop	ix
 	ret
 

--- a/src/crt/llmulu.src
+++ b/src/crt/llmulu.src
@@ -7,6 +7,8 @@
 __llmulu:
 ; Really slow
 
+.if 1
+; clobbers SP.S
 	push	ix
 	push	iy
 	push	af
@@ -74,3 +76,76 @@ __llmulu:
 	pop	iy
 	pop	ix
 	ret
+
+.else
+
+; fallback routine that does not clobber SP.S
+	push	ix
+	push	iy
+	push	af
+
+	ld	ix, 0
+	lea	iy, ix - 6
+	add	iy, sp		; cf=1
+
+	push	de
+	push	hl
+	push	bc
+
+	lea	hl, iy + 18
+	ld	b, 8
+.L.push_loop:
+	push	af
+	ld	a, (hl)
+	inc	hl
+	or	a, a		; cf=0
+	djnz	.L.push_loop
+
+	sbc	hl, hl
+	ld	e, l
+	ld	d, h
+
+.L.byte_loop:
+	scf
+	adc	a, a
+
+.L.bit_loop:
+	push	af
+	add	ix, ix
+	adc	hl, hl
+	ex	de, hl
+	adc	hl, hl
+	ex	de, hl
+	pop	af
+
+	jr	nc, .L.add_end
+	ld	bc, (iy)
+	add	ix, bc
+	ld	bc, (iy + 3)
+	adc	hl, bc
+	ex	de, hl
+	ld	bc, (iy - 3)
+	adc	hl, bc
+	ex	de, hl
+.L.add_end:
+
+	add	a, a
+	jr	nz, .L.bit_loop
+
+	pop	af
+	jr	nc, .L.byte_loop
+
+	ld	b, d
+	ld	c, e
+	ex	de, hl
+	lea	hl, ix + 0
+
+	pop	af
+	pop	af
+	pop	af
+	pop	af
+	pop	iy
+	pop	ix
+	ret
+
+.endif

--- a/src/libc/ldiv.src
+++ b/src/libc/ldiv.src
@@ -5,7 +5,7 @@
 	.type	_ldiv, @function
 
 _ldiv:
-
+.if 1
 	pop	hl
 	pop	iy
 	pop	de
@@ -52,6 +52,62 @@ _ldiv:
 .L.ei_skip:
 	jp	(hl)
 
+.else
+	pop	hl		; return address
+	pop	iy		; ldiv_t pointer
+	pop	de		; [ 0:23] numerator
+	pop	bc		; [24:31] numerator
+	ld	a, c
+	pop	bc		; [ 0:23] denominator
+	ex	(sp), hl	; [24:31] denominator
+	ex	de, hl
+
+	push	ix		; preserve IX since __ldvrmu destroys it
+	ld	d, a
+	xor	a, e
+	push	af		; quotient sign
+
+	ld	a, e
+	ld	e, d
+	push	de		; remainder sign
+
+	bit	7, e
+	call	__ldivs_lrems_common
+
+	push	iy		; preserve IY since __ldvrmu destroys it
+	; E:UHL = numerator
+	; A:UBC = denominator
+	call	__ldvrmu
+	; E:UIX = quotient
+	; A:UHL = remainder
+	pop	iy		; restore IY = ldiv_t pointer
+
+	ld	d, e		; preserve E
+	ld	e, a
+	pop	af		; remainder sign
+
+	; E:UHL = remainder
+	call	m, __lneg
+	ld	(iy + 4), hl
+	ld	(iy + 7), e
+
+	pop	af		; quotient sign
+
+	lea	hl, ix + 0
+	pop	ix		; restore IX
+	ld	e, d		; restore E
+	; E:UHL = quotient
+	call	m, __lneg
+	ld	(iy), hl
+	ld	(iy + 3), e
+
+	ex	(sp), hl	; HL = return address
+	push	de
+	push	de
+	push	de
+	push	de
+	jp	(hl)
+.endif
 
 	.extern	__ldivs_lrems_common
 	.extern	__ldvrmu


### PR DESCRIPTION
Implements the routines specified in this issue https://github.com/CE-Programming/toolchain/issues/780

Adds fallback implementations for `ldiv_t ldiv(long, long)`, `__i48dvrmu`, `__lldvrmu`, and `__llmulu`

There is no way to test these routines without manually enabling them, but they were tested here:  https://github.com/CE-Programming/toolchain/actions/runs/24476830438


Since the fallback `__lldvrmu` implementation is super slow I had to increase the timeout-time for `test/regression/i48routines` to pass. I did add a special 8-bit denominator path to the fallback `__lldvrmu` which is actually faster than the `exx __lldvrmu` code for 8-bit denominators. Useful for dividing by 10 in `printf`, and dividing by other common numbers like 2 or 3. Otherwise for when the denominator is not 8-bit or greater than 255, I estimate that the fallback routine is probably 3-5x slower overall.

```
__lldvrmu with exx:
 - 35F + 1 per worst case iteration
 - 2240F + 64 for 64 iterations
fallback __lldvrmu:
 - 85F + 38R + 20W + 2 per worst case iteration
 - 5540F + 2432R + 1280W + 128 for 64 iterations
```

