### PR TITLE
Restored FASMG require keyword (commented out for now)

### DIFF
--- a/src/crt/and.src
+++ b/src/crt/and.src
@@ -3,14 +3,10 @@
 	.section	.text
 	.global	__land
 	.type	__land, @function
-	.section	.text
-	.global	__iand
-	.type	__iand, @function
 
 .ifdef PREFER_OS_CRT
 
 	.set	__land, 0x0001A4
-	.set	__iand, 0x000134
 
 .else
 
@@ -21,6 +17,21 @@ __land:
 	ld	e, a
 	; jr	.L.hijack_land
 	.db	0x3E			; ld a, *
+
+; REQUIRE	require	__iand
+
+.endif
+
+; REQUIRE	.section	.text
+	.global	__iand
+	.type	__iand, @function
+
+.ifdef PREFER_OS_CRT
+
+	.set	__iand, 0x000134
+
+.else
+
 __iand:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af

--- a/src/crt/and_fast.src
+++ b/src/crt/and_fast.src
@@ -3,15 +3,17 @@
 	.section	.text
 	.global	__land_fast
 	.type	__land_fast, @function
-	.global	__iand_fast
-	.type	__iand_fast, @function
-	.global	__sand_fast
-	.type	__sand_fast, @function
 
 __land_fast:
 ; CC: 24*r(PC)+8*r(SPL)+7*w(SPL)+1
 	and	a, e
 	ld	e, a
+; REQUIRE	require	__iand_fast
+
+; REQUIRE	.section	.text
+	.global	__iand_fast
+	.type	__iand_fast, @function
+
 __iand_fast:
 ; CC: 22*r(PC)+8*r(SPL)+7*w(SPL)+1
 	push	hl
@@ -27,6 +29,12 @@ __iand_fast:
 	and	a, (hl)
 	ld	(hl), a
 	pop	hl
+; REQUIRE	require	__sand_fast
+
+; REQUIRE	.section	.text
+	.global	__sand_fast
+	.type	__sand_fast, @function
+
 __sand_fast:
 ; CC: 8*r(PC)+3*r(SPL)+1
 	ld	a, h

--- a/src/crt/ctlz.src
+++ b/src/crt/ctlz.src
@@ -40,6 +40,9 @@ __sctlz:
 	or	a, a
 	jr	nz, __bctlz
 	ld	a, l
+; REQUIRE	require	__sctlz.hijack
+
+; REQUIRE	.section	.text.__sctlz.hijack
 	.local	__sctlz.hijack
 __sctlz.hijack:
 	call	__bctlz

--- a/src/crt/cttz.src
+++ b/src/crt/cttz.src
@@ -6,7 +6,9 @@
 
 __bcttz:
 	cp	a, 1
+; REQUIRE	require	__cttz_common
 
+; REQUIRE	.section	.text.__cttz_common
 	.local	__cttz_common
 	; Input: A=byte, CF=(A==0)
 	; Output: A=cttz(A)
@@ -45,6 +47,9 @@ __scttz:
 	jr	nz, __cttz_common
 	sub	a, h
 	ccf
+; REQUIRE	require	__scttz.hijack
+
+; REQUIRE	.section	.text.__scttz.hijack
 	.local	__scttz.hijack
 __scttz.hijack:
 	call	__cttz_common
@@ -56,6 +61,9 @@ __scttz.hijack:
 	.type	__icttz, @function
 __icttz:
 	xor	a, a
+; REQUIRE	require	__icttz.hijack
+
+; REQUIRE	.section	.text.__icttz.hijack
 	.local	__icttz.hijack
 __icttz.hijack:
 	or	a, l
@@ -116,6 +124,9 @@ __i48cttz:
 	sbc	hl, de
 	jr	nz, __icttz.hijack
 	ex	de, hl
+; REQUIRE	require	__i48cttz.hijack
+
+; REQUIRE	.section	.text.__i48cttz.hijack
 	.local	__i48cttz.hijack
 __i48cttz.hijack:
 	call	__icttz.hijack

