### PR TITLE
crt saturate add sub

### DIFF
--- a/src/crt/i48add.src
+++ b/src/crt/i48add.src
@@ -6,9 +6,24 @@
 	.assume	adl=1
 
 	.section	.text
+
 	.global	__i48add
 	.type	__i48add, @function
 
+	.global	__i48addu_overflow
+	.type	__i48addu_overflow, @function
+
+	.global	__i48subs_overflow
+	.type	__i48subs_overflow, @function
+
+__i48addu_overflow:
+	; returned flags:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__i48adds_overflow:
+	; returned flags:
+	; PO : no signed overflow
+	; PE : signed overflow occured
 __i48add:
 ; CC: 11 bytes | 12F + 6R + 3W + 1
 	add	hl, bc

--- a/src/crt/i48adds_sat.src
+++ b/src/crt/i48adds_sat.src
@@ -8,18 +8,15 @@
 __i48adds_sat:
 	; signed saturated addition
 	; UDE:UHL = UDE:UHL + UIY:UBC
-	add	hl, bc
-	ex	de, hl
-	push	bc
-	lea	bc, iy + 0
-	adc	hl, bc
-	pop	bc
-	ex	de, hl
+	call	__i48adds_overflow
 	ret	po
-	ld	hl, $FFFFFF
-	ld	de, $7FFFFF
-	ret	m		; positive overflow
-	; negative underflow
-	inc	hl
-	inc	de
+	ex	de, hl
+	add	hl, hl
+	sbc	hl, hl
+	ld	de, $800000
+	ret	nc		; negative underflow
+	; positive overflow
+	dec	de
 	ret
+
+	.extern	__i48adds_overflow

--- a/src/crt/i48adds_sat.src
+++ b/src/crt/i48adds_sat.src
@@ -1,0 +1,25 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48adds_sat
+	.type	__i48adds_sat, @function
+
+__i48adds_sat:
+	; signed saturated addition
+	; UDE:UHL = UDE:UHL + UIY:UBC
+	add	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy + 0
+	adc	hl, bc
+	pop	bc
+	ex	de, hl
+	ret	po
+	ld	hl, $FFFFFF
+	ld	de, $7FFFFF
+	ret	m		; positive overflow
+	; negative underflow
+	inc	hl
+	inc	de
+	ret

--- a/src/crt/i48addu_sat.src
+++ b/src/crt/i48addu_sat.src
@@ -8,15 +8,11 @@
 __i48addu_sat:
 	; unsigned saturated addition
 	; UDE:UHL = UDE:UHL + UIY:UBC
-	add	hl, bc
-	ex	de, hl
-	push	bc
-	lea	bc, iy + 0
-	adc	hl, bc
-	pop	bc
-	ex	de, hl
+	call	__i48addu_overflow
 	ret	nc
 	sbc	hl, hl
 	ex	de, hl
 	sbc	hl, hl
 	ret
+
+	.extern	__i48addu_overflow

--- a/src/crt/i48addu_sat.src
+++ b/src/crt/i48addu_sat.src
@@ -1,0 +1,22 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48addu_sat
+	.type	__i48addu_sat, @function
+
+__i48addu_sat:
+	; unsigned saturated addition
+	; UDE:UHL = UDE:UHL + UIY:UBC
+	add	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy + 0
+	adc	hl, bc
+	pop	bc
+	ex	de, hl
+	ret	nc
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ret

--- a/src/crt/i48sub.src
+++ b/src/crt/i48sub.src
@@ -6,9 +6,24 @@
 	.assume	adl=1
 
 	.section	.text
+
 	.global	__i48sub
 	.type	__i48sub, @function
 
+	.global	__i48subu_overflow
+	.type	__i48subu_overflow, @function
+
+	.global	__i48subs_overflow
+	.type	__i48subs_overflow, @function
+
+__i48subu_overflow:
+	; returned flags:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__i48subs_overflow:
+	; returned flags:
+	; PO : no signed overflow
+	; PE : signed overflow occured
 __i48sub:
 ; CC: 13 bytes | 14F + 6R + 3W + 1
 	or	a, a

--- a/src/crt/i48subs_sat.src
+++ b/src/crt/i48subs_sat.src
@@ -8,19 +8,15 @@
 __i48subs_sat:
 	; signed saturated subtraction
 	; UDE:UHL = UDE:UHL - UIY:UBC
