### PR TITLE
added CRT absolute value functions

### DIFF
--- a/src/crt/babs.src
+++ b/src/crt/babs.src
@@ -1,0 +1,13 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__babs
+	.type	__babs, @function
+
+__babs:
+	; A = abs(A)
+	or	a, a
+	ret	p
+	neg
+	ret

--- a/src/crt/i48abs.src
+++ b/src/crt/i48abs.src
@@ -1,0 +1,18 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48abs
+	.type	__i48abs, @function
+
+__i48abs:
+	; UDE:UHL = abs(UDE:UHL)
+	ex	de, hl
+	add	hl, de
+	or	a, a
+	sbc	hl, de
+	ex	de, hl
+	ret	p
+	jp	__i48neg
+
+	.extern	__i48neg

--- a/src/crt/iabs.src
+++ b/src/crt/iabs.src
@@ -1,0 +1,16 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__iabs
+	.type	__iabs, @function
+
+__iabs:
+	; UHL = abs(UHL)
+	add	hl, bc
+	or	a, a
+	sbc	hl, bc
+	ret	p
+	jp	__ineg
+
+	.extern	__ineg

--- a/src/crt/labs.src
+++ b/src/crt/labs.src
@@ -1,0 +1,14 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__labs
+	.type	__labs, @function
+
+__labs:
+	; E:UHL = abs(E:UHL)
+	bit	7, e
+	ret	z
+	jp	__lneg
+
+	.extern	__lneg

--- a/src/crt/llabs.src
+++ b/src/crt/llabs.src
@@ -1,0 +1,14 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__llabs
+	.type	__llabs, @function
+
+__llabs:
+	; BC:UDE:UHL = abs(BC:UDE:UHL)
+	bit	7, b
+	ret	z
+	jp	__llneg
+
+	.extern	__llneg

--- a/src/crt/sabs.src
+++ b/src/crt/sabs.src
@@ -1,0 +1,14 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__sabs
+	.type	__sabs, @function
+
+__sabs:
+	; HL = abs(HL)
+	bit	7, h
+	ret	z
+	jp	__sneg
+
+	.extern	__sneg


### PR DESCRIPTION
LLVM does not emit these currently.

Current codegen for calculating the absolute value of an integer is pretty bad (involving a "branchless" XOR operation). Having a dedicated routine for the absolute value can help the compiler to produce faster/smaller code in the meantime.