--- a/src/crt/i48shr.src
+++ b/src/crt/i48shr.src
@@ -8,8 +8,6 @@
 	.section	.text
 	.global	__i48shrs
 	.type	__i48shrs, @function
-	.global	__i48shru
-	.type	__i48shru, @function
 
 __i48shrs:
 	inc	c
@@ -17,6 +15,11 @@ __i48shrs:
 	ret	z
 	cp	a, a	; Set Z flag
 	db	$C2	; inc c \ dec c \ ret z -> jp nz, *
+; REQUIRE	require	__i48shru
+
+; REQUIRE	.section	.text
+	.global	__i48shru
+	.type	__i48shru, @function
 __i48shru:
 	inc	c
 	dec	c

--- a/src/crt/ltod.src
+++ b/src/crt/ltod.src
@@ -1,35 +1,46 @@
 	.assume	adl=1
 
+;-------------------------------------------------------------------------------
+
 	.section	.text
 
 	.global	__ulltod
 	.type	__ulltod, @function
-	.global	__lltod
-	.type	__lltod, @function
-	.global	__ultod
-	.type	__ultod, @function
-	.global	__ltod
-	.type	__ltod, @function
-
 __ulltod:
 	; (long double)unsigned long long
 	cp	a, a		; set Z flag
 	push	af
-	jr	.L.lltod_common
+	jr	__lltod_common
+; REQUIRE	jq	__lltod_common
+
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.global	__lltod
+	.type	__lltod, @function
 __lltod:
 	; (long double)long long
 	bit	7, b
 	push	af
 	call	nz, __llneg	; abs(BC:UDE:UHL)
-.L.lltod_common:
+
+; REQUIRE	require	__lltod_common
+
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.local	__lltod_common
+__lltod_common:
 	call	__llctlz
 	sub	a, 63		; normalize clz_result
 	; filter out exponent of $000 (zero) and $3FF (one)
-	jr	nc, .L.int_to_f64_zero_or_one
+	jr	nc, __int_to_f64_zero_or_one
 	; A is [-63, -1]
 	add	a, 52
 	; A is [-11, 51]
-	jr	c, .L.int_to_f64_shl
+	jr	c, __int_to_f64_shl
 ; __int_to_f64_shr:
 	; exponent = (1023 or $3FF or f64_bias) + base2_logarithm
 	; Minimum exponent: $434 (2^53)
@@ -89,25 +100,30 @@ __lltod:
 	or	a, a		; NZ = round-up, Z = no-round
 	ld	b, $43
 .if 0
-	jr	z, .L.int_to_f64_shl.no_round
+	jr	z, __int_to_f64_shl.no_round
 	; inlined __lladd_1
 	inc	hl
 	add	hl, de
 	or	a, a
 	sbc	hl, de
-	jr	nz, .L.int_to_f64_shl.finish
+	jr	nz, __int_to_f64_shl.finish
 	inc	de
 	sbc	hl, de
 	add	hl, de
-	jr	nz, .L.int_to_f64_shl.finish
+	jr	nz, __int_to_f64_shl.finish
 	inc	bc
-	jr	.L.int_to_f64_shl.finish
+	jr	__int_to_f64_shl.finish
 .else
 	call	nz, __lladd_1	; round up to even
-	jr	.L.int_to_f64_shl.finish
+	jr	__int_to_f64_shl.finish
 .endif
 
-.L.int_to_f64_zero_or_one:
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.local	__int_to_f64_zero_or_one
+__int_to_f64_zero_or_one:
 	; carry is cleared here
 	; UHL is either one or zero
 	ld	b, h
@@ -118,29 +134,58 @@ __lltod:
 .L.ret_zero:
 	ex	de, hl
 	sbc	hl, hl
-	jr	.L.int_to_f64_shl.finish
+	jr	__int_to_f64_shl.finish
 
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.global	__ultod
+	.type	__ultod, @function
 __ultod:
 	; (long double)unsigned long
 	cp	a, a		; set Z flag
 	push	af