-	or	a, a
-	sbc	hl, bc
-	ex	de, hl
-	push	bc
-	lea	bc, iy + 0
-	sbc	hl, bc
-	pop	bc
-	ex	de, hl
+	call	__i48subs_overflow
 	ret	po
-	ld	hl, $000000
+	ex	de, hl
+	add	hl, hl
+	sbc	hl, hl
 	ld	de, $800000
-	ret	p		; negative underflow
+	ret	nc		; negative underflow
 	; positive overflow
-	dec	hl
 	dec	de
 	ret
+
+	.extern	__i48subs_overflow

--- a/src/crt/i48subs_sat.src
+++ b/src/crt/i48subs_sat.src
@@ -1,0 +1,26 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48subs_sat
+	.type	__i48subs_sat, @function
+
+__i48subs_sat:
+	; signed saturated subtraction
+	; UDE:UHL = UDE:UHL - UIY:UBC
+	or	a, a
+	sbc	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy + 0
+	sbc	hl, bc
+	pop	bc
+	ex	de, hl
+	ret	po
+	ld	hl, $000000
+	ld	de, $800000
+	ret	p		; negative underflow
+	; positive overflow
+	dec	hl
+	dec	de
+	ret

--- a/src/crt/i48subu_sat.src
+++ b/src/crt/i48subu_sat.src
@@ -1,0 +1,24 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__i48subu_sat
+	.type	__i48subu_sat, @function
+
+__i48subu_sat:
+	; unsigned saturated subtraction
+	; UDE:UHL = UDE:UHL - UIY:UBC
+	or	a, a
+	sbc	hl, bc
+	ex	de, hl
+	push	bc
+	lea	bc, iy + 0
+	sbc	hl, bc
+	pop	bc
+	ex	de, hl
+	ret	nc
+	or	a, a
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ret

--- a/src/crt/i48subu_sat.src
+++ b/src/crt/i48subu_sat.src
@@ -8,17 +8,12 @@
 __i48subu_sat:
 	; unsigned saturated subtraction
 	; UDE:UHL = UDE:UHL - UIY:UBC
-	or	a, a
-	sbc	hl, bc
-	ex	de, hl
-	push	bc
-	lea	bc, iy + 0
-	sbc	hl, bc
-	pop	bc
-	ex	de, hl
+	call	__i48subu_overflow
 	ret	nc
 	or	a, a
 	sbc	hl, hl
 	ex	de, hl
 	sbc	hl, hl
 	ret
+
+	.extern	__i48subu_overflow

--- a/src/crt/iadds_sat.src
+++ b/src/crt/iadds_sat.src
@@ -1,0 +1,18 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__iadds_sat
+	.type	__iadds_sat, @function
+
+__iadds_sat:
+	; signed saturated addition
+	; UHL = UHL + UBC
+	or	a, a
+	adc	hl, bc
+	ret	po
+	ld	hl, $7FFFFF
+	ret	m		; positive overflow
+	; negative underflow
+	inc	hl
+	ret

--- a/src/crt/iaddu_sat.src
+++ b/src/crt/iaddu_sat.src
@@ -1,0 +1,14 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__iaddu_sat
+	.type	__iaddu_sat, @function
+
+__iaddu_sat:
+	; unsigned saturated addition
+	; UHL = UHL + UBC
+	add	hl, bc
+	ret	nc
+	sbc	hl, hl
+	ret

--- a/src/crt/isubs_sat.src
+++ b/src/crt/isubs_sat.src
@@ -1,0 +1,18 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__isubs_sat
+	.type	__isubs_sat, @function
+
+__isubs_sat:
+	; signed saturated subtraction
+	; HL = HL - BC
+	or	a, a
+	sbc	hl, bc
+	ret	po
+	ld	hl, $800000
+	ret	p		; negative underflow
+	; positive overflow
+	inc	hl
+	ret

--- a/src/crt/isubu_sat.src
+++ b/src/crt/isubu_sat.src
@@ -1,0 +1,16 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__isubu_sat
+	.type	__isubu_sat, @function
+
+__isubu_sat:
+	; unsigned saturated subtraction
+	; UHL = UHL - UBC
+	or	a, a
+	sbc	hl, bc
+	ret	nc
+	or	a, a
+	sbc	hl, hl
+	ret

