### PR TITLE
Optimize crt0

### DIFF
--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -291,12 +291,11 @@ ___libload_libs_ret:
 
 	; Set the counter to zero
 	.errif	(ti.mpTmr1Counter & 0xFFFF) != 0
-	ld	l, h				; ld hl, ti.mpTmr1Counter
-	ld	b, 4
+	ld	l, (ti.mpTmr1Counter + 4) & 0xFF
 .L.zeroize_counter:
+	dec	l
 	ld	(hl), h
-	inc	hl
-	djnz	.L.zeroize_counter
+	jr	nz, .L.zeroize_counter
 
 	ld	l, ti.mpTmrCtrl & 0xFF
 	set	ti.bTmr1Enable, (hl)		; Enable the timer

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -288,11 +288,16 @@ ___libload_libs_ret:
 	res	ti.bTmr1Enable, (hl)
 	set	ti.bTmr1Crystal, (hl)
 	res	ti.bTmr1Overflow, (hl)
-	ld	l, (ti.mpTmr1Counter + 1) & 0xFF
-	ld	de, 0				; Set the counter to zero
-	ld	(hl), de
-	dec	hl
-	ld	(hl), e
+
+	; Set the counter to zero
+	.errif	(ti.mpTmr1Counter & 0xFFFF) != 0
+	ld	l, h				; ld hl, ti.mpTmr1Counter
+	ld	b, 4
+.L.zeroize_counter:
+	ld	(hl), h
+	inc	hl
+	djnz	.L.zeroize_counter
+
 	ld	l, ti.mpTmrCtrl & 0xFF
 	set	ti.bTmr1Enable, (hl)		; Enable the timer
 #endif

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -96,6 +96,7 @@ __start:
 	ldir
 	ld	a, ti.kClear
 	jp	ti.JForceCmd
+
 	.local	___app_start
 ___app_start:
 #else
@@ -133,6 +134,7 @@ __start:
 #if HAS_LIBLOAD
 	call	ti.PushRealO1			; save running program name
 	jr	.L.tryfind
+
 .L.inram:
 	call	ti.Arc_Unarc
 .L.tryfind:
@@ -151,6 +153,7 @@ __start:
 	pop	hl				; start of loader (required to be in hl)
 	ld	de, ___libload_libs		; start of relocation data
 	jp	(hl)				; jump to the loader -- it should take care of everything else
+
 .L.notfound:
 	call	ti.PopRealO1			; restore running program name
 	call	ti.ClrScrn
@@ -218,6 +221,7 @@ ___libload_libs_ret:
 	inc	hl
 	ld	b, (hl)
 	jr	.L.parse_ans_next
+
 .L.parse_ans_loop:
 	inc	hl
 	dec	bc
@@ -296,6 +300,7 @@ ___libload_libs_ret:
 #if HAS_INIT_ARRAY
 	ld	hl, __init_array_start
 	jr	.L.init_array_start
+
 .L.init_array_loop:
 	push	hl
 	ld	hl, (hl)
@@ -345,6 +350,7 @@ _exit:
 #if HAS_ATEXIT
 	; input: (sp + 0) = exit status
 	jr	.L.exit_function_start
+
 .L.exit_function_loop:
 	ld	hl, (ix + 1 + 0 * 3)
 	ld	(__atexit_functions), hl
@@ -374,6 +380,7 @@ _exit:
 #if HAS_FINI_ARRAY
 	ld	hl, __fini_array_end
 	jr	.L.fini_array_start
+
 .L.fini_array_loop:
 	dec	hl
 	dec	hl

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -367,14 +367,11 @@ _exit:
 	push	de				; arg
 	push	hl				; exit status
 	ld	hl, (ix + 1 * 3)		; func
-	push	hl				; func
-	push	ix
-	call	_free
-	pop	bc				; reset SP
-	pop	hl				; func
 	; atexit  : void (*func)(void)
 	; on_exit : void (*func)(int status, void *arg)
 	call	__indcallhl
+	ex	(sp), ix
+	call	_free
 	pop	bc				; reset SP
 	pop	bc				; reset SP
 .L.exit_function_start:

--- a/src/crt/crt0.S
+++ b/src/crt/crt0.S
@@ -351,21 +351,24 @@ _exit:
 	; exit status is currently at (sp + 3), so we need to fix that
 	pop	bc				; destroy return address
 #endif
+
 #if HAS_ATEXIT
 	; input: (sp + 0) = exit status
 	jr	.L.exit_function_start
 
 .L.exit_function_loop:
-	ld	hl, (ix + 1 + 0 * 3)
+	push	hl
+	pop	ix
+	ld	hl, (hl)			; ld hl, (ix + 0 * 3)
 	ld	(__atexit_functions), hl
 	pop	hl				; exit status
 	push	hl				; exit status
-	ld	de, (ix + 1 + 2 * 3)		; arg
+	ld	de, (ix + 2 * 3)		; arg
 	push	de				; arg
 	push	hl				; exit status
-	ld	hl, (ix + 1 + 1 * 3)		; func
+	ld	hl, (ix + 1 * 3)		; func
 	push	hl				; func
-	pea	ix + 1
+	push	ix
 	call	_free
 	pop	bc				; reset SP
 	pop	hl				; func
@@ -375,12 +378,16 @@ _exit:
 	pop	bc				; reset SP
 	pop	bc				; reset SP
 .L.exit_function_start:
-	ld	ix, (__atexit_functions)
+	ld	hl, (__atexit_functions)
 	; NULL indicates no more atexit functions
-	ld	bc, -1
-	add	ix, bc
-	jr	c, .L.exit_function_loop
+	add	hl, bc
+	or	a, a
+	sbc	hl, bc
+	jr	nz, .L.exit_function_loop
+
+	.extern	__atexit_functions
 #endif
+
 #if HAS_FINI_ARRAY
 	ld	hl, __fini_array_end
 	jr	.L.fini_array_start


### PR DESCRIPTION
Size optimizes the timer initialization/clearing code, and optimizes the atexit function loop.

Also formatted unconditional branches.

One important change was that I swapped the order of when the `atexit`/`on_exit` function and `free` get called. So now `free` is called after the `atexit`/`on_exit` function (which probably is more technically correct anyways?)