-	jr	.L.ltod_common
+	jr	__ltod_common
+; REQUIRE	jq	__ltod_common
+
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.global	__ltod
+	.type	__ltod, @function
 __ltod:
 	; (long double)long
 	bit	7, e
 	push	af
 	call	nz, __lneg	; abs(E:UHL)
-.L.ltod_common:
+
+; REQUIRE	require	__ltod_common
+
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.local	__ltod_common
+__ltod_common:
 	call	__lctlz
 	sub	a, 31		; normalize clz_result
 
 	; filter out exponent of $000 (zero) and $3FF (one)
-	jr	nc, .L.int_to_f64_zero_or_one
+	jr	nc, __int_to_f64_zero_or_one
 	; A is [-31, -1]
 	add	a, 52
 	; A is [21, 51]
 
-.L.int_to_f64_shl:
+; REQUIRE	require	__int_to_f64_shl
+
+;-------------------------------------------------------------------------------
+
+; REQUIRE	.section	.text
+
+	.local	__int_to_f64_shl
+__int_to_f64_shl:
 	; exponent = (1023 or $3FF or f64_bias) + base2_logarithm
 	; Minimum exponent: $400 (2^1)
 	; Maximum exponent: $434 (2^52)
@@ -169,8 +214,10 @@ __ltod:
 	ld	c, a
 	ld	b, h
 	pop	hl		; restore shifted HL
-.L.int_to_f64_shl.no_round:
-.L.int_to_f64_shl.finish:
+	.local	__int_to_f64_shl.no_round
+__int_to_f64_shl.no_round:
+	.local	__int_to_f64_shl.finish
+__int_to_f64_shl.finish:
 	pop	af
 	ret	z
 	set	7, b

--- a/src/crt/or.src
+++ b/src/crt/or.src
@@ -3,13 +3,10 @@
 	.section	.text
 	.global	__lor
 	.type	__lor, @function
-	.global	__ior
-	.type	__ior, @function
 
 .ifdef PREFER_OS_CRT
 
 	.set	__lor, 0x0001D8
-	.set	__ior, 0x000168
 
 .else
 
@@ -20,6 +17,21 @@ __lor:
 	ld	e, a
 	; jr	.L.hijack_lor
 	.db	0x3E			; ld a, *
+
+; REQUIRE	require	__ior
+
+.endif
+
+; REQUIRE	.section	.text
+	.global	__ior
+	.type	__ior, @function
+
+.ifdef PREFER_OS_CRT
+
+	.set	__ior, 0x000168
+
+.else
+
 __ior:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af

--- a/src/crt/or_fast.src
+++ b/src/crt/or_fast.src
@@ -3,15 +3,17 @@
 	.section	.text
 	.global	__lor_fast
 	.type	__lor_fast, @function
-	.global	__ior_fast
-	.type	__ior_fast, @function
-	.global	__sor_fast
-	.type	__sor_fast, @function
 
 __lor_fast:
 ; CC: 24*r(PC)+8*r(SPL)+7*w(SPL)+1
 	or	a, e
 	ld	e, a
+; REQUIRE	require	__ior_fast
+
+; REQUIRE	.section	.text
+	.global	__ior_fast
+	.type	__ior_fast, @function
+
 __ior_fast:
 ; CC: 22*r(PC)+8*r(SPL)+7*w(SPL)+1
 	push	hl
@@ -27,6 +29,12 @@ __ior_fast:
 	or	a, (hl)
 	ld	(hl), a
 	pop	hl
+; REQUIRE	require	__sor_fast
+
+; REQUIRE	.section	.text
+	.global	__sor_fast
+	.type	__sor_fast, @function
+
 __sor_fast:
 ; CC: 8*r(PC)+3*r(SPL)+1
 	ld	a, h

--- a/src/crt/xor.src
+++ b/src/crt/xor.src
@@ -3,13 +3,10 @@
 	.section	.text
 	.global	__lxor
 	.type	__lxor, @function
-	.global	__ixor
-	.type	__ixor, @function
 
 .ifdef PREFER_OS_CRT
 
 	.set	__lxor, 0x0001FC