--- a/src/crt/ladd_overflow.src
+++ b/src/crt/ladd_overflow.src
@@ -1,0 +1,24 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__laddu_overflow
+	.type	__laddu_overflow, @function
+
+	.global	__ladds_overflow
+	.type	__ladds_overflow, @function
+
+__laddu_overflow:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__ladds_overflow:
+	; PO : no signed overflow
+	; PE : signed overflow occured
+	push	bc
+	add	hl, bc
+	ld	c, a
+	adc	a, e
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret

--- a/src/crt/ladds_sat.src
+++ b/src/crt/ladds_sat.src
@@ -1,0 +1,25 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__ladds_sat
+	.type	__ladds_sat, @function
+
+__ladds_sat:
+	; signed saturated addition
+	; E:UHL = E:UHL + A:UBC
+	push	bc
+	add	hl, bc
+	ld	c, a
+	adc	a, e
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret	po
+	ld	e, $7F
+	ld	hl, $FFFFFF
+	ret	m		; positive overflow
+	; negative underflow
+	inc	hl
+	inc	e
+	ret

--- a/src/crt/ladds_sat.src
+++ b/src/crt/ladds_sat.src
@@ -8,18 +8,14 @@
 __ladds_sat:
 	; signed saturated addition
 	; E:UHL = E:UHL + A:UBC
-	push	bc
-	add	hl, bc
-	ld	c, a
-	adc	a, e
-	ld	e, a
-	ld	a, c
-	pop	bc
+	call	__ladds_overflow
 	ret	po
-	ld	e, $7F
-	ld	hl, $FFFFFF
-	ret	m		; positive overflow
-	; negative underflow
-	inc	hl
-	inc	e
+	sla	e
+	sbc	hl, hl
+	ld	e, $80
+	ret	nc		; negative underflow
+	; positive overflow
+	dec	e
 	ret
+
+	.extern	__ladds_overflow

--- a/src/crt/laddu_sat.src
+++ b/src/crt/laddu_sat.src
@@ -8,14 +8,10 @@
 __laddu_sat:
 	; unsigned saturated addition
 	; E:UHL = E:UHL + A:UBC
-	push	bc
-	add	hl, bc
-	ld	c, a
-	adc	a, e
-	ld	e, a
-	ld	a, c
-	pop	bc
+	call	__laddu_overflow
 	ret	nc
 	sbc	hl, hl
 	ld	e, l
 	ret
+
+	.extern	__laddu_overflow

--- a/src/crt/laddu_sat.src
+++ b/src/crt/laddu_sat.src
@@ -1,0 +1,21 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__laddu_sat
+	.type	__laddu_sat, @function
+
+__laddu_sat:
+	; unsigned saturated addition
+	; E:UHL = E:UHL + A:UBC
+	push	bc
+	add	hl, bc
+	ld	c, a
+	adc	a, e
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret	nc
+	sbc	hl, hl
+	ld	e, l
+	ret

--- a/src/crt/lladd_overflow.src
+++ b/src/crt/lladd_overflow.src
@@ -1,0 +1,34 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lladdu_overflow
+	.type	__lladdu_overflow, @function
+
+	.global	__lladds_overflow
+	.type	__lladds_overflow, @function
+
+__lladdu_overflow:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__lladds_overflow:
+	; PO : no signed overflow
+	; PE : signed overflow
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	add	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	adc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 12)
+	adc.s	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	pop	iy
+	ret

--- a/src/crt/lladds_sat.src
+++ b/src/crt/lladds_sat.src
@@ -1,0 +1,39 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lladds_sat
+	.type	__lladds_sat, @function
+
+__lladds_sat:
+	; signed saturated addition
+	; BC:UDE:UHL = BC:UDE:UHL + (SP)
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	add	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	adc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 12)
+	adc.s	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	pop	iy
+	ret	po
+	ld	hl, $FFFFFF
+	push	hl
+	pop	de
+	ld	c, l
+	ld	b, $7F
+	ret	m		; positive overflow
+	; negative underflow
+	inc	hl
+	inc	de
+	inc	bc
+	ret

