### PR TITLE
Fix #789 and add constructor/destructor/init_priority tests

### DIFF
--- a/test/crt/ctor_dtor_link/autotest.json
+++ b/test/crt/ctor_dtor_link/autotest.json
@@ -1,0 +1,85 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3",
+    "key|enter",
+    "delay|300",
+    "hashWait|4",
+    "key|enter",
+    "delay|300",
+    "hashWait|5",
+    "key|enter",
+    "delay|300",
+    "hashWait|6",
+    "key|enter",
+    "delay|300",
+    "hashWait|7",
+    "key|enter",
+    "delay|300",
+    "hashWait|8",
+    "key|enter",
+    "delay|300",
+    "hashWait|9",
+    "key|enter",
+    "delay|300",
+    "hashWait|10",
+    "key|enter",
+    "delay|300",
+    "hashWait|11",
+    "key|enter",
+    "delay|300",
+    "hashWait|12"
+  ],
+  "hashes": {
+    "1": {
+      "description": "ctor_func",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "19E9ED5F"
+      ]
+    },
+    "2": {
+      "description": "main_func",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "35FF4554"
+      ]
+    },
+    "3": {
+      "description": "dtor_func",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "BBC85D0A"
+      ]
+    },
+    "4": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/ctor_dtor_link/makefile
+++ b/test/crt/ctor_dtor_link/makefile
@@ -1,0 +1,20 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+LTO = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/ctor_dtor_link/src/main.c
+++ b/test/crt/ctor_dtor_link/src/main.c
@@ -1,0 +1,10 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+int main(void) {
+    os_ClrHome();
+    os_PutStrFull("main_func");
+    while (!os_GetCSC());
+
+    return 0;
+}

