### PR TITLE
Fix `<fenv.h>`

### DIFF
--- a/src/libc/fenv.c
+++ b/src/libc/fenv.c
@@ -3,24 +3,58 @@
 const fenv_t __fe_dfl_env = FE_TONEAREST;
 fenv_t __fe_cur_env = __fe_dfl_env;
 
-extern inline int feclearexcept(int __excepts);
+#undef feclearexcept
+#undef fegetexceptflag
+#undef feraiseexcept
+#undef fesetexceptflag
+#undef fetestexcept
+#undef fegetround
+#undef fesetround
+#undef fegetenv
+#undef feholdexcept
+#undef fesetenv
+#undef feupdateenv
 
-extern inline int fegetexceptflag(fexcept_t *__flagp, int __excepts);
+int feclearexcept(int __excepts) {
+    return __feclearexcept(__excepts);
+}
 
-extern inline int feraiseexcept(int __excepts);
+int fegetexceptflag(fexcept_t *__flagp, int __excepts) {
+    return __fegetexceptflag(__flagp, __excepts);
+}
 
-extern inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
+int feraiseexcept(int __excepts) {
+    return __feraiseexcept(__excepts);
+}
 
-extern inline int fetestexcept(int __excepts);
+int fesetexceptflag(const fexcept_t *__flagp, int __excepts) {
+    return __fesetexceptflag(__flagp, __excepts);
+}
 
-extern inline int fegetround(void);
+int fetestexcept(int __excepts) {
+    return __fetestexcept(__excepts);
+}
 
-extern inline int fesetround(int __rounding_mode);
+int fegetround(void) {
+    return __fegetround();
+}
 
-extern inline int fegetenv(fenv_t *__envp);
+int fesetround(int __rounding_mode) {
+    return __fesetround(__rounding_mode);
+}
 
-extern inline int feholdexcept(fenv_t *__envp);
+int fegetenv(fenv_t *__envp) {
+    return __fegetenv(__envp);
+}
 
-extern inline int fesetenv(const fenv_t *__envp);
+int feholdexcept(fenv_t *__envp) {
+    return __feholdexcept(__envp);
+}
 
-extern inline int feupdateenv(const fenv_t *__envp);
+int fesetenv(const fenv_t *__envp) {
+    return __fesetenv(__envp);
+}
+
+int feupdateenv(const fenv_t *__envp) {
+    return __feupdateenv(__envp);
+}

--- a/src/libc/include/__fenv_def.h
+++ b/src/libc/include/__fenv_def.h
@@ -1,0 +1,7 @@
+#ifndef _FENV_DEF_H
+#define _FENV_DEF_H
+
+typedef unsigned char __fenv_t;
+extern __fenv_t __fe_cur_env;
+
+#endif /* _FENV_DEF_H */

--- a/src/libc/include/fenv.h
+++ b/src/libc/include/fenv.h
@@ -1,17 +1,8 @@
-#ifndef _FENV_P
-#define _FENV_P
-typedef unsigned char __fenv_t;
-extern __fenv_t __fe_cur_env;
-#endif
-
-#ifdef _FENV_P_ONLY
-#undef _FENV_P_ONLY
-#else
-
 #ifndef _FENV_H
 #define _FENV_H
 
 #include <cdefs.h>