--- a/src/crt/lladds_sat.src
+++ b/src/crt/lladds_sat.src
@@ -8,32 +8,17 @@
 __lladds_sat:
 	; signed saturated addition
 	; BC:UDE:UHL = BC:UDE:UHL + (SP)
-	push	iy
-	ld	iy, 0
-	add	iy, sp
-	push	bc
-	ld	bc, (iy + 6)
-	add	hl, bc
-	ex	de, hl
-	ld	bc, (iy + 9)
-	adc	hl, bc
-	ex	de, hl
-	ex	(sp), hl
-	ld	bc, (iy + 12)
-	adc.s	hl, bc
-	ld	c, l
-	ld	b, h
-	pop	hl
-	pop	iy
+	call	__lladds_overflow
 	ret	po
-	ld	hl, $FFFFFF
-	push	hl
-	pop	de
+	sla	b
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
 	ld	c, l
-	ld	b, $7F
-	ret	m		; positive overflow
-	; negative underflow
-	inc	hl
-	inc	de
-	inc	bc
+	ld	b, $80
+	ret	nc		; negative underflow
+	; positive overflow
+	dec	b
 	ret
+
+	.extern	__lladds_overflow

--- a/src/crt/lladdu_sat.src
+++ b/src/crt/lladdu_sat.src
@@ -8,24 +8,7 @@
 __lladdu_sat:
 	; unsigned saturated addition
 	; BC:UDE:UHL = BC:UDE:UHL + (SP)
-	push	iy
-	ld	iy, 0
-	add	iy, sp
-	push	bc
-	ld	bc, (iy + 6)
-	add	hl, bc
-	ex	de, hl
-	ld	bc, (iy + 9)
-	adc	hl, bc
-	ex	de, hl
-	pop	bc
-	jr	nc, .nc48
-	inc	bc
-.nc48:
-	ld	iy, (iy + 12)
-	add.s	iy, bc
-	lea	bc, iy + 0
-	pop	iy
+	call	__lladdu_overflow
 	ret	nc
 	sbc	hl, hl
 	ex	de, hl
@@ -33,3 +16,5 @@ __lladdu_sat:
 	ld	b, l
 	ld	c, l
 	ret
+
+	.extern	__lladdu_overflow

--- a/src/crt/lladdu_sat.src
+++ b/src/crt/lladdu_sat.src
@@ -1,0 +1,35 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lladdu_sat
+	.type	__lladdu_sat, @function
+
+__lladdu_sat:
+	; unsigned saturated addition
+	; BC:UDE:UHL = BC:UDE:UHL + (SP)
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	add	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	adc	hl, bc
+	ex	de, hl
+	pop	bc
+	jr	nc, .nc48
+	inc	bc
+.nc48:
+	ld	iy, (iy + 12)
+	add.s	iy, bc
+	lea	bc, iy + 0
+	pop	iy
+	ret	nc
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ld	b, l
+	ld	c, l
+	ret

--- a/src/crt/llsub_overflow.src
+++ b/src/crt/llsub_overflow.src
@@ -1,0 +1,34 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lladdu_overflow
+	.type	__lladdu_overflow, @function
+
+	.global	__lladds_overflow
+	.type	__lladds_overflow, @function
+
+__lladdu_overflow:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__lladds_overflow:
+	; PO : no signed overflow
+	; PE : signed overflow occured
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	sbc	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	sbc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 12)
+	sbc.s	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	pop	iy
+	ret

--- a/src/crt/llsubs_sat.src
+++ b/src/crt/llsubs_sat.src
@@ -8,32 +8,17 @@
 __llsubs_sat:
 	; signed saturated subtraction
 	; BC:UDE:UHL = BC:UDE:UHL - (SP)
-	push	iy
-	ld	iy, 0
-	add	iy, sp
-	push	bc
-	ld	bc, (iy + 6)
-	sbc	hl, bc
-	ex	de, hl
-	ld	bc, (iy + 9)
-	sbc	hl, bc
-	ex	de, hl
-	ex	(sp), hl
-	ld	bc, (iy + 12)
-	sbc.s	hl, bc
-	ld	c, l
-	ld	b, h
-	pop	hl
-	pop	iy
+	call	__llsubs_overflow
 	ret	po
-	ld	hl, $000000
-	push	hl
-	pop	de
+	sla	b
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
 	ld	c, l
 	ld	b, $80
