### PR TITLE
Have `fontlib_SetFont` ignore line spacing with a 100% chance instead of a 99.6% chance.

### DIFF
--- a/src/fontlibc/fontlibc.asm
+++ b/src/fontlibc/fontlibc.asm
@@ -408,7 +408,7 @@ fontlib_SetFont:
 ; Sets the current font to the data at the pointer given
 ; Arguments:
 ;  arg0: Pointer to font
-;  arg1: Load flags
+;  arg1: Load flags (Ignored, and treated as FONTLIB_IGNORE_LINE_SPACING)
 ; Returns:
 ;  bool:
 ;     - true if font loaded successfully
@@ -458,18 +458,20 @@ fontlib_SetFont:
 	add	hl,de
 	add	hl,bc
 	ld	(iy + strucFont.bitmapsTablePtr),hl
-; Check for the ignore ling spacing flag
-	ld	hl,arg0
-	add	hl,sp
-	ld	a,(hl)
-	or	a,a
-	jr	z,.true
+; Check for the ignore line spacing flag
+; Due to a bug, flags must be ignored, and treated as FONTLIB_IGNORE_LINE_SPACING
+	; ld	hl,arg1
+	; add	hl,sp
+	; ld	a,(hl)
+	; or	a,a
+	; jr	z,.true
 	lea	hl,iy + strucFont.spaceAbove
-	xor	a
+	xor	a,a
 	ld	(hl),a
 	inc	hl
 	ld	(hl),a
-.true:	ld	a,1
+.true:
+	ld	a,1
 	ret
 .false:
 	xor	a,a

--- a/src/fontlibc/fontlibc.h
+++ b/src/fontlibc/fontlibc.h
@@ -49,6 +49,7 @@ typedef enum {
 } fontlib_newline_options_t;
 
 /**
+ * @warning Flags are currently ignored due to a bug, and treated as FONTLIB_IGNORE_LINE_SPACING
  * Options for controlling how SetFont functions.
  * @see fontlib_SetFont
  */
@@ -384,9 +385,10 @@ void fontlib_Home();
 /**
  * Sets the current font
  * @param[in] font_data Pointer to font data
- * @param[in] flags Information about how to process the font (unused)
+ * @param[in] Unused and treated as FONTLIB_IGNORE_LINE_SPACING
  * @return Returns false if the font seems invalid for any reason
  * @warning If false is returned, no valid font is currently loaded and trying
+ * @note Flags are currently ignored due to a bug, and treated as FONTLIB_IGNORE_LINE_SPACING
  * to print will print garbage!
  */
 bool fontlib_SetFont(const fontlib_font_t *font_data, fontlib_load_options_t flags);


### PR DESCRIPTION
See discussion:
https://github.com/CE-Programming/toolchain/issues/754
TL:DR `fontlib_SetFont` ignores flags due to a bug and does the equivalent of `fontlib_SetFont(font, FONTLIB_IGNORE_LINE_SPACING)` 99.6% of the time.

We are currently still drafting `fontlib_LoadFont` which will replace `fontlib_SetFont`. For now, we should at least document the issue for the users, and ensure that the line spacing is ignored with a 100% chance instead of a 99.6% chance.