--- a/test/crt/ctor_dtor_link/src/other.c
+++ b/test/crt/ctor_dtor_link/src/other.c
@@ -1,0 +1,20 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+/* test that constructors/destructors are linked from other translation units */
+
+/* test constructor with a priority */
+__attribute__((constructor(123)))
+void ctor_func(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+/* test destructor without a priority */
+__attribute__((destructor))
+void dtor_func(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}

--- a/test/crt/init_fini_order/autotest.json
+++ b/test/crt/init_fini_order/autotest.json
@@ -1,0 +1,149 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|300",
+    "hashWait|2",
+    "key|enter",
+    "delay|300",
+    "hashWait|3",
+    "key|enter",
+    "delay|300",
+    "hashWait|4",
+    "key|enter",
+    "delay|300",
+    "hashWait|5",
+    "key|enter",
+    "delay|300",
+    "hashWait|6",
+    "key|enter",
+    "delay|300",
+    "hashWait|7",
+    "key|enter",
+    "delay|300",
+    "hashWait|8",
+    "key|enter",
+    "delay|300",
+    "hashWait|9",
+    "key|enter",
+    "delay|300",
+    "hashWait|10",
+    "key|enter",
+    "delay|300",
+    "hashWait|11",
+    "key|enter",
+    "delay|300",
+    "hashWait|12"
+  ],
+  "hashes": {
+    "1": {
+      "description": "ctor_func_0",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "93A83427"
+      ]
+    },
+    "2": {
+      "description": "ctor_func_50",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "367D84B4"
+      ]
+    },
+    "3": {
+      "description": "both_ctor_dtor_100",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "3329A0B3"
+      ]
+    },
+    "4": {
+      "description": "ctor_func_120",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "37390D1E"
+      ]
+    },
+    "5": {
+      "description": "ctor_func_none",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "D9CA5C91"
+      ]
+    },
+    "6": {
+      "description": "main_func",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "35FF4554"
+      ]
+    },
+    "7": {
+      "description": "dtor_func_none",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "7BEBECC4"
+      ]
+    },
+    "8": {
+      "description": "dtor_func_120",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "9518BD4B"
+      ]
+    },
+    "9": {
+      "description": "both_ctor_dtor_100",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "3329A0B3"
+      ]
+    },
+    "10": {
+      "description": "dtor_func_50",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "945C34E1"
+      ]
+    },
+    "11": {
+      "description": "dtor_func_0",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "31898472"
+      ]
+    },
+    "12": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/init_fini_order/makefile
+++ b/test/crt/init_fini_order/makefile
@@ -1,0 +1,20 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+LTO = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/init_fini_order/src/main.c
+++ b/test/crt/init_fini_order/src/main.c
@@ -1,0 +1,67 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+/* the following functions are intentionally defined in a random order */
+
+__attribute__((destructor(0)))
+void dtor_func_0(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((constructor(50)))
+void ctor_func_50(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((constructor(0)))
+void ctor_func_0(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((constructor(100))) __attribute__((destructor(100)))
+void both_ctor_dtor_100(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((destructor))
+void dtor_func_none(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((destructor(120)))
+void dtor_func_120(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((constructor))
+void ctor_func_none(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+void random_func(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+int main(void) {
+    os_ClrHome();
+    os_PutStrFull("main_func");
+    while (!os_GetCSC());
+
+    return 0;
+}

--- a/test/crt/init_fini_order/src/other.cpp
+++ b/test/crt/init_fini_order/src/other.cpp
@@ -1,0 +1,24 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+/* test that the ctor/dtor order works with multiple translation units */
+
+__attribute__((constructor(120)))
+void ctor_func_120(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+__attribute__((destructor(50)))
+void dtor_func_50(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+void other_func(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}

--- a/test/crt/init_priority/autotest.json
+++ b/test/crt/init_priority/autotest.json
@@ -1,0 +1,160 @@
+{
+  "transfer_files": [
+    "bin/DEMO.8xp"
+  ],
+  "target": {
+    "name": "DEMO",
+    "isASM": true
+  },
+  "sequence": [
+    "action|launch",
+    "delay|1000",
+    "hashWait|1",
+    "key|enter",
+    "delay|400",
+    "hashWait|2",
+    "key|enter",
+    "delay|400",
+    "hashWait|3",
+    "key|enter",
+    "delay|400",
+    "hashWait|4",
+    "key|enter",
+    "delay|400",
+    "hashWait|5",
+    "key|enter",
+    "delay|400",
+    "hashWait|6",
+    "key|enter",
+    "delay|400",
+    "hashWait|7",
+    "key|enter",
+    "delay|400",
+    "hashWait|8",
+    "key|enter",
+    "delay|400",
+    "hashWait|9",
+    "key|enter",
+    "delay|400",
+    "hashWait|10",
+    "key|enter",
+    "delay|400",
+    "hashWait|11",
+    "key|enter",
+    "delay|400",
+    "hashWait|12",
+    "key|enter",
+    "delay|400",
+    "hashWait|13"
+  ],
+  "hashes": {
+    "1": {
+      "description": "init_ctor_101",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "BE18DD48"
+      ]
+    },
+    "2": {
+      "description": "init_ctor_109",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "1CDA110C"
+      ]
+    },
+    "3": {
+      "description": "ctor_func_110",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "61B85259"
+      ]
+    },
+    "4": {
+      "description": "init_ctor_120",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "6BE020FB"
+      ]
+    },
+    "5": {
+      "description": "init_ctor_121",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "6D5C6543"
+      ]
+    },
+    "6": {
+      "description": "init_ctor_none",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "85137174"
+      ]
+    },
+    "7": {
+      "description": "main_func",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "35FF4554"
+      ]
+    },
+    "8": {
+      "description": "init_dtor_none",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "E88B2D21"
+      ]
+    },
+    "9": {
+      "description": "init_dtor_121",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "00C43916"
+      ]
+    },
+    "10": {
+      "description": "init_dtor_120",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "06787CAE"
+      ]
+    },
+    "11": {
+      "description": "init_dtor_109",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "71424D59"
+      ]
+    },
+    "12": {
+      "description": "init_dtor_101",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "D380811D"
+      ]
+    },
+    "13": {
+      "description": "Exit",
+      "start": "vram_start",
+      "size": "vram_16_size",
+      "expected_CRCs": [
+        "FFAF89BA",
+        "101734A5",
+        "9DA19F44",
+        "A32840C8",
+        "349F4775"
+      ]
+    }
+  }
+}

--- a/test/crt/init_priority/makefile
+++ b/test/crt/init_priority/makefile
@@ -1,0 +1,20 @@
+# ----------------------------
+# Makefile Options
+# ----------------------------
+
+NAME = DEMO
+ICON = icon.png
+DESCRIPTION = "CE C Toolchain Demo"
+COMPRESSED = NO
+ARCHIVED = NO
+
+CFLAGS = -Wall -Wextra -Wshadow -Oz
+CXXFLAGS = -Wall -Wextra -Wshadow -Oz
+
+PREFER_OS_LIBC = NO
+PREFER_OS_CRT = NO
+LTO = NO
+
+# ----------------------------
+
+include $(shell cedev-config --makefile)