+#include <__fenv_def.h>
 
 enum {
     FE_DIVBYZERO  = 1 << 6,
@@ -91,6 +82,4 @@ inline int feupdateenv(const fenv_t *__envp) {
 
 __END_DECLS
 
-#endif /* _FENV_P_ONLY */
-
-#endif /* _FENV_P */
+#endif /* _FENV_H */

--- a/src/libc/include/fenv.h
+++ b/src/libc/include/fenv.h
@@ -34,52 +34,171 @@ typedef unsigned char fexcept_t;
 extern const fenv_t __fe_dfl_env;
 #define FE_DFL_ENV (&__fe_dfl_env)
 
-__BEGIN_DECLS
+//------------------------------------------------------------------------------
+// functions
+//------------------------------------------------------------------------------
 
-inline int feclearexcept(int __excepts) {
+static inline __attribute__((__always_inline__))
+int __feclearexcept(int __excepts) {
     return (__fe_cur_env &= ~((__excepts) & FE_ALL_EXCEPT), 0);
 }
 
-inline int fegetexceptflag(fexcept_t *__flagp, int __excepts) {
+static inline __attribute__((__always_inline__))
+int __fegetexceptflag(fexcept_t *__flagp, int __excepts) {
     return (*(__flagp) = __fe_cur_env & (__excepts) & FE_ALL_EXCEPT, 0);
 }
 
-inline int feraiseexcept(int __excepts) {
+static inline __attribute__((__always_inline__))
+int __feraiseexcept(int __excepts) {
     return (__fe_cur_env |= (__excepts) & FE_ALL_EXCEPT, 0);
 }
 
-inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts) {
+static inline __attribute__((__always_inline__))
+int __fesetexceptflag(const fexcept_t *__flagp, int __excepts) {
     return (__fe_cur_env = (__fe_cur_env & ~((__excepts) & FE_ALL_EXCEPT)) | (*(__flagp) & (__excepts) & FE_ALL_EXCEPT), 0);
 }
 
-inline int fetestexcept(int __excepts) {
+static inline __attribute__((__always_inline__))
+int __fetestexcept(int __excepts) {
     return (__fe_cur_env & (__excepts) & FE_ALL_EXCEPT);
 }
 
-inline int fegetround(void) {
+static inline __attribute__((__always_inline__))
+int __fegetround(void) {
     return (__fe_cur_env & 3);
 }
 
-inline int fesetround(int __rounding_mode) {
+static inline __attribute__((__always_inline__))
+int __fesetround(int __rounding_mode) {
     return (__fe_cur_env = (__fe_cur_env & ~3) | ((__rounding_mode) & 3), 0);
 }
 
-inline int fegetenv(fenv_t *__envp) {
+static inline __attribute__((__always_inline__))
+int __fegetenv(fenv_t *__envp) {
     return (*(__envp) = __fe_cur_env, 0);
 }
 
-inline int feholdexcept(fenv_t *__envp) {
+static inline __attribute__((__always_inline__))
+int __feholdexcept(fenv_t *__envp) {
     return (*(__envp) = __fe_cur_env, __fe_cur_env &= ~FE_ALL_EXCEPT, 0);
 }
 
-inline int fesetenv(const fenv_t *__envp) {
+static inline __attribute__((__always_inline__))
+int __fesetenv(const fenv_t *__envp) {
     return (__fe_cur_env = *(__envp), 0);
 }
 
-inline int feupdateenv(const fenv_t *__envp) {
+static inline __attribute__((__always_inline__))
+int __feupdateenv(const fenv_t *__envp) {
     return (__fe_cur_env = (__fe_cur_env & FE_ALL_EXCEPT) | *(__envp), 0);
 }
 
+//------------------------------------------------------------------------------
+// prototypes
+//------------------------------------------------------------------------------
+
+__BEGIN_DECLS
+
+int feclearexcept(int __excepts) __NOEXCEPT;
+
+int fegetexceptflag(fexcept_t *__flagp, int __excepts) __NOEXCEPT;
+
+int feraiseexcept(int __excepts) __NOEXCEPT;
+
+int fesetexceptflag(const fexcept_t *__flagp, int __excepts) __NOEXCEPT;
+
+int fetestexcept(int __excepts) __NOEXCEPT_PURE;
+
+int fegetround(void) __NOEXCEPT_PURE;
+
+int fesetround(int __rounding_mode) __NOEXCEPT;
+
+int fegetenv(fenv_t *__envp) __NOEXCEPT;
+
+int feholdexcept(fenv_t *__envp) __NOEXCEPT;
+
+int fesetenv(const fenv_t *__envp) __NOEXCEPT;
+
+int feupdateenv(const fenv_t *__envp) __NOEXCEPT;
+
+#ifdef __cplusplus
+
+inline int feclearexcept(int __excepts) __NOEXCEPT {
+    return __feclearexcept(__excepts);
+}
+
+inline int fegetexceptflag(fexcept_t *__flagp, int __excepts) __NOEXCEPT {
+    return __fegetexceptflag(__flagp, __excepts);
+}
+
+inline int feraiseexcept(int __excepts) __NOEXCEPT {
+    return __feraiseexcept(__excepts);
+}
+
+inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts) __NOEXCEPT {
+    return __fesetexceptflag(__flagp, __excepts);
+}
+
+inline int fetestexcept(int __excepts) __NOEXCEPT {
+    return __fetestexcept(__excepts);
+}
+
+inline int fegetround(void) __NOEXCEPT {
+    return __fegetround();
+}
+
+inline int fesetround(int __rounding_mode) __NOEXCEPT {
+    return __fesetround(__rounding_mode);
+}
+
+inline int fegetenv(fenv_t *__envp) __NOEXCEPT {
+    return __fegetenv(__envp);
+}
+
+inline int feholdexcept(fenv_t *__envp) __NOEXCEPT {
+    return __feholdexcept(__envp);
+}
+
+inline int fesetenv(const fenv_t *__envp) __NOEXCEPT {
+    return __fesetenv(__envp);
+}
+
+inline int feupdateenv(const fenv_t *__envp) __NOEXCEPT {
+    return __feupdateenv(__envp);
+}
+
+#endif /* __cplusplus */
+
 __END_DECLS
+
+//------------------------------------------------------------------------------
+// macros
+//------------------------------------------------------------------------------
+
+#ifndef __cplusplus
+
+#define feclearexcept(excepts) __feclearexcept(excepts)
+
+#define fegetexceptflag(flagp, excepts) __fegetexceptflag(flagp, excepts)
+
+#define feraiseexcept(excepts) __feraiseexcept(excepts)
+
+#define fesetexceptflag(flagp, excepts) __fesetexceptflag(flagp, excepts)
+
+#define fetestexcept(excepts) __fetestexcept(excepts)
+
+#define fegetround() __fegetround()
+
+#define fesetround(rounding_mode) __fesetround(rounding_mode)
+
+#define fegetenv(envp) __fegetenv(envp)
+
+#define feholdexcept(envp) __feholdexcept(envp)
+
+#define fesetenv(envp) __fesetenv(envp)
+
+#define feupdateenv(envp) __feupdateenv(envp)
+
+#endif /* __cplusplus */
 
 #endif /* _FENV_H */

--- a/src/libc/include/float.h
+++ b/src/libc/include/float.h
@@ -1,8 +1,7 @@
 #ifndef _FLOAT_H
 #define _FLOAT_H
 
-#define _FENV_P_ONLY
-#include <fenv.h>
+#include <__fenv_def.h>
 
 #define  FLT_RADIX        __FLT_RADIX__
 

--- a/test/standalone/fenv/autotest.json
+++ b/test/standalone/fenv/autotest.json
@@ -1,0 +1,40 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2"
+  ],
+  "hashes": {
+    "1": {
+      "description": "All tests passed",
+      "timeout": 5000,
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "38E2AD5A"
+      ]
+    },
+    "2": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/standalone/fenv/makefile
+++ b/test/standalone/fenv/makefile
@@ -1,0 +1,20 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Oz
+CXXFLAGS = -Wall -Wextra -Oz
+
+HAS_MATH_ERRNO = YES
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/standalone/fenv/src/func.h
+++ b/test/standalone/fenv/src/func.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#define C(expr) if (!(expr)) { return __LINE__; }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int test_1_c(void);
+
+int test_2_cpp(void);
+
+int test_3_asm(void);
+
+int test_4_c(void);
+
+int test_5_cpp(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/standalone/fenv/src/main.c
+++ b/test/standalone/fenv/src/main.c
@@ -1,0 +1,45 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+#include <sys/util.h>
+#include <ti/sprintf.h>
+#include <stdio.h>
+#include <fenv.h>
+
+#include "func.h"
+
+#define TEST(test) do { \
+    ret = test; \
+    if (ret != 0) { \
+        puts("failed " #test); \
+        return ret; \
+    } \
+} while(0)
+
+int run_tests(void) {
+    int ret = 0;
+
+    TEST(test_1_c());
+    TEST(test_2_cpp());
+    TEST(test_3_asm());
+    TEST(test_4_c());
+    TEST(test_5_cpp());
+
+    return ret;
+}
+
+int main(void) {
+    os_ClrHome();
+
+    int failed_test = run_tests();
+    if (failed_test != 0) {
+        char buf[sizeof("Failed test L-8388608")];
+        boot_sprintf(buf, "Failed test L%d", failed_test);
+        puts(buf);
+    } else {
+        puts("All tests passed");
+    }
+
+    while (!os_GetCSC());
+
+    return 0;
+}

--- a/test/standalone/fenv/src/on_exit_func.s
+++ b/test/standalone/fenv/src/on_exit_func.s
@@ -1,0 +1,37 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	_on_exit_func
+	.type	_on_exit_func, @function
+
+; void on_exit_func(int, void*)
+_on_exit_func:
+	ld	hl, 6
+	add	hl, sp
+	ld	hl, (hl)
+	ld	bc, _fesetexceptflag
+	; test that C fesetexceptflag and C++ fesetexceptflag have the same address
+	or	a, a
+	sbc	hl, bc
+	add	hl, bc
+	ret	z
+	ld	hl, _on_exit_func_error_str
+	push	hl
+	call	_puts
+	pop	hl
+.L.wait_loop:
+	call	_os_GetCSC
+	or	a, a
+	jr	z, .L.wait_loop
+	ret
+
+	.section	.rodata._on_exit_func_error_str
+
+	.local	_on_exit_func_error_str
+_on_exit_func_error_str:
+	.asciz	"error:\nstd::fesetexceptflag\naddress mismatch"
+
+	.extern	_fesetexceptflag
+	.extern	_puts
+	.extern	_os_GetCSC

--- a/test/standalone/fenv/src/test_1_c.c
+++ b/test/standalone/fenv/src/test_1_c.c
@@ -1,0 +1,17 @@
+#include <fenv.h>
+
+#include "func.h"
+
+fenv_t env_data;
+
+int test_1_c(void) {
+    C(fegetround() == FE_TONEAREST);
+    C(fetestexcept(FE_ALL_EXCEPT) == 0);
+
+    C(fesetround(FE_DOWNWARD) == 0);
+    C(feraiseexcept(FE_DIVBYZERO) == 0);
+
+    C(feholdexcept(&env_data) == 0);
+
+    return 0;
+}

--- a/test/standalone/fenv/src/test_2_cpp.cpp
+++ b/test/standalone/fenv/src/test_2_cpp.cpp
@@ -1,0 +1,23 @@
+#include <fenv.h>
+
+#include "func.h"
+
+#ifdef fetestexcept
+#error "<fenv.h> functions cannot be macros in C++"
+#endif
+
+int test_2_cpp(void) {
+    fenv_t temp;
+
+    C(fetestexcept(FE_ALL_EXCEPT) == 0);
+    C(fegetenv(&temp) == 0);
+    C(feraiseexcept(FE_UNDERFLOW) == 0);
+
+    int (*testexcept)(int) = fetestexcept;
+    C(testexcept(FE_UNDERFLOW) != 0);
+    C(fesetenv(&temp) == 0);
+    C(testexcept(FE_UNDERFLOW) == 0);
+    C(::fetestexcept(FE_ALL_EXCEPT) == 0);
+
+    return 0;
+}

--- a/test/standalone/fenv/src/test_3_asm.s
+++ b/test/standalone/fenv/src/test_3_asm.s
@@ -1,0 +1,74 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	_test_3_asm
+	.type	_test_3_asm, @function
+
+; int test_3_asm(void)
+_test_3_asm:
+	ld	hl, -3
+	call	__frameset
+
+	; preserve current rounding mode
+	call	_fegetround
+	ld	(ix - 3), hl
+
+	; compare it to the real deal
+	ld	a, (___fe_cur_env)
+	cp	a, l
+	jr	nz, .L.fail_1
+
+	; set a new and different rounding mode
+	ld	a, l
+	xor	a, 1
+	ld	l, a
+	push	hl
+	call	_fesetround
+	pop	bc
+
+	; return value should be zero
+	add	hl, bc
+	or	a, a
+	sbc	hl, bc
+	jr	nz, .L.fail_2
+
+	; see if changes were made correctly
+	call	_fegetround
+	ld	bc, (ix - 3)
+	ld	a, c
+	xor	a, 1
+	ld	c, a
+
+	or	a, a
+	sbc	hl, bc
+	add	hl, bc
+	jr	nz, .L.fail_3
+
+	; restore current rounding mode
+	ld	a, (ix - 3)
+	ld	(___fe_cur_env), a
+
+	; passed tests
+	ld	hl, 0
+.L.finish:
+	ld	sp, ix
+	pop	ix
+	ret
+
+.L.fail_1:
+	ld	hl, 1000
+	jr	.L.finish
+
+.L.fail_2:
+	ld	hl, 2000
+	jr	.L.finish
+
+.L.fail_3:
+	ld	hl, 3000
+	jr	.L.finish
+
+	.extern	__frameset
+	.extern	__fe_cur_env
+	.extern	_fegetround
+	.extern	_fesetround

--- a/test/standalone/fenv/src/test_4_c.c
+++ b/test/standalone/fenv/src/test_4_c.c
@@ -1,0 +1,17 @@
+#include <fenv.h>
+#include <math.h>
+
+#include "func.h"
+
+int test_4_c(void) {
+    int (*clearexcept)(int) = feclearexcept;
+    int (*testexcept)(int) = fetestexcept;
+    C(fegetround() == FE_DOWNWARD);
+    C(feclearexcept(FE_ALL_EXCEPT) == 0);
+    C(ilogbf(*(const float*)0xE40000) == FP_ILOGB0);
+    C(fegetround() == FE_DOWNWARD);
+    C(testexcept(FE_ALL_EXCEPT) != 0);
+    C(clearexcept(FE_INVALID) == 0);
+    C(fetestexcept(FE_ALL_EXCEPT) == 0);
+    return 0;
+}

--- a/test/standalone/fenv/src/test_5_cpp.cpp
+++ b/test/standalone/fenv/src/test_5_cpp.cpp
@@ -1,0 +1,47 @@
+#include <cfenv>
+#include <stdlib.h>
+
+#include "func.h"
+
+extern "C" fenv_t env_data;
+
+#ifdef fetestexcept
+#error "<cfenv> functions cannot be macros in C++"
+#endif
+
+extern "C" void on_exit_func(int, void*);
+
+int test_5_cpp(void) {
+    C(std::fetestexcept(FE_OVERFLOW) == 0);
+    C(std::feraiseexcept(FE_OVERFLOW) == 0);
+    int (*func)(const fenv_t*);
+    func = feupdateenv;
+    C(func(&env_data) == 0);
+    func = ::feupdateenv;
+    C(func(&env_data) == 0);
+    func = std::feupdateenv;
+    C(func(&env_data) == 0);
+
+    C(feupdateenv(&env_data) == 0);
+
+    C(::feupdateenv(&env_data) == 0);
+    C(std::feupdateenv(&env_data) == 0);
+
+    C(std::fetestexcept(FE_OVERFLOW) != 0);
+    C(on_exit(on_exit_func, reinterpret_cast<void*>(fesetexceptflag)) == 0);
+    {
+        using namespace std;
+        func = feupdateenv;
+        C(func(&env_data) == 0);
+        func = ::feupdateenv;
+        C(func(&env_data) == 0);
+        func = std::feupdateenv;
+        C(func(&env_data) == 0);
+
+        C(feupdateenv(&env_data) == 0);
+        C(::feupdateenv(&env_data) == 0);
+        C(std::feupdateenv(&env_data) == 0);
+    }
+    C(std::fegetround() == FE_DOWNWARD);
+    return 0;
+}


### PR DESCRIPTION
Removed this header inclusion mechanism
```c
#define _FENV_P_ONLY
#include <fenv.h>
```
And replaced it with this (which is less work to maintain)
```c
#include <__fenv_def.h>
```

`inline int feclearexcept(int __excepts)` technically is not conforming (since the `feclearexcept` symbol must not be `inline`) so I corrected that by having `int feclearexcept(int __excepts)` and `#define feclearexcept(excepts) __fetestexcept(excepts)` and etc.