-	.set	__ixor, 0x000198
 
 .else
 
@@ -20,6 +17,21 @@ __lxor:
 	ld	e, a
 	; jr	.L.hijack_lxor
 	.db	0x3E			; ld a, *
+
+; REQUIRE	require	__ixor
+
+.endif
+
+; REQUIRE	.section	.text
+	.global	__ixor
+	.type	__ixor, @function
+
+.ifdef PREFER_OS_CRT
+
+	.set	__ixor, 0x000198
+
+.else
+
 __ixor:
 ; CC: 24*r(PC)+11*r(SPL)+10*w(SPL)+1
 	push	af

--- a/src/crt/xor_fast.src
+++ b/src/crt/xor_fast.src
@@ -3,15 +3,17 @@
 	.section	.text
 	.global	__lxor_fast
 	.type	__lxor_fast, @function
-	.global	__ixor_fast
-	.type	__ixor_fast, @function
-	.global	__sxor_fast
-	.type	__sxor_fast, @function
 
 __lxor_fast:
 ; CC: 24*r(PC)+8*r(SPL)+7*w(SPL)+1
 	xor	a, e
 	ld	e, a
+; REQUIRE	require	__ixor_fast
+
+; REQUIRE	.section	.text
+	.global	__ixor_fast
+	.type	__ixor_fast, @function
+
 __ixor_fast:
 ; CC: 22*r(PC)+8*r(SPL)+7*w(SPL)+1
 	push	hl
@@ -27,6 +29,12 @@ __ixor_fast:
 	xor	a, (hl)
 	ld	(hl), a
 	pop	hl
+; REQUIRE	require	__sxor_fast
+
+; REQUIRE	.section	.text
+	.global	__sxor_fast
+	.type	__sxor_fast, @function
+
 __sxor_fast:
 ; CC: 8*r(PC)+3*r(SPL)+1
 	ld	a, h

--- a/src/libc/strtol.src
+++ b/src/libc/strtol.src
@@ -99,6 +99,10 @@ ___strtoui:
 	ret	z
 
 .if HAVE_WE_FIGURED_OUT_BINUTILS_YET
+; REQUIRE	require	_strtoul.out_of_range
+
+;-------------------------------------------------------------------------------
+
 	.section	.text._strtoul.out_of_range
 
 	.local	_strtoul.out_of_range

--- a/src/libc/tolower.src
+++ b/src/libc/tolower.src
@@ -3,15 +3,18 @@
 	.section	.text
 	.global	_tolower
 	.type	_tolower, @function
-	.global	_tolower.internal
-	.type	_tolower.internal, @function
 
 _tolower:
 	pop	de
 	ex	(sp), hl
 	push	de
-	; ASM interface: input/output char in L, destroys AF
+; REQUIRE	require	_tolower.internal
+
+; REQUIRE	.section	.text
+	.global	_tolower.internal
+	.type	_tolower.internal, @function
 _tolower.internal:
+	; ASM interface: input/output char in L, destroys AF
 	ld	a, l
 	sub	a, 'A'
 	cp	a, 1+'Z'-'A'

--- a/src/libc/toupper.src
+++ b/src/libc/toupper.src
@@ -3,15 +3,18 @@
 	.section	.text
 	.global	_toupper
 	.type	_toupper, @function
-	.global	_toupper_internal
-	.type	_toupper_internal, @function
 
 _toupper:
 	pop	de
 	ex	(sp), hl
 	push	de
+; REQUIRE	require	_toupper.internal
+
+; REQUIRE	.section	.text
+	.global	_toupper.internal
+	.type	_toupper.internal, @function
+_toupper.internal:
 	; ASM interface: input/output char in L, destroys AF
-_toupper_internal:
 	ld	a, l
 	sub	a, 'a'
 	cp	a, 1+'z'-'a'


### PR DESCRIPTION
The `require` keyword was removed from assembly code during the transition to `binutils`. I have added it back (but commented out) in case we are able to get something like the `require` keyword to work again.