--- a/test/crt/init_priority/src/init_fini.c
+++ b/test/crt/init_priority/src/init_fini.c
@@ -1,0 +1,23 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+__attribute__((constructor(110)))
+void ctor_func_110(void) {
+    os_ClrHome();
+    os_PutStrFull(__FUNCTION__);
+    while (!os_GetCSC());
+}
+
+/* the order for destructors and atexit functions is unspecified */
+
+__attribute__((destructor(110)))
+void dtor_func_110(void) {
+    // have an observable effect
+    os_ClrHome();
+}
+
+__attribute__((destructor))
+void dtor_func_none(void) {
+    // have an observable effect
+    os_ClrHome();
+}

--- a/test/crt/init_priority/src/main.cpp
+++ b/test/crt/init_priority/src/main.cpp
@@ -1,0 +1,38 @@
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "ordered_event.h"
+
+/* the following functions are intentionally defined in a random order */
+
+OrderedEvent init_101 __attribute__((init_priority(101)))("init_ctor_101", "init_dtor_101");
+OrderedEvent init_none("init_ctor_none", "init_dtor_none");
+OrderedEvent init_121 __attribute__((init_priority(121)))("init_ctor_121", "init_dtor_121");
+
+int main(int argc, char * argv[]) {
+    os_ClrHome();
+
+    if (argc != 1) {
+        os_PutStrFull("unexpected argc");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (strcmp(argv[0], "DEMO") != 0) {
+        os_PutStrFull("unexpected argv[0]");
+        while (!os_GetCSC());
+        return 0;
+    }
+    if (argv[1] != nullptr) {
+        os_PutStrFull("unexpected argv[1]");
+        while (!os_GetCSC());
+        return 0;
+    }
+
+    os_PutStrFull("main_func");
+    while (!os_GetCSC());
+
+    return 0;
+}

--- a/test/crt/init_priority/src/ordered_event.h
+++ b/test/crt/init_priority/src/ordered_event.h
@@ -1,0 +1,32 @@
+#ifndef ORDERED_EVENT_H
+#define ORDERED_EVENT_H
+
+#include <ti/screen.h>
+#include <ti/getcsc.h>
+
+class OrderedEvent {
+public:
+    OrderedEvent(
+        const char *ctor_label, const char *dtor_label
+    ) : ctor_label_(ctor_label), dtor_label_(dtor_label) {
+        if (ctor_label_) {
+            os_ClrHome();
+            os_PutStrFull(ctor_label_);
+            while (!os_GetCSC());
+        }
+    }
+
+    ~OrderedEvent() {
+        if (dtor_label_) {
+            os_ClrHome();
+            os_PutStrFull(dtor_label_);
+            while (!os_GetCSC());
+        }
+    }
+
+private:
+    const char *ctor_label_;
+    const char *dtor_label_;
+};
+
+#endif /* ORDERED_EVENT_H */

--- a/test/crt/init_priority/src/other.cpp
+++ b/test/crt/init_priority/src/other.cpp
@@ -1,0 +1,6 @@
+#include "ordered_event.h"
+
+/* Ensure init_priority ordering works across translation units. */
+
+OrderedEvent init_120 __attribute__((init_priority(120)))("init_ctor_120", "init_dtor_120");
+OrderedEvent init_109 __attribute__((init_priority(109)))("init_ctor_109", "init_dtor_109");

--- a/tools/cedev-obj/src/elf_inspect.c
+++ b/tools/cedev-obj/src/elf_inspect.c
@@ -464,6 +464,30 @@ bool elf_has_section(struct elf_file *elf, const char *section_name)
     return false;
 }
 
+bool elf_has_section_prefix(struct elf_file *elf, const char *section_prefix)
+{
+    if (!elf || !section_prefix)
+    {
+        return false;
+    }
+
+    const size_t prefix_len = strlen(section_prefix);
+    for (uint16_t i = 0; i < elf->ehdr.e_shnum; i++)
+    {
+        if (elf->section_headers[i].sh_name < elf->shstrtab_size)
+        {
+            const char *name = elf->shstrtab + elf->section_headers[i].sh_name;
+            if (strncmp(name, section_prefix, prefix_len) == 0)
+            {
+                /* Section exists - check if it's non-empty */
+                return elf->section_headers[i].sh_size > 0;
+            }
+        }
+    }
+
+    return false;
+}
+
 const char *elf_get_error(struct elf_file *elf)
 {
     return elf ? elf->error : "Invalid ELF handle";

--- a/tools/cedev-obj/src/elf_inspect.c
+++ b/tools/cedev-obj/src/elf_inspect.c
@@ -312,6 +312,21 @@ static bool load_symbol_table(struct elf_file *elf)
     return true;
 }
 