-	ret	m		; negative underflow
+	ret	nc		; negative underflow
 	; positive overflow
-	dec	hl
-	dec	de
-	dec	bc
+	dec	b
 	ret
+
+	.extern	__llsubs_overflow

--- a/src/crt/llsubs_sat.src
+++ b/src/crt/llsubs_sat.src
@@ -1,0 +1,39 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__llsubs_sat
+	.type	__llsubs_sat, @function
+
+__llsubs_sat:
+	; signed saturated subtraction
+	; BC:UDE:UHL = BC:UDE:UHL - (SP)
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	sbc	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	sbc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 12)
+	sbc.s	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	pop	iy
+	ret	po
+	ld	hl, $000000
+	push	hl
+	pop	de
+	ld	c, l
+	ld	b, $80
+	ret	m		; negative underflow
+	; positive overflow
+	dec	hl
+	dec	de
+	dec	bc
+	ret

--- a/src/crt/llsubu_sat.src
+++ b/src/crt/llsubu_sat.src
@@ -8,23 +8,7 @@
 __llsubu_sat:
 	; unsigned saturated subtraction
 	; BC:UDE:UHL = BC:UDE:UHL - (SP)
-	push	iy
-	ld	iy, 0
-	add	iy, sp
-	push	bc
-	ld	bc, (iy + 6)
-	sbc	hl, bc
-	ex	de, hl
-	ld	bc, (iy + 9)
-	sbc	hl, bc
-	ex	de, hl
-	ex	(sp), hl
-	ld	bc, (iy + 12)
-	sbc.s	hl, bc
-	ld	c, l
-	ld	b, h
-	pop	hl
-	pop	iy
+	call	__llsubu_overflow
 	ret	nc
 	or	a, a
 	sbc	hl, hl
@@ -33,3 +17,5 @@ __llsubu_sat:
 	ld	b, l
 	ld	c, l
 	ret
+
+	.extern	__llsubu_overflow

--- a/src/crt/llsubu_sat.src
+++ b/src/crt/llsubu_sat.src
@@ -1,0 +1,35 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__llsubu_sat
+	.type	__llsubu_sat, @function
+
+__llsubu_sat:
+	; unsigned saturated subtraction
+	; BC:UDE:UHL = BC:UDE:UHL - (SP)
+	push	iy
+	ld	iy, 0
+	add	iy, sp
+	push	bc
+	ld	bc, (iy + 6)
+	sbc	hl, bc
+	ex	de, hl
+	ld	bc, (iy + 9)
+	sbc	hl, bc
+	ex	de, hl
+	ex	(sp), hl
+	ld	bc, (iy + 12)
+	sbc.s	hl, bc
+	ld	c, l
+	ld	b, h
+	pop	hl
+	pop	iy
+	ret	nc
+	or	a, a
+	sbc	hl, hl
+	ex	de, hl
+	sbc	hl, hl
+	ld	b, l
+	ld	c, l
+	ret

--- a/src/crt/lsub_overflow.src
+++ b/src/crt/lsub_overflow.src
@@ -1,0 +1,26 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lsubu_overflow
+	.type	__lsubu_overflow, @function
+
+	.global	__lsubs_overflow
+	.type	__lsubs_overflow, @function
+
+__lsubu_overflow:
+	; NC : no unsigned overflow
+	; C  : unsigned overflow occured
+__lsubs_overflow:
+	; PO : no signed overflow
+	; PE : signed overflow occured
+	push	bc
+	or	a, a
+	sbc	hl, bc
+	ld	c, a
+	ld	a, e
+	sbc	a, c
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret

--- a/src/crt/lsubs_sat.src
+++ b/src/crt/lsubs_sat.src
@@ -1,0 +1,27 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lsubs_sat
+	.type	__lsubs_sat, @function
+
+__lsubs_sat:
+	; signed saturated subtraction
+	; E:UHL = E:UHL - A:UBC
+	push	bc
+	or	a, a
+	sbc	hl, bc
+	ld	c, a
+	ld	a, e
+	sbc	a, c
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret	po
+	ld	hl, $000000
+	ld	e, $80
+	ret	p		; negative underflow
+	; positive overflow
+	dec	hl
+	dec	e
+	ret