+static bool is_empty_string(const char *str) {
+    // test for a null string
+    if (!str)
+    {
+        return true;
+    }
+    // test for an empty string
+    if (*str == '\0')
+    {
+        return true;
+    }
+    // string contains at least one character
+    return false;
+}
+
 struct elf_file *elf_open(const char *filename)
 {
     struct elf_file *elf = calloc(1, sizeof(struct elf_file));
@@ -399,7 +414,7 @@ void elf_close(struct elf_file *elf)
 
 bool elf_has_symbol(struct elf_file *elf, const char *symbol_name)
 {
-    if (!elf || !symbol_name)
+    if (!elf || is_empty_string(symbol_name))
     {
         return false;
     }
@@ -421,7 +436,7 @@ bool elf_has_symbol(struct elf_file *elf, const char *symbol_name)
 
 bool elf_has_defined_symbol(struct elf_file *elf, const char *symbol_name)
 {
-    if (!elf || !symbol_name)
+    if (!elf || is_empty_string(symbol_name))
     {
         return false;
     }
@@ -443,7 +458,7 @@ bool elf_has_defined_symbol(struct elf_file *elf, const char *symbol_name)
 
 bool elf_has_section(struct elf_file *elf, const char *section_name)
 {
-    if (!elf || !section_name)
+    if (!elf || is_empty_string(section_name))
     {
         return false;
     }
@@ -466,7 +481,7 @@ bool elf_has_section(struct elf_file *elf, const char *section_name)
 
 bool elf_has_section_prefix(struct elf_file *elf, const char *section_prefix)
 {
-    if (!elf || !section_prefix)
+    if (!elf || is_empty_string(section_prefix))
     {
         return false;
     }

--- a/tools/cedev-obj/src/elf_inspect.h
+++ b/tools/cedev-obj/src/elf_inspect.h
@@ -42,6 +42,9 @@ bool elf_has_defined_symbol(struct elf_file *elf, const char *symbol_name);
 /* Check if a section exists and is non-empty */
 bool elf_has_section(struct elf_file *elf, const char *section_name);
 
+/* Check if any section with a given prefix exists and is non-empty */
+bool elf_has_section_prefix(struct elf_file *elf, const char *section_prefix);
+
 /* Get last error message (valid until next call or elf_close) */
 const char *elf_get_error(struct elf_file *elf);
 

--- a/tools/cedev-obj/src/main.c
+++ b/tools/cedev-obj/src/main.c
@@ -119,8 +119,15 @@ static bool parse_arguments(int argc, char **argv, options_t *opts)
 static void write_header_defines(FILE *out, const char *elf_file, struct elf_file *elf)
 {
     fprintf(out, "/* generated from: %s */\n", elf_file);
-    fprintf(out, "#define HAS_INIT_ARRAY %d\n", elf_has_section(elf, ".init_array") ? 1 : 0);
-    fprintf(out, "#define HAS_FINI_ARRAY %d\n", elf_has_section(elf, ".fini_array") ? 1 : 0);
+
+    /*
+     * We check for the prefix so that both forms will be correctly detected:
+     * .section\t.init_array,"aw",@init_array
+     * .section\t.init_array.123,"aw",@init_array
+     */
+    fprintf(out, "#define HAS_INIT_ARRAY %d\n", elf_has_section_prefix(elf, ".init_array") ? 1 : 0);
+    fprintf(out, "#define HAS_FINI_ARRAY %d\n", elf_has_section_prefix(elf, ".fini_array") ? 1 : 0);
+
     fprintf(out, "#define HAS_CLOCK %d\n", elf_has_symbol(elf, "_clock") ? 1 : 0);
     #if 0
         fprintf(out, "#define HAS_ABORT %d\n", elf_has_symbol(elf, "_abort") ? 1 : 0);


### PR DESCRIPTION
Fixes https://github.com/CE-Programming/toolchain/issues/789

`cedev-obj` currently rejects `NULL` strings, so I also made it also reject empty `""` strings (especially since `strncmp(str, "", len)` always returns 0, thereby matching any string)

Added test for:
```
__attribute__((constructor))
__attribute__((constructor(N)))

__attribute__((destructor))
__attribute__((destructor(N)))

__attribute__((init_priority(N)))
```