--- a/src/crt/lsubs_sat.src
+++ b/src/crt/lsubs_sat.src
@@ -8,20 +8,14 @@
 __lsubs_sat:
 	; signed saturated subtraction
 	; E:UHL = E:UHL - A:UBC
-	push	bc
-	or	a, a
-	sbc	hl, bc
-	ld	c, a
-	ld	a, e
-	sbc	a, c
-	ld	e, a
-	ld	a, c
-	pop	bc
+	call	__lsubs_overflow
 	ret	po
-	ld	hl, $000000
+	sla	e
+	sbc	hl, hl
 	ld	e, $80
-	ret	p		; negative underflow
+	ret	nc		; negative underflow
 	; positive overflow
-	dec	hl
 	dec	e
 	ret
+
+	.extern	__lsubs_overflow

--- a/src/crt/lsubu_sat.src
+++ b/src/crt/lsubu_sat.src
@@ -1,0 +1,24 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__lsubu_sat
+	.type	__lsubu_sat, @function
+
+__lsubu_sat:
+	; unsigned saturated subtraction
+	; E:UHL = E:UHL - A:UBC
+	push	bc
+	or	a, a
+	sbc	hl, bc
+	ld	c, a
+	ld	a, e
+	sbc	a, c
+	ld	e, a
+	ld	a, c
+	pop	bc
+	ret	nc
+	or	a, a
+	sbc	hl, hl
+	ld	e, l
+	ret

--- a/src/crt/lsubu_sat.src
+++ b/src/crt/lsubu_sat.src
@@ -8,17 +8,11 @@
 __lsubu_sat:
 	; unsigned saturated subtraction
 	; E:UHL = E:UHL - A:UBC
-	push	bc
-	or	a, a
-	sbc	hl, bc
-	ld	c, a
-	ld	a, e
-	sbc	a, c
-	ld	e, a
-	ld	a, c
-	pop	bc
+	call	__lsubu_overflow
 	ret	nc
 	or	a, a
 	sbc	hl, hl
 	ld	e, l
 	ret
+
+	.extern	__lsubu_overflow

--- a/src/crt/sadds_sat.src
+++ b/src/crt/sadds_sat.src
@@ -1,0 +1,18 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__sadds_sat
+	.type	__sadds_sat, @function
+
+__sadds_sat:
+	; signed saturated addition
+	; HL = HL + BC
+	or	a, a
+	adc.s	hl, bc
+	ret	po
+	ld.sis	hl, $7FFF
+	ret	m		; positive overflow
+	; negative underflow
+	inc	hl
+	ret

--- a/src/crt/saddu_sat.src
+++ b/src/crt/saddu_sat.src
@@ -1,0 +1,14 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__saddu_sat
+	.type	__saddu_sat, @function
+
+__saddu_sat:
+	; unsigned saturated addition
+	; HL = HL + BC
+	add.s	hl, bc
+	ret	nc
+	sbc	hl, hl
+	ret

--- a/src/crt/ssubs_sat.src
+++ b/src/crt/ssubs_sat.src
@@ -1,0 +1,18 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__ssubs_sat
+	.type	__ssubs_sat, @function
+
+__ssubs_sat:
+	; signed saturated subtraction
+	; HL = HL - BC
+	or	a, a
+	sbc.s	hl, bc
+	ret	po
+	ld.sis	hl, $8000
+	ret	p		; negative underflow
+	; positive overflow
+	dec	hl
+	ret

--- a/src/crt/ssubu_sat.src
+++ b/src/crt/ssubu_sat.src
@@ -1,0 +1,16 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__ssubu_sat
+	.type	__ssubu_sat, @function
+
+__ssubu_sat:
+	; unsigned saturated subtraction
+	; HL = HL - BC
+	or	a, a
+	sbc.s	hl, bc
+	ret	nc
+	or	a, a
+	sbc	hl, hl
+	ret


### PR DESCRIPTION
LLVM does not emit these currently.

Adds routines for signed/unsigned add/subtract overflow/saturation (except for 8 bit since calling convention is undefined for that width)

`__*(add/sub)u_overflow` outputs to NC/C
`__*(add/sub)s_overflow` outputs to PO/PE
`__*(add/sub)u_sat` performs unsigned saturation
`__*(add/sub)s_overflow` performs signed saturation

Some of the overflow routines alias the regular `__*add`/`__*sub` routines